### PR TITLE
Fix ITIM linking

### DIFF
--- a/mee/itim.h
+++ b/mee/itim.h
@@ -4,6 +4,6 @@
 #ifndef MEE__ITIM_H
 #define MEE__ITIM_H
 
-#define MEE_PLACE_IN_ITIM	__attribute__((section(".text.itim")))
+#define MEE_PLACE_IN_ITIM	__attribute__((section(".itim")))
 
 #endif


### PR DESCRIPTION
ITIM sections are placed in .itim, not .text.itim. This enables the
linker script to pull in the .text.* sections without pulling in the .itim
sections.