### PR TITLE
Add Support for PMP Configuration (No vtable version)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -92,6 +92,7 @@ nobase_include_HEADERS = \
 	mee/io.h \
 	mee/machine.h \
 	mee/shutdown.h \
+	mee/pmp.h \
 	mee/tty.h \
 	mee/uart.h \
 	mee/timer.h \
@@ -157,6 +158,7 @@ libriscv__mmachine__@MACHINE_NAME@_a_SOURCES = \
 	src/button.c \
 	src/switch.c \
 	src/interrupt.c \
+	src/pmp.c \
 	src/uart.c \
 	src/entry.S
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -224,6 +224,7 @@ am_libriscv__mmachine__@MACHINE_NAME@_a_OBJECTS = src/drivers/libriscv__mmachine
 	src/libriscv__mmachine__@MACHINE_NAME@_a-button.$(OBJEXT) \
 	src/libriscv__mmachine__@MACHINE_NAME@_a-switch.$(OBJEXT) \
 	src/libriscv__mmachine__@MACHINE_NAME@_a-interrupt.$(OBJEXT) \
+	src/libriscv__mmachine__@MACHINE_NAME@_a-pmp.$(OBJEXT) \
 	src/libriscv__mmachine__@MACHINE_NAME@_a-uart.$(OBJEXT) \
 	src/libriscv__mmachine__@MACHINE_NAME@_a-entry.$(OBJEXT)
 libriscv__mmachine__@MACHINE_NAME@_a_OBJECTS =  \
@@ -483,6 +484,7 @@ nobase_include_HEADERS = \
 	mee/io.h \
 	mee/machine.h \
 	mee/shutdown.h \
+	mee/pmp.h \
 	mee/tty.h \
 	mee/uart.h \
 	mee/timer.h \
@@ -528,6 +530,7 @@ libriscv__mmachine__@MACHINE_NAME@_a_SOURCES = \
 	src/button.c \
 	src/switch.c \
 	src/interrupt.c \
+	src/pmp.c \
 	src/uart.c \
 	src/entry.S
 
@@ -804,6 +807,8 @@ src/libriscv__mmachine__@MACHINE_NAME@_a-switch.$(OBJEXT):  \
 	src/$(am__dirstamp) src/$(DEPDIR)/$(am__dirstamp)
 src/libriscv__mmachine__@MACHINE_NAME@_a-interrupt.$(OBJEXT):  \
 	src/$(am__dirstamp) src/$(DEPDIR)/$(am__dirstamp)
+src/libriscv__mmachine__@MACHINE_NAME@_a-pmp.$(OBJEXT):  \
+	src/$(am__dirstamp) src/$(DEPDIR)/$(am__dirstamp)
 src/libriscv__mmachine__@MACHINE_NAME@_a-uart.$(OBJEXT):  \
 	src/$(am__dirstamp) src/$(DEPDIR)/$(am__dirstamp)
 src/libriscv__mmachine__@MACHINE_NAME@_a-entry.$(OBJEXT):  \
@@ -896,6 +901,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-entry.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-interrupt.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-led.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-pmp.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-shutdown.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-switch.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-timer.Po@am__quote@
@@ -1332,6 +1338,20 @@ src/libriscv__mmachine__@MACHINE_NAME@_a-interrupt.obj: src/interrupt.c
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/interrupt.c' object='src/libriscv__mmachine__@MACHINE_NAME@_a-interrupt.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libriscv__mmachine__@MACHINE_NAME@_a_CFLAGS) $(CFLAGS) -c -o src/libriscv__mmachine__@MACHINE_NAME@_a-interrupt.obj `if test -f 'src/interrupt.c'; then $(CYGPATH_W) 'src/interrupt.c'; else $(CYGPATH_W) '$(srcdir)/src/interrupt.c'; fi`
+
+src/libriscv__mmachine__@MACHINE_NAME@_a-pmp.o: src/pmp.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libriscv__mmachine__@MACHINE_NAME@_a_CFLAGS) $(CFLAGS) -MT src/libriscv__mmachine__@MACHINE_NAME@_a-pmp.o -MD -MP -MF src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-pmp.Tpo -c -o src/libriscv__mmachine__@MACHINE_NAME@_a-pmp.o `test -f 'src/pmp.c' || echo '$(srcdir)/'`src/pmp.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-pmp.Tpo src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-pmp.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/pmp.c' object='src/libriscv__mmachine__@MACHINE_NAME@_a-pmp.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libriscv__mmachine__@MACHINE_NAME@_a_CFLAGS) $(CFLAGS) -c -o src/libriscv__mmachine__@MACHINE_NAME@_a-pmp.o `test -f 'src/pmp.c' || echo '$(srcdir)/'`src/pmp.c
+
+src/libriscv__mmachine__@MACHINE_NAME@_a-pmp.obj: src/pmp.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libriscv__mmachine__@MACHINE_NAME@_a_CFLAGS) $(CFLAGS) -MT src/libriscv__mmachine__@MACHINE_NAME@_a-pmp.obj -MD -MP -MF src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-pmp.Tpo -c -o src/libriscv__mmachine__@MACHINE_NAME@_a-pmp.obj `if test -f 'src/pmp.c'; then $(CYGPATH_W) 'src/pmp.c'; else $(CYGPATH_W) '$(srcdir)/src/pmp.c'; fi`
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-pmp.Tpo src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-pmp.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/pmp.c' object='src/libriscv__mmachine__@MACHINE_NAME@_a-pmp.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libriscv__mmachine__@MACHINE_NAME@_a_CFLAGS) $(CFLAGS) -c -o src/libriscv__mmachine__@MACHINE_NAME@_a-pmp.obj `if test -f 'src/pmp.c'; then $(CYGPATH_W) 'src/pmp.c'; else $(CYGPATH_W) '$(srcdir)/src/pmp.c'; fi`
 
 src/libriscv__mmachine__@MACHINE_NAME@_a-uart.o: src/uart.c
 @am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libriscv__mmachine__@MACHINE_NAME@_a_CFLAGS) $(CFLAGS) -MT src/libriscv__mmachine__@MACHINE_NAME@_a-uart.o -MD -MP -MF src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-uart.Tpo -c -o src/libriscv__mmachine__@MACHINE_NAME@_a-uart.o `test -f 'src/uart.c' || echo '$(srcdir)/'`src/uart.c

--- a/doc/sphinx/classes/pmp.rst
+++ b/doc/sphinx/classes/pmp.rst
@@ -1,0 +1,6 @@
+PMPs
+====
+
+.. doxygenfile:: mee/pmp.h
+   :project: metal
+

--- a/doc/sphinx/index.rst
+++ b/doc/sphinx/index.rst
@@ -10,6 +10,7 @@ Freedom Metal
    classes/cpu
    classes/interrupt
    classes/itim
+   classes/pmp
    classes/led
    classes/shutdown
    classes/switch

--- a/mee/pmp.h
+++ b/mee/pmp.h
@@ -1,0 +1,67 @@
+/* Copyright 2018 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef MEE__PMP_H
+#define MEE__PMP_H
+
+#include <stddef.h>
+
+struct mee_pmp;
+
+enum mee_pmp_address_mode {
+    MEE_PMP_OFF   = 0,
+    MEE_PMP_TOR   = 1,
+    MEE_PMP_NA4   = 2,
+    MEE_PMP_NAPOT = 3
+};
+
+struct mee_pmp_config {
+    int R : 1;
+    int W : 1;
+    int X : 1;
+
+    enum mee_pmp_address_mode A : 2;
+
+    int _pad : 2;
+
+    enum {
+        MEE_PMP_UNLOCKED = 0,
+        MEE_PMP_LOCKED   = 1
+    } L : 1;
+};
+
+struct mee_pmp {
+    const int num_regions;
+};
+
+/* Get the PMP device handle */
+struct mee_pmp *mee_pmp_get_device(void);
+
+/* Initializes the PMP. */
+void mee_pmp_init(struct mee_pmp *pmp);
+
+/* Configure a PMP region */
+int mee_pmp_set_region(struct mee_pmp *pmp, unsigned int region, struct mee_pmp_config config, size_t address);
+
+/* Get the configuration for a PMP region */
+int mee_pmp_get_region(struct mee_pmp *pmp, unsigned int region, struct mee_pmp_config *config, size_t *address);
+
+/* Get/Set individual features of a PMP region */
+int mee_pmp_lock(struct mee_pmp *pmp, unsigned int region);
+
+int mee_pmp_set_address(struct mee_pmp *pmp, unsigned int region, size_t address);
+size_t mee_pmp_get_address(struct mee_pmp *pmp, unsigned int region);
+
+int mee_pmp_set_address_mode(struct mee_pmp *pmp, unsigned int region, enum mee_pmp_address_mode mode);
+enum mee_pmp_address_mode mee_pmp_get_address_mode(struct mee_pmp *pmp, unsigned int region);
+
+int mee_pmp_set_executable(struct mee_pmp *pmp, unsigned int region, int X);
+int mee_pmp_get_executable(struct mee_pmp *pmp, unsigned int region);
+
+int mee_pmp_set_writeable(struct mee_pmp *pmp, unsigned int region, int W);
+int mee_pmp_get_writeable(struct mee_pmp *pmp, unsigned int region);
+
+int mee_pmp_set_readable(struct mee_pmp *pmp, unsigned int region, int R);
+int mee_pmp_get_readable(struct mee_pmp *pmp, unsigned int region);
+
+#endif

--- a/mee/pmp.h
+++ b/mee/pmp.h
@@ -4,64 +4,202 @@
 #ifndef MEE__PMP_H
 #define MEE__PMP_H
 
+/*!
+ * @file mee/pmp.h
+ *
+ * @brief API for Configuring Physical Memory Protection on RISC-V Cores
+ *
+ * The Physical Memory Protection (PMP) interface on RISC-V cores
+ * is a form of memory protection unit which allows for a finite number
+ * of physical memory regions to be configured with certain access
+ * permissions. 
+ *
+ * Additional information about the use and configuration rules for PMPs
+ * can be found by reading the RISC-V Privileged Architecture Specification
+ * v1.10.
+ */
+
 #include <stddef.h>
 
 struct mee_pmp;
 
+/*!
+ * @brief Set of available PMP addressing modes
+ */
 enum mee_pmp_address_mode {
+    /*! @brief Disable the PMP region */
     MEE_PMP_OFF   = 0,
+    /*! @brief Use Top-of-Range mode */
     MEE_PMP_TOR   = 1,
+    /*! @brief Use naturally-aligned 4-byte region mode */
     MEE_PMP_NA4   = 2,
+    /*! @brief Use naturally-aligned power-of-two mode */
     MEE_PMP_NAPOT = 3
 };
 
+/*!
+ * @brief Configuration for a PMP region
+ */
 struct mee_pmp_config {
+    /*! @brief Sets whether reads to the PMP region succeed */
     int R : 1;
+    /*! @brief Sets whether writes to the PMP region succeed */
     int W : 1;
+    /*! @brief Sets whether the PMP region is executable */
     int X : 1;
 
+    /*! @brief Sets the addressing mode of the PMP region */
     enum mee_pmp_address_mode A : 2;
 
     int _pad : 2;
 
-    enum {
+    /*! @brief Sets whether the PMP region is locked */
+    enum mee_pmp_locked {
         MEE_PMP_UNLOCKED = 0,
         MEE_PMP_LOCKED   = 1
     } L : 1;
 };
 
+/*!
+ * @brief A handle for the PMP device
+ */
 struct mee_pmp {
+    /*!
+     * @brief The number of regions in the PMP
+     */
     const int num_regions;
 };
 
-/* Get the PMP device handle */
+/*!
+ * @brief Get the PMP device handle
+ */
 struct mee_pmp *mee_pmp_get_device(void);
 
-/* Initializes the PMP. */
+/*!
+ * @brief Initialize the PMP
+ * @param pmp The PMP device handle to be initialized
+ *
+ * The PMP initialization routine is optional and may be called as many times
+ * as is desired. The effect of the initialization routine is to attempt to set
+ * all regions to unlocked and disabled, as well as to clear the X, W, and R
+ * bits.
+ *
+ * If any regions are fused to preset values by the implementation or locked,
+ * the PMP region will silently remain uninitialized.
+ */
 void mee_pmp_init(struct mee_pmp *pmp);
 
-/* Configure a PMP region */
+/*!
+ * @brief Configure a PMP region
+ * @param pmp The PMP device handle
+ * @param region The PMP region to configure
+ * @param config The desired configuration of the PMP region
+ * @param address The desired address of the PMP region
+ * @return 0 upon success
+ */
 int mee_pmp_set_region(struct mee_pmp *pmp, unsigned int region, struct mee_pmp_config config, size_t address);
 
-/* Get the configuration for a PMP region */
+/*! 
+ * @brief Get the configuration for a PMP region
+ * @param pmp The PMP device handle
+ * @param region The PMP region to read
+ * @param config Variable to store the PMP region configuration
+ * @param address Variable to store the PMP region address
+ * @return 0 if the region is read successfully
+ */
 int mee_pmp_get_region(struct mee_pmp *pmp, unsigned int region, struct mee_pmp_config *config, size_t *address);
 
-/* Get/Set individual features of a PMP region */
+/*!
+ * @brief Lock a PMP region
+ * @param pmp The PMP device handle
+ * @param region The PMP region to lock
+ * @return 0 if the region is successfully locked
+ */
 int mee_pmp_lock(struct mee_pmp *pmp, unsigned int region);
 
+/*!
+ * @brief Set the address for a PMP region
+ * @param pmp The PMP device handle
+ * @param region The PMP region to set
+ * @param address The desired address of the PMP region
+ * @return 0 if the address is successfully set
+ */
 int mee_pmp_set_address(struct mee_pmp *pmp, unsigned int region, size_t address);
+
+/*!
+ * @brief Get the address of a PMP region
+ * @param pmp The PMP device handle
+ * @param region The PMP region to read
+ * @return The address of the PMP region, or 0 if the region could not be read
+ */
 size_t mee_pmp_get_address(struct mee_pmp *pmp, unsigned int region);
 
+/*!
+ * @brief Set the addressing mode of a PMP region
+ * @param pmp The PMP device handle
+ * @param region The PMP region to set
+ * @param mode The PMP addressing mode to set
+ * @return 0 if the addressing mode is successfully set
+ */
 int mee_pmp_set_address_mode(struct mee_pmp *pmp, unsigned int region, enum mee_pmp_address_mode mode);
+
+/*!
+ * @brief Get the addressing mode of a PMP region
+ * @param pmp The PMP device handle
+ * @param region The PMP region to read
+ * @return The address mode of the PMP region
+ */
 enum mee_pmp_address_mode mee_pmp_get_address_mode(struct mee_pmp *pmp, unsigned int region);
 
+/*!
+ * @brief Set the executable bit for a PMP region
+ * @param pmp The PMP device handle
+ * @param region The PMP region to set
+ * @param X The desired value of the executable bit
+ * @return 0 if the executable bit is successfully set
+ */
 int mee_pmp_set_executable(struct mee_pmp *pmp, unsigned int region, int X);
+
+/*!
+ * @brief Get the executable bit for a PMP region
+ * @param pmp The PMP device handle
+ * @param region The PMP region to read
+ * @return the value of the executable bit
+ */
 int mee_pmp_get_executable(struct mee_pmp *pmp, unsigned int region);
 
+/*!
+ * @brief Set the writable bit for a PMP region
+ * @param pmp The PMP device handle
+ * @param region The PMP region to set
+ * @param W The desired value of the writable bit
+ * @return 0 if the writable bit is successfully set
+ */
 int mee_pmp_set_writeable(struct mee_pmp *pmp, unsigned int region, int W);
+
+/*!
+ * @brief Get the writable bit for a PMP region
+ * @param pmp The PMP device handle
+ * @param region The PMP region to read
+ * @return the value of the writable bit
+ */
 int mee_pmp_get_writeable(struct mee_pmp *pmp, unsigned int region);
 
+/*!
+ * @brief Set the readable bit for a PMP region
+ * @param pmp The PMP device handle
+ * @param region The PMP region to set
+ * @param R The desired value of the readable bit
+ * @return 0 if the readable bit is successfully set
+ */
 int mee_pmp_set_readable(struct mee_pmp *pmp, unsigned int region, int R);
+
+/*!
+ * @brief Set the readable bit for a PMP region
+ * @param pmp The PMP device handle
+ * @param region The PMP region to read
+ * @return the value of the readable bit
+ */
 int mee_pmp_get_readable(struct mee_pmp *pmp, unsigned int region);
 
 #endif

--- a/src/pmp.c
+++ b/src/pmp.c
@@ -1,0 +1,497 @@
+/* Copyright 2018 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include <mee/machine.h>
+#include <mee/pmp.h>
+
+#define CONFIG_TO_INT(_config) (*((size_t *) &(_config)))
+#define INT_TO_CONFIG(_int) (*((struct mee_pmp_config *) &(_int)))
+
+struct mee_pmp *mee_pmp_get_device(void)
+{
+#ifdef __MEE_DT_PMP_HANDLE
+    return __MEE_DT_PMP_HANDLE;
+#else
+    return NULL;
+#endif
+}
+
+void mee_pmp_init(struct mee_pmp *pmp)
+{
+    struct mee_pmp_config init_config = {
+        .L = MEE_PMP_UNLOCKED,
+        .A = MEE_PMP_OFF,
+        .X = 0,
+        .W = 0,
+        .R = 0,
+    };
+
+    for(unsigned int i = 0; i < pmp->num_regions; i++) {
+        mee_pmp_set_region(pmp, i, init_config, 0);
+    }
+}
+
+int mee_pmp_set_region(struct mee_pmp *pmp,
+                       unsigned int region,
+                       struct mee_pmp_config config,
+                       size_t address)
+{
+    struct mee_pmp_config old_config;
+    size_t old_address;
+    size_t cfgmask;
+    size_t pmpcfg;
+    int rc = 0;
+
+    if(!pmp) {
+        /* Device handle cannot be NULL */
+        return 1;
+    }
+
+    if(region > pmp->num_regions) {
+        /* Region outside of supported range */
+        return 2;
+    }
+
+    rc = mee_pmp_get_region(pmp, region, &old_config, &old_address);
+    if(rc) {
+        /* Error reading region */
+        return rc;
+    }
+
+    if(old_config.L == MEE_PMP_LOCKED) {
+        /* Cannot modify locked region */
+        return 3;
+    }
+
+    /* Update the address first, because if the region is being locked we won't
+     * be able to modify it after we set the config */
+    if(old_address != address) {
+        switch(region) {
+        case 0:
+            asm("csrw pmpaddr0, %[addr]"
+                    :: [addr] "r" (address) :);
+            break;
+        case 1:
+            asm("csrw pmpaddr1, %[addr]"
+                    :: [addr] "r" (address) :);
+            break;
+        case 2:
+            asm("csrw pmpaddr2, %[addr]"
+                    :: [addr] "r" (address) :);
+            break;
+        case 3:
+            asm("csrw pmpaddr3, %[addr]"
+                    :: [addr] "r" (address) :);
+            break;
+        case 4:
+            asm("csrw pmpaddr4, %[addr]"
+                    :: [addr] "r" (address) :);
+            break;
+        case 5:
+            asm("csrw pmpaddr5, %[addr]"
+                    :: [addr] "r" (address) :);
+            break;
+        case 6:
+            asm("csrw pmpaddr6, %[addr]"
+                    :: [addr] "r" (address) :);
+            break;
+        case 7:
+            asm("csrw pmpaddr7, %[addr]"
+                    :: [addr] "r" (address) :);
+            break;
+        case 8:
+            asm("csrw pmpaddr8, %[addr]"
+                    :: [addr] "r" (address) :);
+            break;
+        case 9:
+            asm("csrw pmpaddr9, %[addr]"
+                    :: [addr] "r" (address) :);
+            break;
+        case 10:
+            asm("csrw pmpaddr10, %[addr]"
+                    :: [addr] "r" (address) :);
+            break;
+        case 11:
+            asm("csrw pmpaddr11, %[addr]"
+                    :: [addr] "r" (address) :);
+            break;
+        case 12:
+            asm("csrw pmpaddr12, %[addr]"
+                    :: [addr] "r" (address) :);
+            break;
+        case 13:
+            asm("csrw pmpaddr13, %[addr]"
+                    :: [addr] "r" (address) :);
+            break;
+        case 14:
+            asm("csrw pmpaddr14, %[addr]"
+                    :: [addr] "r" (address) :);
+            break;
+        case 15:
+            asm("csrw pmpaddr15, %[addr]"
+                    :: [addr] "r" (address) :);
+            break;
+        }
+    }
+
+#if __riscv_xlen==32
+    if(CONFIG_TO_INT(old_config) != CONFIG_TO_INT(config)) {
+        /* Mask to clear old pmpcfg */
+        cfgmask = (0xFF << (8 * (region % 4)) );
+        pmpcfg = (CONFIG_TO_INT(config) << (8 * (region % 4)) );
+        
+        switch(region / 4) {
+        case 0:
+            asm("csrc pmpcfg0, %[mask]"
+                    :: [mask] "r" (cfgmask) :);
+
+            asm("csrs pmpcfg0, %[cfg]"
+                    :: [cfg] "r" (pmpcfg) :);
+            break;
+        case 1:
+            asm("csrc pmpcfg1, %[mask]"
+                    :: [mask] "r" (cfgmask) :);
+
+            asm("csrs pmpcfg1, %[cfg]"
+                    :: [cfg] "r" (pmpcfg) :);
+            break;
+        case 2:
+            asm("csrc pmpcfg2, %[mask]"
+                    :: [mask] "r" (cfgmask) :);
+
+            asm("csrs pmpcfg2, %[cfg]"
+                    :: [cfg] "r" (pmpcfg) :);
+            break;
+        case 3:
+            asm("csrc pmpcfg3, %[mask]"
+                    :: [mask] "r" (cfgmask) :);
+
+            asm("csrs pmpcfg3, %[cfg]"
+                    :: [cfg] "r" (pmpcfg) :);
+            break;
+        }
+    }
+#elif __riscv_xlen==64
+    if(CONFIG_TO_INT(old_config) != CONFIG_TO_INT(config)) {
+        /* Mask to clear old pmpcfg */
+        cfgmask = (0xFF << (8 * (region % 8)) );
+        pmpcfg = (CONFIG_TO_INT(config) << (8 * (region % 8)) );
+        
+        switch(region / 8) {
+        case 0:
+            asm("csrc pmpcfg0, %[mask]"
+                    :: [mask] "r" (cfgmask) :);
+
+            asm("csrs pmpcfg0, %[cfg]"
+                    :: [cfg] "r" (pmpcfg) :);
+            break;
+        case 1:
+            asm("csrc pmpcfg2, %[mask]"
+                    :: [mask] "r" (cfgmask) :);
+
+            asm("csrs pmpcfg2, %[cfg]"
+                    :: [cfg] "r" (pmpcfg) :);
+            break;
+        }
+    }
+#else
+#error XLEN is not set to supported value for PMP driver
+#endif
+
+    return 0;
+}
+
+int mee_pmp_get_region(struct mee_pmp *pmp,
+                       unsigned int region,
+                       struct mee_pmp_config *config,
+                       size_t *address)
+{
+    size_t pmpcfg = 0;
+
+    if(!pmp || !config || !address) {
+        /* NULL pointers are invalid arguments */
+        return 1;
+    }
+
+    if(region > pmp->num_regions) {
+        /* Region outside of supported range */
+        return 2;
+    }
+
+#if __riscv_xlen==32
+    switch(region / 4) {
+    case 0:
+        asm("csrr %[cfg], pmpcfg0"
+                : [cfg] "=r" (pmpcfg) ::);
+        break;
+    case 1:
+        asm("csrr %[cfg], pmpcfg1"
+                : [cfg] "=r" (pmpcfg) ::);
+        break;
+    case 2:
+        asm("csrr %[cfg], pmpcfg2"
+                : [cfg] "=r" (pmpcfg) ::);
+        break;
+    case 3:
+        asm("csrr %[cfg], pmpcfg3"
+                : [cfg] "=r" (pmpcfg) ::);
+        break;
+    }
+
+    pmpcfg = (0xFF & (pmpcfg >> (8 * (region % 4)) ) );
+
+#elif __riscv_xlen==64
+    switch(region / 8) {
+    case 0:
+        asm("csrr %[cfg], pmpcfg0"
+                : [cfg] "=r" (pmpcfg) ::);
+        break;
+    case 1:
+        asm("csrr %[cfg], pmpcfg2"
+                : [cfg] "=r" (pmpcfg) ::);
+        break;
+    }
+
+    pmpcfg = (0xFF & (pmpcfg >> (8 * (region % 8)) ) );
+
+#else
+#error XLEN is not set to supported value for PMP driver
+#endif
+
+    *config = INT_TO_CONFIG(pmpcfg);
+
+    switch(region) {
+    case 0:
+        asm("csrr %[addr], pmpaddr0"
+                : [addr] "=r" (*address) ::);
+        break;
+    case 1:
+        asm("csrr %[addr], pmpaddr1"
+                : [addr] "=r" (*address) ::);
+        break;
+    case 2:
+        asm("csrr %[addr], pmpaddr2"
+                : [addr] "=r" (*address) ::);
+        break;
+    case 3:
+        asm("csrr %[addr], pmpaddr3"
+                : [addr] "=r" (*address) ::);
+        break;
+    case 4:
+        asm("csrr %[addr], pmpaddr4"
+                : [addr] "=r" (*address) ::);
+        break;
+    case 5:
+        asm("csrr %[addr], pmpaddr5"
+                : [addr] "=r" (*address) ::);
+        break;
+    case 6:
+        asm("csrr %[addr], pmpaddr6"
+                : [addr] "=r" (*address) ::);
+        break;
+    case 7:
+        asm("csrr %[addr], pmpaddr7"
+                : [addr] "=r" (*address) ::);
+        break;
+    case 8:
+        asm("csrr %[addr], pmpaddr8"
+                : [addr] "=r" (*address) ::);
+        break;
+    case 9:
+        asm("csrr %[addr], pmpaddr9"
+                : [addr] "=r" (*address) ::);
+        break;
+    case 10:
+        asm("csrr %[addr], pmpaddr10"
+                : [addr] "=r" (*address) ::);
+        break;
+    case 11:
+        asm("csrr %[addr], pmpaddr11"
+                : [addr] "=r" (*address) ::);
+        break;
+    case 12:
+        asm("csrr %[addr], pmpaddr12"
+                : [addr] "=r" (*address) ::);
+        break;
+    case 13:
+        asm("csrr %[addr], pmpaddr13"
+                : [addr] "=r" (*address) ::);
+        break;
+    case 14:
+        asm("csrr %[addr], pmpaddr14"
+                : [addr] "=r" (*address) ::);
+        break;
+    case 15:
+        asm("csrr %[addr], pmpaddr15"
+                : [addr] "=r" (*address) ::);
+        break;
+    }
+
+    return 0;
+}
+
+int mee_pmp_lock(struct mee_pmp *pmp, unsigned int region)
+{
+    struct mee_pmp_config config;
+    size_t address;
+    int rc = 0;
+
+    rc = mee_pmp_get_region(pmp, region, &config, &address);
+    if(rc) {
+        return rc;
+    }
+
+    if(config.L == MEE_PMP_LOCKED) {
+        return 0;
+    }
+
+    config.L = MEE_PMP_LOCKED;
+
+    rc = mee_pmp_set_region(pmp, region, config, address);
+
+    return rc;
+}
+
+
+int mee_pmp_set_address(struct mee_pmp *pmp, unsigned int region, size_t address)
+{
+    struct mee_pmp_config config;
+    size_t old_address;
+    int rc = 0;
+
+    rc = mee_pmp_get_region(pmp, region, &config, &old_address);
+    if(rc) {
+        return rc;
+    }
+
+    rc = mee_pmp_set_region(pmp, region, config, address);
+
+    return rc;
+}
+
+size_t mee_pmp_get_address(struct mee_pmp *pmp, unsigned int region)
+{
+    struct mee_pmp_config config;
+    size_t address = 0;
+
+    mee_pmp_get_region(pmp, region, &config, &address);
+
+    return address;
+}
+
+
+int mee_pmp_set_address_mode(struct mee_pmp *pmp, unsigned int region, enum mee_pmp_address_mode mode)
+{
+    struct mee_pmp_config config;
+    size_t address;
+    int rc = 0;
+
+    rc = mee_pmp_get_region(pmp, region, &config, &address);
+    if(rc) {
+        return rc;
+    }
+
+    config.A = mode;
+
+    rc = mee_pmp_set_region(pmp, region, config, address);
+
+    return rc;
+}
+
+enum mee_pmp_address_mode mee_pmp_get_address_mode(struct mee_pmp *pmp, unsigned int region)
+{
+    struct mee_pmp_config config;
+    size_t address = 0;
+
+    mee_pmp_get_region(pmp, region, &config, &address);
+
+    return config.A;
+}
+
+
+int mee_pmp_set_executable(struct mee_pmp *pmp, unsigned int region, int X)
+{
+    struct mee_pmp_config config;
+    size_t address;
+    int rc = 0;
+
+    rc = mee_pmp_get_region(pmp, region, &config, &address);
+    if(rc) {
+        return rc;
+    }
+
+    config.X = X;
+
+    rc = mee_pmp_set_region(pmp, region, config, address);
+
+    return rc;
+}
+
+int mee_pmp_get_executable(struct mee_pmp *pmp, unsigned int region)
+{
+    struct mee_pmp_config config;
+    size_t address = 0;
+
+    mee_pmp_get_region(pmp, region, &config, &address);
+
+    return config.X;
+}
+
+
+int mee_pmp_set_writeable(struct mee_pmp *pmp, unsigned int region, int W)
+{
+    struct mee_pmp_config config;
+    size_t address;
+    int rc = 0;
+
+    rc = mee_pmp_get_region(pmp, region, &config, &address);
+    if(rc) {
+        return rc;
+    }
+
+    config.W = W;
+
+    rc = mee_pmp_set_region(pmp, region, config, address);
+
+    return rc;
+}
+
+int mee_pmp_get_writeable(struct mee_pmp *pmp, unsigned int region)
+{
+    struct mee_pmp_config config;
+    size_t address = 0;
+
+    mee_pmp_get_region(pmp, region, &config, &address);
+
+    return config.W;
+}
+
+
+int mee_pmp_set_readable(struct mee_pmp *pmp, unsigned int region, int R)
+{
+    struct mee_pmp_config config;
+    size_t address;
+    int rc = 0;
+
+    rc = mee_pmp_get_region(pmp, region, &config, &address);
+    if(rc) {
+        return rc;
+    }
+
+    config.R = R;
+
+    rc = mee_pmp_set_region(pmp, region, config, address);
+
+    return rc;
+}
+
+int mee_pmp_get_readable(struct mee_pmp *pmp, unsigned int region)
+{
+    struct mee_pmp_config config;
+    size_t address = 0;
+
+    mee_pmp_get_region(pmp, region, &config, &address);
+
+    return config.R;
+}
+


### PR DESCRIPTION
Driver for PMP configuration which uses __riscv_xlen to determine which pmpcfgX CSRs to configure without requiring vtable lookups.