### PR TITLE
Add missing include in the GPIO driver

### DIFF
--- a/mee/drivers/sifive,gpio0.h
+++ b/mee/drivers/sifive,gpio0.h
@@ -4,6 +4,8 @@
 #ifndef MEE__DRIVERS__SIFIVE_GPIO0_H
 #define MEE__DRIVERS__SIFIVE_GPIO0_H
 
+#include <mee/compiler.h>
+
 struct __mee_driver_sifive_gpio0;
 
 long __mee_driver_sifive_gpio0_enable_io(const struct __mee_driver_sifive_gpio0 *, long source, long dest);


### PR DESCRIPTION
This manifests when attempting to build for the Arty.

Signed-off-by: Palmer Dabbelt <palmer@sifive.com>