### PR TITLE
Add .gitattributes to fix language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# Ignore autotools files when computing language stats
+m4/* linguist-vendored=true
+ar-lib linguist-generated=true
+compile linguist-generated=true
+configure linguist-generated=true
+depcomp linguist-generated=true
+install-sh linguist-generated=true
+missing linguist-generated=true
+Makefile.in linguist-generated=true
+aclocal.m4 linguist-generated=true
+


### PR DESCRIPTION
Marks autotools-generated files as generated and the m4 support files as vendored so that they don't contribute to the language stats for the project.