### PR TITLE
Add support for ITIM

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -79,6 +79,7 @@ nobase_include_HEADERS = \
 	mee/drivers/sifive,test0.h \
 	mee/compiler.h \
 	mee/clock.h \
+	mee/itim.h \
 	mee/io.h \
 	mee/machine.h \
 	mee/shutdown.h \

--- a/Makefile.in
+++ b/Makefile.in
@@ -455,6 +455,7 @@ nobase_include_HEADERS = \
 	mee/drivers/sifive,test0.h \
 	mee/compiler.h \
 	mee/clock.h \
+	mee/itim.h \
 	mee/io.h \
 	mee/machine.h \
 	mee/shutdown.h \

--- a/gloss/crt0.S
+++ b/gloss/crt0.S
@@ -78,6 +78,22 @@ _start:
   blt  t1, t2, 1b
 2:
 
+  /* Copy the ITIM section */
+  la t0, mee_segment_itim_source_start
+  la t1, mee_segment_itim_target_start
+  la t2, mee_segment_itim_target_end
+
+  beq t0, t1, 2f
+  bge t1, t2, 2f
+
+1:
+  lw   t3, 0(t0)
+  addi t0, t0, 4
+  sw   t3, 0(t1)
+  addi t1, t1, 4
+  blt  t1, t2, 1b
+2:
+
   /* Zero the BSS segment. */
   la t1, mee_segment_bss_target_start
   la t2, mee_segment_bss_target_end

--- a/mee/itim.h
+++ b/mee/itim.h
@@ -1,0 +1,9 @@
+/* Copyright 2018 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef MEE__ITIM_H
+#define MEE__ITIM_H
+
+#define MEE_PLACE_IN_ITIM	__attribute__((section(".text.itim")))
+
+#endif


### PR DESCRIPTION
Adds support to `gloss/crt0.S` for copying the `.itim` section into the ITIM memory.

Adds `mee/itim.h` for library support for interacting with the ITIM. To start with, define the macro `MEE_PLACE_IN_ITIM` which decorates functions to place in the ITIM.