### PR TITLE
Decrease RAM consumption by moving driver data into ROM

### DIFF
--- a/metal/button.h
+++ b/metal/button.h
@@ -14,9 +14,9 @@
 struct metal_button;
 
 struct metal_button_vtable {
-    int (*button_exist)(struct metal_button *button, char *label);
-    struct metal_interrupt* (*interrupt_controller)(struct metal_button *button);
-    int (*get_interrupt_id)(struct metal_button *button);
+    int (*button_exist)(const struct metal_button *button, char *label);
+    const struct metal_interrupt* (*interrupt_controller)(const struct metal_button *button);
+    int (*get_interrupt_id)(const struct metal_button *button);
 };
 
 /*!
@@ -35,7 +35,7 @@ struct metal_button {
  * @param label The DeviceTree label for the button
  * @return A handle for the button
  */
-struct metal_button* metal_button_get(char *label);
+const struct metal_button* metal_button_get(char *label);
 
 
 /*!
@@ -45,8 +45,8 @@ struct metal_button* metal_button_get(char *label);
  * @return A pointer to the interrupt controller responsible for handling
  * button interrupts.
  */
-inline struct metal_interrupt*
-    metal_button_interrupt_controller(struct metal_button *button) { return button->vtable->interrupt_controller(button); }
+inline const struct metal_interrupt*
+    metal_button_interrupt_controller(const struct metal_button *button) { return button->vtable->interrupt_controller(button); }
 
 /*!
  * @brief Get the interrupt id for a button
@@ -54,6 +54,6 @@ inline struct metal_interrupt*
  * @param button The handle for the button
  * @return The interrupt id corresponding to a button.
  */
-inline int metal_button_get_interrupt_id(struct metal_button *button) { return button->vtable->get_interrupt_id(button); }
+inline int metal_button_get_interrupt_id(const struct metal_button *button) { return button->vtable->get_interrupt_id(button); }
 
 #endif

--- a/metal/clock.h
+++ b/metal/clock.h
@@ -18,7 +18,7 @@ struct metal_clock;
 /* The generic interface to all clocks. */
 struct __metal_clock_vtable {
     long (*get_rate_hz)(const struct metal_clock *clk);
-    long (*set_rate_hz)(struct metal_clock *clk, long hz);
+    long (*set_rate_hz)(const struct metal_clock *clk, long hz);
 };
 
 /*!
@@ -30,6 +30,16 @@ typedef void (*metal_clock_pre_rate_change_callback)(void *priv);
  * @brief Function signature of clock post-rate change callbacks
  */
 typedef void (*metal_clock_post_rate_change_callback)(void *priv);
+
+struct __metal_clock_data {
+    /* Pre-rate change callback */
+    metal_clock_pre_rate_change_callback _pre_rate_change_callback;
+    void *_pre_rate_change_callback_priv;
+
+    /* Post-rate change callback */
+    metal_clock_post_rate_change_callback _post_rate_change_callback;
+    void *_post_rate_change_callback_priv;
+};
 
 /*!
  * @struct metal_clock
@@ -45,14 +55,7 @@ typedef void (*metal_clock_post_rate_change_callback)(void *priv);
  */
 struct metal_clock {
     const struct __metal_clock_vtable *vtable;
-
-    /* Pre-rate change callback */
-    metal_clock_pre_rate_change_callback _pre_rate_change_callback;
-    void *_pre_rate_change_callback_priv;
-
-    /* Post-rate change callback */
-    metal_clock_post_rate_change_callback _post_rate_change_callback;
-    void *_post_rate_change_callback_priv;
+    struct __metal_clock_data *data;
 };
 
 /*!
@@ -77,15 +80,21 @@ inline long metal_clock_get_rate_hz(const struct metal_clock *clk) { return clk-
  * Prior to and after the rate change of the clock, this will call the registered
  * pre- and post-rate change callbacks.
  */
-inline long metal_clock_set_rate_hz(struct metal_clock *clk, long hz)
+inline long metal_clock_set_rate_hz(const struct metal_clock *clk, long hz)
 {
-    if(clk->_pre_rate_change_callback != NULL)
-        clk->_pre_rate_change_callback(clk->_pre_rate_change_callback_priv);
+    if(clk->data != NULL) {
+        if(clk->data->_pre_rate_change_callback != NULL) {
+            clk->data->_pre_rate_change_callback(clk->data->_pre_rate_change_callback_priv);
+        }
+    }
 
     long out = clk->vtable->set_rate_hz(clk, hz);
 
-    if (clk->_post_rate_change_callback != NULL)
-        clk->_post_rate_change_callback(clk->_post_rate_change_callback_priv);
+    if(clk->data != NULL) {
+        if (clk->data->_post_rate_change_callback != NULL) {
+            clk->data->_post_rate_change_callback(clk->data->_post_rate_change_callback_priv);
+        }
+    }
 
     return out;
 }
@@ -97,10 +106,12 @@ inline long metal_clock_set_rate_hz(struct metal_clock *clk, long hz)
  * @param cb The callback to be registered
  * @param priv Private data for the callback handler
  */
-inline void metal_clock_register_pre_rate_change_callback(struct metal_clock *clk, metal_clock_pre_rate_change_callback cb, void *priv)
+inline void metal_clock_register_pre_rate_change_callback(const struct metal_clock *clk, metal_clock_pre_rate_change_callback cb, void *priv)
 {
-    clk->_pre_rate_change_callback = cb;
-    clk->_pre_rate_change_callback_priv = priv;
+    if(clk->data != NULL) {
+        clk->data->_pre_rate_change_callback = cb;
+        clk->data->_pre_rate_change_callback_priv = priv;
+    }
 }
 
 /*!
@@ -110,10 +121,12 @@ inline void metal_clock_register_pre_rate_change_callback(struct metal_clock *cl
  * @param cb The callback to be registered
  * @param priv Private data for the callback handler
  */
-inline void metal_clock_register_post_rate_change_callback(struct metal_clock *clk, metal_clock_post_rate_change_callback cb, void *priv)
+inline void metal_clock_register_post_rate_change_callback(const struct metal_clock *clk, metal_clock_post_rate_change_callback cb, void *priv)
 {
-    clk->_post_rate_change_callback = cb;
-    clk->_post_rate_change_callback_priv = priv;
+    if(clk->data != NULL) {
+        clk->data->_post_rate_change_callback = cb;
+        clk->data->_post_rate_change_callback_priv = priv;
+    }
 }
 
 #endif

--- a/metal/cpu.h
+++ b/metal/cpu.h
@@ -24,14 +24,14 @@ struct metal_cpu_vtable {
     unsigned long long (*timebase_get)(const struct metal_cpu *cpu);
     unsigned long long (*mtime_get)(const struct metal_cpu *cpu);
     int (*mtimecmp_set)(const struct metal_cpu *cpu, unsigned long long time);
-    struct metal_interrupt* (*tmr_controller_interrupt)(const struct metal_cpu *cpu);
+    const struct metal_interrupt* (*tmr_controller_interrupt)(const struct metal_cpu *cpu);
     int (*get_tmr_interrupt_id)(const struct metal_cpu *cpu);
-    struct metal_interrupt* (*sw_controller_interrupt)(const struct metal_cpu *cpu);
+    const struct metal_interrupt* (*sw_controller_interrupt)(const struct metal_cpu *cpu);
     int (*get_sw_interrupt_id)(const struct metal_cpu *cpu);
     int (*set_sw_ipi)(const struct metal_cpu *cpu, int hartid);
     int (*clear_sw_ipi)(const struct metal_cpu *cpu, int hartid);
     int (*get_msip)(const struct metal_cpu *cpu, int hartid);
-    struct metal_interrupt* (*controller_interrupt)(const struct metal_cpu *cpu);
+    const struct metal_interrupt* (*controller_interrupt)(const struct metal_cpu *cpu);
     int (*exception_register)(const struct metal_cpu *cpu, int ecode, metal_exception_handler_t handler);
     int (*get_ilen)(const struct metal_cpu *cpu, uintptr_t epc);
     uintptr_t (*get_epc)(const struct metal_cpu *cpu);
@@ -105,7 +105,7 @@ inline int metal_cpu_set_mtimecmp(const struct metal_cpu *cpu, unsigned long lon
  * @param cpu The CPU device handle
  * @return A pointer to the timer interrupt handle
  */
-inline struct metal_interrupt* metal_cpu_timer_interrupt_controller(const struct metal_cpu *cpu)
+inline const struct metal_interrupt* metal_cpu_timer_interrupt_controller(const struct metal_cpu *cpu)
 { return cpu->vtable->tmr_controller_interrupt(cpu); }
 
 /*! @brief Get the RTC timer interrupt id
@@ -127,7 +127,7 @@ inline int metal_cpu_timer_get_interrupt_id(const struct metal_cpu *cpu)
  * @param cpu The CPU device handle
  * @return A pointer to the software interrupt handle
  */
-inline struct metal_interrupt* metal_cpu_software_interrupt_controller(const struct metal_cpu *cpu)
+inline const struct metal_interrupt* metal_cpu_software_interrupt_controller(const struct metal_cpu *cpu)
 { return cpu->vtable->sw_controller_interrupt(cpu); }
 
 /*! @brief Get the software interrupt id
@@ -194,7 +194,7 @@ inline int metal_cpu_get_msip(const struct metal_cpu *cpu, int hartid)
  * @param cpu The CPU device handle
  * @return The handle for the CPU interrupt controller
  */
-inline struct metal_interrupt* metal_cpu_interrupt_controller(const struct metal_cpu *cpu)
+inline const struct metal_interrupt* metal_cpu_interrupt_controller(const struct metal_cpu *cpu)
 { return cpu->vtable->controller_interrupt(cpu); }
 
 /*!

--- a/metal/cpu.h
+++ b/metal/cpu.h
@@ -17,25 +17,25 @@ struct metal_cpu;
 /*!
  * @brief Function signature for exception handlers
  */
-typedef void (*metal_exception_handler_t) (struct metal_cpu *cpu, int ecode);
+typedef void (*metal_exception_handler_t) (const struct metal_cpu *cpu, int ecode);
 
 struct metal_cpu_vtable {
-    unsigned long long (*timer_get)(struct metal_cpu *cpu);
-    unsigned long long (*timebase_get)(struct metal_cpu *cpu);
-    unsigned long long (*mtime_get)(struct metal_cpu *cpu);
-    int (*mtimecmp_set)(struct metal_cpu *cpu, unsigned long long time);
-    struct metal_interrupt* (*tmr_controller_interrupt)(struct metal_cpu *cpu);
-    int (*get_tmr_interrupt_id)(struct metal_cpu *cpu);
-    struct metal_interrupt* (*sw_controller_interrupt)(struct metal_cpu *cpu);
-    int (*get_sw_interrupt_id)(struct metal_cpu *cpu);
-    int (*set_sw_ipi)(struct metal_cpu *cpu, int hartid);
-    int (*clear_sw_ipi)(struct metal_cpu *cpu, int hartid);
-    int (*get_msip)(struct metal_cpu *cpu, int hartid);
-    struct metal_interrupt* (*controller_interrupt)(struct metal_cpu *cpu);
-    int (*exception_register)(struct metal_cpu *cpu, int ecode, metal_exception_handler_t handler);
-    int (*get_ilen)(struct metal_cpu *cpu, uintptr_t epc);
-    uintptr_t (*get_epc)(struct metal_cpu *cpu);
-    int (*set_epc)(struct metal_cpu *cpu, uintptr_t epc);
+    unsigned long long (*timer_get)(const struct metal_cpu *cpu);
+    unsigned long long (*timebase_get)(const struct metal_cpu *cpu);
+    unsigned long long (*mtime_get)(const struct metal_cpu *cpu);
+    int (*mtimecmp_set)(const struct metal_cpu *cpu, unsigned long long time);
+    struct metal_interrupt* (*tmr_controller_interrupt)(const struct metal_cpu *cpu);
+    int (*get_tmr_interrupt_id)(const struct metal_cpu *cpu);
+    struct metal_interrupt* (*sw_controller_interrupt)(const struct metal_cpu *cpu);
+    int (*get_sw_interrupt_id)(const struct metal_cpu *cpu);
+    int (*set_sw_ipi)(const struct metal_cpu *cpu, int hartid);
+    int (*clear_sw_ipi)(const struct metal_cpu *cpu, int hartid);
+    int (*get_msip)(const struct metal_cpu *cpu, int hartid);
+    struct metal_interrupt* (*controller_interrupt)(const struct metal_cpu *cpu);
+    int (*exception_register)(const struct metal_cpu *cpu, int ecode, metal_exception_handler_t handler);
+    int (*get_ilen)(const struct metal_cpu *cpu, uintptr_t epc);
+    uintptr_t (*get_epc)(const struct metal_cpu *cpu);
+    int (*set_epc)(const struct metal_cpu *cpu, uintptr_t epc);
 };
 
 /*! @brief A device handle for a CPU hart
@@ -49,7 +49,7 @@ struct metal_cpu {
  * @param hartid The ID of the desired CPU hart
  * @return A pointer to the CPU device handle
  */
-struct metal_cpu* metal_cpu_get(int hartid);
+const struct metal_cpu* metal_cpu_get(int hartid);
 
 /*! @brief Get the CPU cycle count timer value
  *
@@ -58,7 +58,7 @@ struct metal_cpu* metal_cpu_get(int hartid);
  * @param cpu The CPU device handle
  * @return The value of the CPU cycle count timer
  */
-inline unsigned long long metal_cpu_get_timer(struct metal_cpu *cpu)
+inline unsigned long long metal_cpu_get_timer(const struct metal_cpu *cpu)
 { return cpu->vtable->timer_get(cpu); }
 
 /*! @brief Get the timebase of the CPU
@@ -68,7 +68,7 @@ inline unsigned long long metal_cpu_get_timer(struct metal_cpu *cpu)
  * @param cpu The CPU device handle
  * @return The value of the cycle count timer timebase
  */
-inline unsigned long long metal_cpu_get_timebase(struct metal_cpu *cpu)
+inline unsigned long long metal_cpu_get_timebase(const struct metal_cpu *cpu)
 { return cpu->vtable->timebase_get(cpu); }
 
 /*! @brief Get the value of the mtime RTC
@@ -80,7 +80,7 @@ inline unsigned long long metal_cpu_get_timebase(struct metal_cpu *cpu)
  * @param cpu The CPU device handle
  * @return The value of mtime, or 0 if failure
  */
-inline unsigned long long metal_cpu_get_mtime(struct metal_cpu *cpu)
+inline unsigned long long metal_cpu_get_mtime(const struct metal_cpu *cpu)
 { return cpu->vtable->mtime_get(cpu); }
 
 /*! @brief Set the value of the RTC mtimecmp RTC
@@ -93,7 +93,7 @@ inline unsigned long long metal_cpu_get_mtime(struct metal_cpu *cpu)
  * @param time The value to set the compare register to
  * @return The value of mtimecmp or -1 if error
  */
-inline int metal_cpu_set_mtimecmp(struct metal_cpu *cpu, unsigned long long time)
+inline int metal_cpu_set_mtimecmp(const struct metal_cpu *cpu, unsigned long long time)
 { return cpu->vtable->mtimecmp_set(cpu, time); }
 
 /*! @brief Get a reference to RTC timer interrupt controller
@@ -105,7 +105,7 @@ inline int metal_cpu_set_mtimecmp(struct metal_cpu *cpu, unsigned long long time
  * @param cpu The CPU device handle
  * @return A pointer to the timer interrupt handle
  */
-inline struct metal_interrupt* metal_cpu_timer_interrupt_controller(struct metal_cpu *cpu)
+inline struct metal_interrupt* metal_cpu_timer_interrupt_controller(const struct metal_cpu *cpu)
 { return cpu->vtable->tmr_controller_interrupt(cpu); }
 
 /*! @brief Get the RTC timer interrupt id
@@ -115,7 +115,7 @@ inline struct metal_interrupt* metal_cpu_timer_interrupt_controller(struct metal
  * @param cpu The CPU device handle
  * @return The timer interrupt ID
  */
-inline int metal_cpu_timer_get_interrupt_id(struct metal_cpu *cpu)
+inline int metal_cpu_timer_get_interrupt_id(const struct metal_cpu *cpu)
 { return cpu->vtable->get_tmr_interrupt_id(cpu); }
 
 /*! @brief Get a reference to the software interrupt controller
@@ -127,7 +127,7 @@ inline int metal_cpu_timer_get_interrupt_id(struct metal_cpu *cpu)
  * @param cpu The CPU device handle
  * @return A pointer to the software interrupt handle
  */
-inline struct metal_interrupt* metal_cpu_software_interrupt_controller(struct metal_cpu *cpu)
+inline struct metal_interrupt* metal_cpu_software_interrupt_controller(const struct metal_cpu *cpu)
 { return cpu->vtable->sw_controller_interrupt(cpu); }
 
 /*! @brief Get the software interrupt id
@@ -137,7 +137,7 @@ inline struct metal_interrupt* metal_cpu_software_interrupt_controller(struct me
  * @param cpu The CPU device handle
  * @return the software interrupt ID
  */
-inline int metal_cpu_software_get_interrupt_id(struct metal_cpu *cpu)
+inline int metal_cpu_software_get_interrupt_id(const struct metal_cpu *cpu)
 { return cpu->vtable->get_sw_interrupt_id(cpu); }
 
 /*!
@@ -151,7 +151,7 @@ inline int metal_cpu_software_get_interrupt_id(struct metal_cpu *cpu)
  * @param hartid The CPU hart ID to be interrupted
  * @return 0 upon success
  */
-inline int metal_cpu_software_set_ipi(struct metal_cpu *cpu, int hartid)
+inline int metal_cpu_software_set_ipi(const struct metal_cpu *cpu, int hartid)
 { return cpu->vtable->set_sw_ipi(cpu, hartid); }
 
 /*!
@@ -165,7 +165,7 @@ inline int metal_cpu_software_set_ipi(struct metal_cpu *cpu, int hartid)
  * @param hartid The CPU hart ID to clear
  * @return 0 upon success
  */
-inline int metal_cpu_software_clear_ipi(struct metal_cpu *cpu, int hartid)
+inline int metal_cpu_software_clear_ipi(const struct metal_cpu *cpu, int hartid)
 { return cpu->vtable->clear_sw_ipi(cpu, hartid); }
 
 /*!
@@ -180,7 +180,7 @@ inline int metal_cpu_software_clear_ipi(struct metal_cpu *cpu, int hartid)
  * @param hartid The CPU hart to read
  * @return 0 upon success
  */
-inline int metal_cpu_get_msip(struct metal_cpu *cpu, int hartid)
+inline int metal_cpu_get_msip(const struct metal_cpu *cpu, int hartid)
 { return cpu->vtable->get_msip(cpu, hartid); }
 
 /*!
@@ -194,7 +194,7 @@ inline int metal_cpu_get_msip(struct metal_cpu *cpu, int hartid)
  * @param cpu The CPU device handle
  * @return The handle for the CPU interrupt controller
  */
-inline struct metal_interrupt* metal_cpu_interrupt_controller(struct metal_cpu *cpu)
+inline struct metal_interrupt* metal_cpu_interrupt_controller(const struct metal_cpu *cpu)
 { return cpu->vtable->controller_interrupt(cpu); }
 
 /*!
@@ -208,7 +208,7 @@ inline struct metal_interrupt* metal_cpu_interrupt_controller(struct metal_cpu *
  * @param handler Callback function for the exception handler
  * @return 0 upon success
  */
-inline int metal_cpu_exception_register(struct metal_cpu *cpu, int ecode, metal_exception_handler_t handler)
+inline int metal_cpu_exception_register(const struct metal_cpu *cpu, int ecode, metal_exception_handler_t handler)
 { return cpu->vtable->exception_register(cpu, ecode, handler); }
 
 /*!
@@ -227,7 +227,7 @@ inline int metal_cpu_exception_register(struct metal_cpu *cpu, int ecode, metal_
  * @param epc The address of the instruction to measure
  * @return the length of the instruction in bytes
  */
-inline int metal_cpu_get_instruction_length(struct metal_cpu *cpu, uintptr_t epc)
+inline int metal_cpu_get_instruction_length(const struct metal_cpu *cpu, uintptr_t epc)
 { return cpu->vtable->get_ilen(cpu, epc); }
 
 /*!
@@ -239,7 +239,7 @@ inline int metal_cpu_get_instruction_length(struct metal_cpu *cpu, uintptr_t epc
  * @param cpu The CPU device handle
  * @return The value of the program counter at the time of the exception
  */
-inline uintptr_t metal_cpu_get_exception_pc(struct metal_cpu *cpu)
+inline uintptr_t metal_cpu_get_exception_pc(const struct metal_cpu *cpu)
 { return cpu->vtable->get_epc(cpu); }
 
 /*!
@@ -255,7 +255,7 @@ inline uintptr_t metal_cpu_get_exception_pc(struct metal_cpu *cpu)
  * @param epc The address to set the exception program counter to
  * @return 0 upon success
  */
-inline int metal_cpu_set_exception_pc(struct metal_cpu *cpu, uintptr_t epc)
+inline int metal_cpu_set_exception_pc(const struct metal_cpu *cpu, uintptr_t epc)
 { return cpu->vtable->set_epc(cpu, epc); }
 
 #endif

--- a/metal/drivers/fixed-clock.h
+++ b/metal/drivers/fixed-clock.h
@@ -10,11 +10,11 @@ struct __metal_driver_fixed_clock;
 #include <metal/clock.h>
 
 struct __metal_driver_vtable_fixed_clock {
-    struct __metal_clock_vtable clock;
+    const struct __metal_clock_vtable clock;
 };
 
 long __metal_driver_fixed_clock_get_rate_hz(const struct metal_clock *gclk);
-long __metal_driver_fixed_clock_set_rate_hz(struct metal_clock *gclk, long target_hz);
+long __metal_driver_fixed_clock_set_rate_hz(const struct metal_clock *gclk, long target_hz);
 
 __METAL_DECLARE_VTABLE(__metal_driver_vtable_fixed_clock) = {
     .clock.get_rate_hz = __metal_driver_fixed_clock_get_rate_hz,
@@ -22,9 +22,9 @@ __METAL_DECLARE_VTABLE(__metal_driver_vtable_fixed_clock) = {
 };
 
 struct __metal_driver_fixed_clock {
-    struct metal_clock clock;
+    const struct metal_clock clock;
     const struct __metal_driver_vtable_fixed_clock *vtable;
-    long rate;
+    const long rate;
 };
 
 #endif

--- a/metal/drivers/riscv,clint0.h
+++ b/metal/drivers/riscv,clint0.h
@@ -32,12 +32,16 @@ __METAL_DECLARE_VTABLE(__metal_driver_vtable_riscv_clint0) = {
     .clint_vtable.command_request    = __metal_driver_riscv_clint0_command_request,
 };
 
+struct __metal_driver_riscv_clint0_data {
+    int init_done;
+};
+
 struct __metal_driver_riscv_clint0 {
     const struct metal_interrupt controller;
     const struct __metal_driver_vtable_riscv_clint0 *vtable;
     const unsigned long control_base;
     const unsigned long control_size;
-    int init_done;
+    struct __metal_driver_riscv_clint0_data *data;
     const struct metal_interrupt *interrupt_parent;
     const int num_interrupts;
     const int interrupt_lines[];

--- a/metal/drivers/riscv,clint0.h
+++ b/metal/drivers/riscv,clint0.h
@@ -12,16 +12,16 @@
 #define METAL_CLINT_MTIME_OFFSET        0xBFF8UL
 
 struct __metal_driver_vtable_riscv_clint0 {
-    struct metal_interrupt_vtable clint_vtable;
+    const struct metal_interrupt_vtable clint_vtable;
 };
 
-void __metal_driver_riscv_clint0_init(struct metal_interrupt *clint);
-int __metal_driver_riscv_clint0_register(struct metal_interrupt *controller,
+void __metal_driver_riscv_clint0_init(const struct metal_interrupt *clint);
+int __metal_driver_riscv_clint0_register(const struct metal_interrupt *controller,
                                        int id, metal_interrupt_handler_t isr,
                                        void *priv);
-int __metal_driver_riscv_clint0_enable(struct metal_interrupt *controller, int id);
-int __metal_driver_riscv_clint0_disable(struct metal_interrupt *controller, int id);
-int __metal_driver_riscv_clint0_command_request(struct metal_interrupt *clint,
+int __metal_driver_riscv_clint0_enable(const struct metal_interrupt *controller, int id);
+int __metal_driver_riscv_clint0_disable(const struct metal_interrupt *controller, int id);
+int __metal_driver_riscv_clint0_command_request(const struct metal_interrupt *clint,
                                               int command, void *data);
 
 __METAL_DECLARE_VTABLE(__metal_driver_vtable_riscv_clint0) = {
@@ -33,12 +33,12 @@ __METAL_DECLARE_VTABLE(__metal_driver_vtable_riscv_clint0) = {
 };
 
 struct __metal_driver_riscv_clint0 {
-    struct metal_interrupt controller;
+    const struct metal_interrupt controller;
     const struct __metal_driver_vtable_riscv_clint0 *vtable;
     const unsigned long control_base;
     const unsigned long control_size;
     int init_done;
-    struct metal_interrupt *interrupt_parent;
+    const struct metal_interrupt *interrupt_parent;
     const int num_interrupts;
     const int interrupt_lines[];
 };

--- a/metal/drivers/riscv,cpu.h
+++ b/metal/drivers/riscv,cpu.h
@@ -136,28 +136,28 @@ typedef struct __metal_interrupt_data {
 uintptr_t __metal_myhart_id(void);
 
 struct __metal_driver_interrupt_controller_vtable {
-    void (*interrupt_init)(struct metal_interrupt *controller);
-    int (*interrupt_register)(struct metal_interrupt *controller,
+    void (*interrupt_init)(const struct metal_interrupt *controller);
+    int (*interrupt_register)(const struct metal_interrupt *controller,
 			      int id, metal_interrupt_handler_t isr, void *priv_data);
-    int (*interrupt_enable)(struct metal_interrupt *controller, int id);
-    int (*interrupt_disable)(struct metal_interrupt *controller, int id);
-    int (*command_request)(struct metal_interrupt *intr, int cmd, void *data);
+    int (*interrupt_enable)(const struct metal_interrupt *controller, int id);
+    int (*interrupt_disable)(const struct metal_interrupt *controller, int id);
+    int (*command_request)(const struct metal_interrupt *intr, int cmd, void *data);
 };
 
 struct __metal_driver_vtable_riscv_cpu_intc {
-  struct metal_interrupt_vtable controller_vtable;
+  const struct metal_interrupt_vtable controller_vtable;
 };
 
-void __metal_driver_riscv_cpu_controller_interrupt_init(struct metal_interrupt *controller);
-int __metal_driver_riscv_cpu_controller_interrupt_register(struct metal_interrupt *controller,
+void __metal_driver_riscv_cpu_controller_interrupt_init(const struct metal_interrupt *controller);
+int __metal_driver_riscv_cpu_controller_interrupt_register(const struct metal_interrupt *controller,
 							 int id, metal_interrupt_handler_t isr,
 							 void *priv_data);
-int __metal_driver_riscv_cpu_controller_interrupt_enable(struct metal_interrupt *controller, int id);
-int __metal_driver_riscv_cpu_controller_interrupt_disable(struct metal_interrupt *controller, int id);
-int __metal_driver_riscv_cpu_controller_interrupt_enable_vector(struct metal_interrupt *controller,
+int __metal_driver_riscv_cpu_controller_interrupt_enable(const struct metal_interrupt *controller, int id);
+int __metal_driver_riscv_cpu_controller_interrupt_disable(const struct metal_interrupt *controller, int id);
+int __metal_driver_riscv_cpu_controller_interrupt_enable_vector(const struct metal_interrupt *controller,
                                                               int id, metal_vector_mode mode);
-int __metal_driver_riscv_cpu_controller_interrupt_disable_vector(struct metal_interrupt *controller, int id);
-int __metal_driver_riscv_cpu_controller_command_request(struct metal_interrupt *controller,
+int __metal_driver_riscv_cpu_controller_interrupt_disable_vector(const struct metal_interrupt *controller, int id);
+int __metal_driver_riscv_cpu_controller_command_request(const struct metal_interrupt *controller,
 						      int cmd, void *data);
 
 void __metal_interrupt_global_enable(void);
@@ -182,7 +182,7 @@ __METAL_DECLARE_VTABLE(__metal_driver_vtable_riscv_cpu_intc) = {
 };
 
 struct __metal_driver_riscv_cpu_intc {
-    struct metal_interrupt controller;
+    const struct metal_interrupt controller;
     const struct __metal_driver_vtable_riscv_cpu_intc *vtable;
     int init_done;
     int interrupt_controller;
@@ -201,16 +201,16 @@ unsigned long long  __metal_driver_cpu_timebase_get(const struct metal_cpu *cpu)
 unsigned long long
       __metal_driver_cpu_mtime_get(const struct metal_cpu *cpu);
 int  __metal_driver_cpu_mtimecmp_set(const struct metal_cpu *cpu, unsigned long long time);
-struct metal_interrupt*
+const struct metal_interrupt*
      __metal_driver_cpu_timer_controller_interrupt(const struct metal_cpu *cpu);
 int  __metal_driver_cpu_get_timer_interrupt_id(const struct metal_cpu *cpu);
-struct metal_interrupt*
+const struct metal_interrupt*
      __metal_driver_cpu_sw_controller_interrupt(const struct metal_cpu *cpu);
 int  __metal_driver_cpu_get_sw_interrupt_id(const struct metal_cpu *cpu);
 int  __metal_driver_cpu_set_sw_ipi(const struct metal_cpu *cpu, int hartid);
 int  __metal_driver_cpu_clear_sw_ipi(const struct metal_cpu *cpu, int hartid);
 int  __metal_driver_cpu_get_msip(const struct metal_cpu *cpu, int hartid);
-struct metal_interrupt*
+const struct metal_interrupt*
      __metal_driver_cpu_controller_interrupt(const struct metal_cpu *cpu);
 int  __metal_driver_cpu_exception_register(const struct metal_cpu *cpu, int ecode,
 					 metal_exception_handler_t isr);
@@ -241,7 +241,7 @@ struct __metal_driver_cpu {
     const struct metal_cpu cpu;
     const struct __metal_driver_vtable_cpu *vtable;
     const int timebase;    
-    struct metal_interrupt *interrupt_controller;
+    const struct metal_interrupt *interrupt_controller;
 };
 
 #endif

--- a/metal/drivers/riscv,cpu.h
+++ b/metal/drivers/riscv,cpu.h
@@ -193,30 +193,30 @@ struct __metal_driver_riscv_cpu_intc {
 
 /* CPU driver*/
 struct __metal_driver_vtable_cpu {
-  struct metal_cpu_vtable cpu_vtable;
+  const struct metal_cpu_vtable cpu_vtable;
 };
 
-unsigned long long  __metal_driver_cpu_timer_get(struct metal_cpu *cpu);
-unsigned long long  __metal_driver_cpu_timebase_get(struct metal_cpu *cpu);
+unsigned long long  __metal_driver_cpu_timer_get(const struct metal_cpu *cpu);
+unsigned long long  __metal_driver_cpu_timebase_get(const struct metal_cpu *cpu);
 unsigned long long
-      __metal_driver_cpu_mtime_get(struct metal_cpu *cpu);
-int  __metal_driver_cpu_mtimecmp_set(struct metal_cpu *cpu, unsigned long long time);
+      __metal_driver_cpu_mtime_get(const struct metal_cpu *cpu);
+int  __metal_driver_cpu_mtimecmp_set(const struct metal_cpu *cpu, unsigned long long time);
 struct metal_interrupt*
-     __metal_driver_cpu_timer_controller_interrupt(struct metal_cpu *cpu);
-int  __metal_driver_cpu_get_timer_interrupt_id(struct metal_cpu *cpu);
+     __metal_driver_cpu_timer_controller_interrupt(const struct metal_cpu *cpu);
+int  __metal_driver_cpu_get_timer_interrupt_id(const struct metal_cpu *cpu);
 struct metal_interrupt*
-     __metal_driver_cpu_sw_controller_interrupt(struct metal_cpu *cpu);
-int  __metal_driver_cpu_get_sw_interrupt_id(struct metal_cpu *cpu);
-int  __metal_driver_cpu_set_sw_ipi(struct metal_cpu *cpu, int hartid);
-int  __metal_driver_cpu_clear_sw_ipi(struct metal_cpu *cpu, int hartid);
-int  __metal_driver_cpu_get_msip(struct metal_cpu *cpu, int hartid);
+     __metal_driver_cpu_sw_controller_interrupt(const struct metal_cpu *cpu);
+int  __metal_driver_cpu_get_sw_interrupt_id(const struct metal_cpu *cpu);
+int  __metal_driver_cpu_set_sw_ipi(const struct metal_cpu *cpu, int hartid);
+int  __metal_driver_cpu_clear_sw_ipi(const struct metal_cpu *cpu, int hartid);
+int  __metal_driver_cpu_get_msip(const struct metal_cpu *cpu, int hartid);
 struct metal_interrupt*
-     __metal_driver_cpu_controller_interrupt(struct metal_cpu *cpu);
-int  __metal_driver_cpu_exception_register(struct metal_cpu *cpu, int ecode,
+     __metal_driver_cpu_controller_interrupt(const struct metal_cpu *cpu);
+int  __metal_driver_cpu_exception_register(const struct metal_cpu *cpu, int ecode,
 					 metal_exception_handler_t isr);
-int  __metal_driver_cpu_get_instruction_length(struct metal_cpu *cpu, uintptr_t epc);
-uintptr_t  __metal_driver_cpu_get_exception_pc(struct metal_cpu *cpu);
-int  __metal_driver_cpu_set_exception_pc(struct metal_cpu *cpu, uintptr_t epc);
+int  __metal_driver_cpu_get_instruction_length(const struct metal_cpu *cpu, uintptr_t epc);
+uintptr_t  __metal_driver_cpu_get_exception_pc(const struct metal_cpu *cpu);
+int  __metal_driver_cpu_set_exception_pc(const struct metal_cpu *cpu, uintptr_t epc);
 
 __METAL_DECLARE_VTABLE(__metal_driver_vtable_cpu) = {
     .cpu_vtable.timer_get     = __metal_driver_cpu_timer_get,
@@ -238,7 +238,7 @@ __METAL_DECLARE_VTABLE(__metal_driver_vtable_cpu) = {
 };
 
 struct __metal_driver_cpu {
-    struct metal_cpu cpu;
+    const struct metal_cpu cpu;
     const struct __metal_driver_vtable_cpu *vtable;
     const int timebase;    
     struct metal_interrupt *interrupt_controller;

--- a/metal/drivers/riscv,cpu.h
+++ b/metal/drivers/riscv,cpu.h
@@ -181,14 +181,19 @@ __METAL_DECLARE_VTABLE(__metal_driver_vtable_riscv_cpu_intc) = {
     .controller_vtable.command_request    = __metal_driver_riscv_cpu_controller_command_request,
 };
 
-struct __metal_driver_riscv_cpu_intc {
-    const struct metal_interrupt controller;
-    const struct __metal_driver_vtable_riscv_cpu_intc *vtable;
+
+struct __metal_driver_riscv_cpu_intc_data {
     int init_done;
-    int interrupt_controller;
     uintptr_t metal_mtvec_table[METAL_MAX_MI];
     __metal_interrupt_data metal_int_table[METAL_MAX_MI];
     metal_exception_handler_t metal_exception_table[METAL_MAX_ME];
+};
+
+struct __metal_driver_riscv_cpu_intc {
+    const struct metal_interrupt controller;
+    const struct __metal_driver_vtable_riscv_cpu_intc *vtable;
+    const int interrupt_controller;
+    struct __metal_driver_riscv_cpu_intc_data *data;
 };
 
 /* CPU driver*/

--- a/metal/drivers/riscv,plic0.h
+++ b/metal/drivers/riscv,plic0.h
@@ -9,15 +9,15 @@
 
 
 struct __metal_driver_vtable_riscv_plic0 {
-    struct metal_interrupt_vtable plic_vtable;
+    const struct metal_interrupt_vtable plic_vtable;
 };
 
-void __metal_driver_riscv_plic0_init(struct metal_interrupt *controller);
-int __metal_driver_riscv_plic0_register(struct metal_interrupt *plic,
+void __metal_driver_riscv_plic0_init(const struct metal_interrupt *controller);
+int __metal_driver_riscv_plic0_register(const struct metal_interrupt *plic,
 				      int id, metal_interrupt_handler_t isr,
 				      void *priv_data);
-int __metal_driver_riscv_plic0_enable(struct metal_interrupt *controller, int id);
-int __metal_driver_riscv_plic0_disable(struct metal_interrupt *controller, int id);
+int __metal_driver_riscv_plic0_enable(const struct metal_interrupt *controller, int id);
+int __metal_driver_riscv_plic0_disable(const struct metal_interrupt *controller, int id);
 
 __METAL_DECLARE_VTABLE(__metal_driver_vtable_riscv_plic0) = {
     .plic_vtable.interrupt_init = __metal_driver_riscv_plic0_init,
@@ -27,11 +27,11 @@ __METAL_DECLARE_VTABLE(__metal_driver_vtable_riscv_plic0) = {
 };
 
 struct __metal_driver_riscv_plic0 {
-    struct metal_interrupt controller;
+    const struct metal_interrupt controller;
     const struct __metal_driver_vtable_riscv_plic0 *vtable;
     const unsigned long control_base;
     const unsigned long control_size;
-    struct metal_interrupt *interrupt_parent;
+    const struct metal_interrupt *interrupt_parent;
     const int interrupt_line;
     int max_priority;
     int num_interrupts;

--- a/metal/drivers/riscv,plic0.h
+++ b/metal/drivers/riscv,plic0.h
@@ -26,6 +26,11 @@ __METAL_DECLARE_VTABLE(__metal_driver_vtable_riscv_plic0) = {
     .plic_vtable.interrupt_disable  = __metal_driver_riscv_plic0_disable,
 };
 
+struct __metal_driver_riscv_plic0_data {
+    int init_done;
+    __metal_interrupt_data metal_exint_table[];
+};
+
 struct __metal_driver_riscv_plic0 {
     const struct metal_interrupt controller;
     const struct __metal_driver_vtable_riscv_plic0 *vtable;
@@ -33,11 +38,10 @@ struct __metal_driver_riscv_plic0 {
     const unsigned long control_size;
     const struct metal_interrupt *interrupt_parent;
     const int interrupt_line;
-    int max_priority;
-    int num_interrupts;
-    int init_done;
-    int interrupt_controller;
-    __metal_interrupt_data metal_exint_table[];
+    const int max_priority;
+    const int num_interrupts;
+    const int interrupt_controller;
+    struct __metal_driver_riscv_plic0_data *data;
 };
 
 

--- a/metal/drivers/sifive,clic0.h
+++ b/metal/drivers/sifive,clic0.h
@@ -41,20 +41,20 @@
 #define METAL_MAX_INTERRUPT_LEVEL      ((1 << METAL_CLIC_MAX_NLBITS) - 1)
 
 struct __metal_driver_vtable_sifive_clic0 {
-    struct metal_interrupt_vtable clic_vtable;
+    const struct metal_interrupt_vtable clic_vtable;
 };
 
-void __metal_driver_sifive_clic0_init(struct metal_interrupt *clic);
-int __metal_driver_sifive_clic0_register(struct metal_interrupt *controller,
+void __metal_driver_sifive_clic0_init(const struct metal_interrupt *clic);
+int __metal_driver_sifive_clic0_register(const struct metal_interrupt *controller,
                                        int id, metal_interrupt_handler_t isr,
                                        void *priv);
-int __metal_driver_sifive_clic0_enable(struct metal_interrupt *controller, int id);
-int __metal_driver_sifive_clic0_disable(struct metal_interrupt *controller, int id);
-int __metal_driver_sifive_clic0_enable_interrupt_vector(struct metal_interrupt *controller,
+int __metal_driver_sifive_clic0_enable(const struct metal_interrupt *controller, int id);
+int __metal_driver_sifive_clic0_disable(const struct metal_interrupt *controller, int id);
+int __metal_driver_sifive_clic0_enable_interrupt_vector(const struct metal_interrupt *controller,
                                                       int id, metal_vector_mode mode);
-int __metal_driver_sifive_clic0_disable_interrupt_vector(struct metal_interrupt *controller,
+int __metal_driver_sifive_clic0_disable_interrupt_vector(const struct metal_interrupt *controller,
                                                        int id);
-int __metal_driver_sifive_clic0_command_request(struct metal_interrupt *clic,
+int __metal_driver_sifive_clic0_command_request(const struct metal_interrupt *clic,
                                               int command, void *data);
 
 __METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_clic0) = {
@@ -70,12 +70,12 @@ __METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_clic0) = {
 #define __METAL_MACHINE_MACROS
 #include <metal/machine.h>
 struct __metal_driver_sifive_clic0 {
-    struct metal_interrupt controller;
+    const struct metal_interrupt controller;
     const struct __metal_driver_vtable_sifive_clic0 *vtable;
     const unsigned long control_base;
     const unsigned long control_size;
     int init_done;
-    struct metal_interrupt *interrupt_parent;
+    const struct metal_interrupt *interrupt_parent;
     const int num_interrupts;
     /* Hardcode max of 3 direct interrupts to core for now, SW, Timer, Ext */
     const int interrupt_lines[3];

--- a/metal/drivers/sifive,clic0.h
+++ b/metal/drivers/sifive,clic0.h
@@ -69,22 +69,27 @@ __METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_clic0) = {
 
 #define __METAL_MACHINE_MACROS
 #include <metal/machine.h>
+
+struct __metal_driver_sifive_clic0_data {
+    int init_done;
+    metal_interrupt_handler_t metal_mtvt_table[__METAL_CLIC_SUBINTERRUPTS];
+    __metal_interrupt_data metal_exint_table[__METAL_CLIC_SUBINTERRUPTS];
+};
+
 struct __metal_driver_sifive_clic0 {
     const struct metal_interrupt controller;
     const struct __metal_driver_vtable_sifive_clic0 *vtable;
     const unsigned long control_base;
     const unsigned long control_size;
-    int init_done;
     const struct metal_interrupt *interrupt_parent;
     const int num_interrupts;
     /* Hardcode max of 3 direct interrupts to core for now, SW, Timer, Ext */
     const int interrupt_lines[3];
-    int max_levels;
-    int num_subinterrupts;
-    int num_intbits;
-    int interrupt_controller;
-    metal_interrupt_handler_t metal_mtvt_table[__METAL_CLIC_SUBINTERRUPTS];
-    __metal_interrupt_data metal_exint_table[__METAL_CLIC_SUBINTERRUPTS];
+    const int max_levels;
+    const int num_subinterrupts;
+    const int num_intbits;
+    const int interrupt_controller;
+    struct __metal_driver_sifive_clic0_data *data;
 };
 #undef __METAL_MACHINE_MACROS
 

--- a/metal/drivers/sifive,fe310-g000,hfrosc.h
+++ b/metal/drivers/sifive,fe310-g000,hfrosc.h
@@ -10,10 +10,10 @@
 #include <metal/io.h>
 
 long __metal_driver_sifive_fe310_g000_hfrosc_get_rate_hz(const struct metal_clock *clock);
-long __metal_driver_sifive_fe310_g000_hfrosc_set_rate_hz(struct metal_clock *clock, long rate);
+long __metal_driver_sifive_fe310_g000_hfrosc_set_rate_hz(const struct metal_clock *clock, long rate);
 
 struct __metal_driver_vtable_sifive_fe310_g000_hfrosc {
-    struct __metal_clock_vtable clock;
+    const struct __metal_clock_vtable clock;
 };
 
 __METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_fe310_g000_hfrosc) = {
@@ -22,7 +22,7 @@ __METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_fe310_g000_hfrosc) = {
 };
 
 struct __metal_driver_sifive_fe310_g000_hfrosc {
-    struct metal_clock clock;
+    const struct metal_clock clock;
     const struct __metal_driver_vtable_sifive_fe310_g000_hfrosc *vtable;
     const struct metal_clock *ref;
     const struct __metal_driver_sifive_fe310_g000_prci *config_base;

--- a/metal/drivers/sifive,fe310-g000,hfxosc.h
+++ b/metal/drivers/sifive,fe310-g000,hfxosc.h
@@ -8,10 +8,10 @@
 #include <metal/drivers/sifive,fe310-g000,prci.h>
 
 long __metal_driver_sifive_fe310_g000_hfxosc_get_rate_hz(const struct metal_clock *clock);
-long __metal_driver_sifive_fe310_g000_hfxosc_set_rate_hz(struct metal_clock *clock, long rate);
+long __metal_driver_sifive_fe310_g000_hfxosc_set_rate_hz(const struct metal_clock *clock, long rate);
 
 struct __metal_driver_vtable_sifive_fe310_g000_hfxosc {
-    struct __metal_clock_vtable clock;
+    const struct __metal_clock_vtable clock;
 };
 
 __METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_fe310_g000_hfxosc) = {
@@ -20,7 +20,7 @@ __METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_fe310_g000_hfxosc) = {
 };
 
 struct __metal_driver_sifive_fe310_g000_hfxosc {
-    struct metal_clock clock;
+    const struct metal_clock clock;
     const struct __metal_driver_vtable_sifive_fe310_g000_hfxosc *vtable;
     const struct metal_clock *ref;
     const struct __metal_driver_sifive_fe310_g000_prci *config_base;

--- a/metal/drivers/sifive,fe310-g000,pll.h
+++ b/metal/drivers/sifive,fe310-g000,pll.h
@@ -9,13 +9,13 @@ struct __metal_driver_sifive_fe310_g000_pll;
 #include <metal/clock.h>
 #include <metal/drivers/sifive,fe310-g000,prci.h>
 
-void __metal_driver_sifive_fe310_g000_pll_init(struct __metal_driver_sifive_fe310_g000_pll *pll);
+void __metal_driver_sifive_fe310_g000_pll_init(const struct __metal_driver_sifive_fe310_g000_pll *pll);
 long __metal_driver_sifive_fe310_g000_pll_get_rate_hz(const struct metal_clock *clock);
-long __metal_driver_sifive_fe310_g000_pll_set_rate_hz(struct metal_clock *clock, long rate);
+long __metal_driver_sifive_fe310_g000_pll_set_rate_hz(const struct metal_clock *clock, long rate);
 
 struct __metal_driver_vtable_sifive_fe310_g000_pll {
-    void (*init)(struct __metal_driver_sifive_fe310_g000_pll *pll);
-    struct __metal_clock_vtable clock;
+    void (*init)(const struct __metal_driver_sifive_fe310_g000_pll *pll);
+    const struct __metal_clock_vtable clock;
 };
 
 __METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_fe310_g000_pll) = {
@@ -25,7 +25,7 @@ __METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_fe310_g000_pll) = {
 };
 
 struct __metal_driver_sifive_fe310_g000_pll {
-    struct metal_clock clock;
+    const struct metal_clock clock;
     const struct __metal_driver_vtable_sifive_fe310_g000_pll *vtable;
     const struct metal_clock *pllsel0;
     const struct metal_clock *pllref;

--- a/metal/drivers/sifive,global-external-interrupts0.h
+++ b/metal/drivers/sifive,global-external-interrupts0.h
@@ -8,16 +8,16 @@
 #include <metal/drivers/riscv,cpu.h>
 
 struct __metal_driver_vtable_sifive_global_external_interrupts0 {
-    struct metal_interrupt_vtable global0_vtable;
+    const struct metal_interrupt_vtable global0_vtable;
 };
 
-void __metal_driver_sifive_global_external_interrupt_init(struct metal_interrupt *global0);
-int __metal_driver_sifive_global_external_interrupt_register(struct metal_interrupt *controller,
+void __metal_driver_sifive_global_external_interrupt_init(const struct metal_interrupt *global0);
+int __metal_driver_sifive_global_external_interrupt_register(const struct metal_interrupt *controller,
                                                            int id, metal_interrupt_handler_t isr,
                                                            void *priv_data);
-int __metal_driver_sifive_global_external_interrupt_enable(struct metal_interrupt *controller, int id);
-int __metal_driver_sifive_global_external_interrupt_disable(struct metal_interrupt *controller, int id);
-int __metal_driver_sifive_global_external_command_request(struct metal_interrupt *clint,
+int __metal_driver_sifive_global_external_interrupt_enable(const struct metal_interrupt *controller, int id);
+int __metal_driver_sifive_global_external_interrupt_disable(const struct metal_interrupt *controller, int id);
+int __metal_driver_sifive_global_external_command_request(const struct metal_interrupt *clint,
                                                         int command, void *data);
 
 __METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_global_external_interrupts0) = {
@@ -29,10 +29,10 @@ __METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_global_external_interrupts0)
 };
 
 struct __metal_driver_sifive_global_external_interrupts0 {
-    struct metal_interrupt irc;
+    const struct metal_interrupt irc;
     const struct __metal_driver_vtable_sifive_global_external_interrupts0 *vtable;
     int init_done;
-    struct metal_interrupt *interrupt_parent;
+    const struct metal_interrupt *interrupt_parent;
     const int num_interrupts;
     const int interrupt_lines[];
 };

--- a/metal/drivers/sifive,global-external-interrupts0.h
+++ b/metal/drivers/sifive,global-external-interrupts0.h
@@ -28,10 +28,14 @@ __METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_global_external_interrupts0)
     .global0_vtable.command_request    = __metal_driver_sifive_global_external_command_request,
 };
 
+struct __metal_driver_sifive_global_external_interrupts0_data {
+    int init_done;
+};
+
 struct __metal_driver_sifive_global_external_interrupts0 {
     const struct metal_interrupt irc;
     const struct __metal_driver_vtable_sifive_global_external_interrupts0 *vtable;
-    int init_done;
+    struct __metal_driver_sifive_global_external_interrupts0_data *data;
     const struct metal_interrupt *interrupt_parent;
     const int num_interrupts;
     const int interrupt_lines[];

--- a/metal/drivers/sifive,gpio-buttons.h
+++ b/metal/drivers/sifive,gpio-buttons.h
@@ -9,13 +9,13 @@
 #include <metal/compiler.h>
 
 struct __metal_driver_vtable_sifive_button {
-  struct metal_button_vtable button_vtable;
+  const struct metal_button_vtable button_vtable;
 };
 
-int  __metal_driver_button_exist(struct metal_button *button, char *label);
-struct metal_interrupt*
-     __metal_driver_button_interrupt_controller(struct metal_button *button);
-int  __metal_driver_button_get_interrupt_id(struct metal_button *button);
+int  __metal_driver_button_exist(const struct metal_button *button, char *label);
+const struct metal_interrupt*
+     __metal_driver_button_interrupt_controller(const struct metal_button *button);
+int  __metal_driver_button_get_interrupt_id(const struct metal_button *button);
 
 __METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_button) = {
     .button_vtable.button_exist   = __metal_driver_button_exist,
@@ -24,10 +24,10 @@ __METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_button) = {
 };
 
 struct __metal_driver_sifive_gpio_button {
-    struct metal_button button;
+    const struct metal_button button;
     const struct __metal_driver_vtable_sifive_button *vtable;
-    struct metal_interrupt *interrupt_parent;
-    struct __metal_driver_sifive_gpio0 *gpio;
+    const struct metal_interrupt *interrupt_parent;
+    const struct __metal_driver_sifive_gpio0 *gpio;
     const char *label;
     const int pin;
     const int interrupt_line;

--- a/metal/drivers/sifive,gpio-leds.h
+++ b/metal/drivers/sifive,gpio-leds.h
@@ -9,14 +9,14 @@
 #include <metal/compiler.h>
 
 struct __metal_driver_vtable_sifive_led {
-  struct metal_led_vtable led_vtable;
+  const struct metal_led_vtable led_vtable;
 };
 
-int  __metal_driver_led_exist(struct metal_led *led, char *label);
-void __metal_driver_led_enable(struct metal_led *led);
-void __metal_driver_led_on(struct metal_led *led);
-void __metal_driver_led_off(struct metal_led *led);
-void __metal_driver_led_toggle(struct metal_led *led);
+int  __metal_driver_led_exist(const struct metal_led *led, char *label);
+void __metal_driver_led_enable(const struct metal_led *led);
+void __metal_driver_led_on(const struct metal_led *led);
+void __metal_driver_led_off(const struct metal_led *led);
+void __metal_driver_led_toggle(const struct metal_led *led);
 
 __METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_led) = {
     .led_vtable.led_exist   = __metal_driver_led_exist,
@@ -27,9 +27,9 @@ __METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_led) = {
 };
 
 struct __metal_driver_sifive_gpio_led {
-    struct metal_led led;
+    const struct metal_led led;
     const struct __metal_driver_vtable_sifive_led *vtable;
-    struct __metal_driver_sifive_gpio0 *gpio;
+    const struct __metal_driver_sifive_gpio0 *gpio;
     const char *label;
     const int pin;
 };

--- a/metal/drivers/sifive,gpio-switches.h
+++ b/metal/drivers/sifive,gpio-switches.h
@@ -9,13 +9,13 @@
 #include <metal/compiler.h>
 
 struct __metal_driver_vtable_sifive_switch {
-  struct metal_switch_vtable switch_vtable;
+  const struct metal_switch_vtable switch_vtable;
 };
 
-int  __metal_driver_switch_exist(struct metal_switch *flip, char *label);
-struct metal_interrupt*
-     __metal_driver_switch_interrupt_controller(struct metal_switch *flip);
-int  __metal_driver_switch_get_interrupt_id(struct metal_switch *flip);
+int  __metal_driver_switch_exist(const struct metal_switch *flip, char *label);
+const struct metal_interrupt*
+     __metal_driver_switch_interrupt_controller(const struct metal_switch *flip);
+int  __metal_driver_switch_get_interrupt_id(const struct metal_switch *flip);
 
 __METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_switch) = {
     .switch_vtable.switch_exist   = __metal_driver_switch_exist,
@@ -24,10 +24,10 @@ __METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_switch) = {
 };
 
 struct __metal_driver_sifive_gpio_switch {
-    struct metal_switch flip;
+    const struct metal_switch flip;
     const struct __metal_driver_vtable_sifive_switch *vtable;
-    struct metal_interrupt *interrupt_parent;
-    struct __metal_driver_sifive_gpio0 *gpio;
+    const struct metal_interrupt *interrupt_parent;
+    const struct __metal_driver_sifive_gpio0 *gpio;
     const char *label;
     const int pin;
     const int interrupt_line;

--- a/metal/drivers/sifive,gpio0.h
+++ b/metal/drivers/sifive,gpio0.h
@@ -40,7 +40,7 @@ struct __metal_driver_sifive_gpio0 {
     const struct __metal_driver_vtable_sifive_gpio0 *vtable;
     const long base;
     const long size;
-    struct metal_interrupt *interrupt_parent;
+    const struct metal_interrupt *interrupt_parent;
     const int num_interrupts;
     const int interrupt_lines[];
 };

--- a/metal/drivers/sifive,local-external-interrupts0.h
+++ b/metal/drivers/sifive,local-external-interrupts0.h
@@ -8,16 +8,16 @@
 #include <metal/drivers/riscv,cpu.h>
 
 struct __metal_driver_vtable_sifive_local_external_interrupts0 {
-    struct metal_interrupt_vtable local0_vtable;
+    const struct metal_interrupt_vtable local0_vtable;
 };
 
-void __metal_driver_sifive_local_external_interrupt_init(struct metal_interrupt *local0);
-int __metal_driver_sifive_local_external_interrupt_register(struct metal_interrupt *controller,
+void __metal_driver_sifive_local_external_interrupt_init(const struct metal_interrupt *local0);
+int __metal_driver_sifive_local_external_interrupt_register(const struct metal_interrupt *controller,
                                                           int id, metal_interrupt_handler_t isr,
                                                           void *priv);
-int __metal_driver_sifive_local_external_interrupt_enable(struct metal_interrupt *controller, int id);
-int __metal_driver_sifive_local_external_interrupt_disable(struct metal_interrupt *controller, int id);
-int __metal_driver_sifive_local_external_command_request(struct metal_interrupt *clint,
+int __metal_driver_sifive_local_external_interrupt_enable(const struct metal_interrupt *controller, int id);
+int __metal_driver_sifive_local_external_interrupt_disable(const struct metal_interrupt *controller, int id);
+int __metal_driver_sifive_local_external_command_request(const struct metal_interrupt *clint,
                                               	       int command, void *data);
 
 __METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_local_external_interrupts0) = {
@@ -29,10 +29,10 @@ __METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_local_external_interrupts0) 
 };
 
 struct __metal_driver_sifive_local_external_interrupts0 {
-    struct metal_interrupt irc;
+    const struct metal_interrupt irc;
     const struct __metal_driver_vtable_sifive_local_external_interrupts0 *vtable;
     int init_done;
-    struct metal_interrupt *interrupt_parent;
+    const struct metal_interrupt *interrupt_parent;
     const int num_interrupts;
     const int interrupt_lines[];
 };

--- a/metal/drivers/sifive,local-external-interrupts0.h
+++ b/metal/drivers/sifive,local-external-interrupts0.h
@@ -28,10 +28,14 @@ __METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_local_external_interrupts0) 
     .local0_vtable.command_request    = __metal_driver_sifive_local_external_command_request,
 };
 
+struct __metal_driver_sifive_local_external_interrupts0_data {
+    int init_done;
+};
+
 struct __metal_driver_sifive_local_external_interrupts0 {
     const struct metal_interrupt irc;
     const struct __metal_driver_vtable_sifive_local_external_interrupts0 *vtable;
-    int init_done;
+    struct __metal_driver_sifive_local_external_interrupts0_data *data;
     const struct metal_interrupt *interrupt_parent;
     const int num_interrupts;
     const int interrupt_lines[];

--- a/metal/drivers/sifive,spi0.h
+++ b/metal/drivers/sifive,spi0.h
@@ -35,7 +35,7 @@ struct __metal_driver_sifive_spi0 {
     const unsigned long control_base;
     const unsigned long control_size;
     unsigned long baud_rate;
-    struct __metal_driver_sifive_gpio0 *pinmux;
+    const struct __metal_driver_sifive_gpio0 *pinmux;
     const unsigned long pinmux_output_selector;
     const unsigned long pinmux_source_selector;
 };

--- a/metal/drivers/sifive,spi0.h
+++ b/metal/drivers/sifive,spi0.h
@@ -31,7 +31,7 @@ __METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_spi0) = {
 struct __metal_driver_sifive_spi0 {
     struct metal_spi spi;
     const struct __metal_driver_vtable_sifive_spi0 *vtable;
-    struct metal_clock *clock;
+    const struct metal_clock *clock;
     const unsigned long control_base;
     const unsigned long control_size;
     unsigned long baud_rate;

--- a/metal/drivers/sifive,spi0.h
+++ b/metal/drivers/sifive,spi0.h
@@ -16,10 +16,10 @@ struct __metal_driver_vtable_sifive_spi0 {
 
 struct __metal_driver_sifive_spi0;
 
-void __metal_driver_sifive_spi0_init(struct metal_spi *spi, int baud_rate);
-int __metal_driver_sifive_spi0_transfer(struct metal_spi *spi, struct metal_spi_config *config, size_t len, char *tx_buf, char *rx_buf);
-int __metal_driver_sifive_spi0_get_baud_rate(struct metal_spi *spi);
-int __metal_driver_sifive_spi0_set_baud_rate(struct metal_spi *spi, int baud_rate);
+void __metal_driver_sifive_spi0_init(const struct metal_spi *spi, int baud_rate);
+int __metal_driver_sifive_spi0_transfer(const struct metal_spi *spi, const struct metal_spi_config *config, size_t len, char *tx_buf, char *rx_buf);
+int __metal_driver_sifive_spi0_get_baud_rate(const struct metal_spi *spi);
+int __metal_driver_sifive_spi0_set_baud_rate(const struct metal_spi *spi, int baud_rate);
 
 __METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_spi0) = {
     .spi.init          = __metal_driver_sifive_spi0_init,
@@ -28,16 +28,20 @@ __METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_spi0) = {
     .spi.set_baud_rate = __metal_driver_sifive_spi0_set_baud_rate,
 };
 
+struct __metal_driver_sifive_spi0_data {
+    unsigned long baud_rate;
+};
+
 struct __metal_driver_sifive_spi0 {
-    struct metal_spi spi;
+    const struct metal_spi spi;
     const struct __metal_driver_vtable_sifive_spi0 *vtable;
     const struct metal_clock *clock;
     const unsigned long control_base;
     const unsigned long control_size;
-    unsigned long baud_rate;
     const struct __metal_driver_sifive_gpio0 *pinmux;
     const unsigned long pinmux_output_selector;
     const unsigned long pinmux_source_selector;
+    struct __metal_driver_sifive_spi0_data *data;
 };
 
 #endif

--- a/metal/drivers/sifive,test0.h
+++ b/metal/drivers/sifive,test0.h
@@ -20,7 +20,7 @@ __METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_test0) = {
 };
 
 struct __metal_driver_sifive_test0 {
-    struct __metal_shutdown shutdown;
+    const struct __metal_shutdown shutdown;
     const struct __metal_driver_vtable_sifive_test0 *vtable;
     const unsigned long base;
     const unsigned long size;

--- a/metal/drivers/sifive,uart0.h
+++ b/metal/drivers/sifive,uart0.h
@@ -17,13 +17,13 @@ struct __metal_driver_vtable_sifive_uart0 {
 
 struct __metal_driver_sifive_uart0;
 
-void __metal_driver_sifive_uart0_init(struct metal_uart *uart, int baud_rate);
-int __metal_driver_sifive_uart0_putc(struct metal_uart *uart, unsigned char c);
-int __metal_driver_sifive_uart0_getc(struct metal_uart *uart, unsigned char *c);
-int __metal_driver_sifive_uart0_get_baud_rate(struct metal_uart *guart);
-int __metal_driver_sifive_uart0_set_baud_rate(struct metal_uart *guart, int baud_rate);
-struct metal_interrupt* __metal_driver_sifive_uart0_interrupt_controller(struct metal_uart *uart);
-int __metal_driver_sifive_uart0_get_interrupt_id(struct metal_uart *uart);
+void __metal_driver_sifive_uart0_init(const struct metal_uart *uart, int baud_rate);
+int __metal_driver_sifive_uart0_putc(const struct metal_uart *uart, unsigned char c);
+int __metal_driver_sifive_uart0_getc(const struct metal_uart *uart, unsigned char *c);
+int __metal_driver_sifive_uart0_get_baud_rate(const struct metal_uart *guart);
+int __metal_driver_sifive_uart0_set_baud_rate(const struct metal_uart *guart, int baud_rate);
+struct metal_interrupt* __metal_driver_sifive_uart0_interrupt_controller(const struct metal_uart *uart);
+int __metal_driver_sifive_uart0_get_interrupt_id(const struct metal_uart *uart);
 
 __METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_uart0) = {
     .uart.init          = __metal_driver_sifive_uart0_init,
@@ -35,19 +35,23 @@ __METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_uart0) = {
     .uart.get_interrupt_id     = __metal_driver_sifive_uart0_get_interrupt_id,
 };
 
+struct __metal_driver_sifive_uart0_data {
+    unsigned long baud_rate;
+};
+
 struct __metal_driver_sifive_uart0 {
-    struct metal_uart uart;
+    const struct metal_uart uart;
     const struct __metal_driver_vtable_sifive_uart0 *vtable;
     const struct metal_clock *clock;
     const unsigned long control_base;
     const unsigned long control_size;
-    unsigned long baud_rate;
     struct __metal_driver_sifive_gpio0 *pinmux;
     const unsigned long pinmux_output_selector;
     const unsigned long pinmux_source_selector;
     const struct metal_interrupt *interrupt_parent;
     const int num_interrupts;
     const int interrupt_line;
+    struct __metal_driver_sifive_uart0_data *data;
 };
 
 

--- a/metal/drivers/sifive,uart0.h
+++ b/metal/drivers/sifive,uart0.h
@@ -38,7 +38,7 @@ __METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_uart0) = {
 struct __metal_driver_sifive_uart0 {
     struct metal_uart uart;
     const struct __metal_driver_vtable_sifive_uart0 *vtable;
-    struct metal_clock *clock;
+    const struct metal_clock *clock;
     const unsigned long control_base;
     const unsigned long control_size;
     unsigned long baud_rate;

--- a/metal/drivers/sifive,uart0.h
+++ b/metal/drivers/sifive,uart0.h
@@ -45,7 +45,7 @@ struct __metal_driver_sifive_uart0 {
     struct __metal_driver_sifive_gpio0 *pinmux;
     const unsigned long pinmux_output_selector;
     const unsigned long pinmux_source_selector;
-    struct metal_interrupt *interrupt_parent;
+    const struct metal_interrupt *interrupt_parent;
     const int num_interrupts;
     const int interrupt_line;
 };

--- a/metal/drivers/sifive,uart0.h
+++ b/metal/drivers/sifive,uart0.h
@@ -45,7 +45,7 @@ struct __metal_driver_sifive_uart0 {
     const struct metal_clock *clock;
     const unsigned long control_base;
     const unsigned long control_size;
-    struct __metal_driver_sifive_gpio0 *pinmux;
+    const struct __metal_driver_sifive_gpio0 *pinmux;
     const unsigned long pinmux_output_selector;
     const unsigned long pinmux_source_selector;
     const struct metal_interrupt *interrupt_parent;

--- a/metal/interrupt.h
+++ b/metal/interrupt.h
@@ -28,15 +28,15 @@ typedef void (*metal_interrupt_handler_t) (int, void *);
 struct metal_interrupt;
 
 struct metal_interrupt_vtable {
-    void (*interrupt_init)(struct metal_interrupt *controller);
-    int (*interrupt_register)(struct metal_interrupt *controller, int id,
+    void (*interrupt_init)(const struct metal_interrupt *controller);
+    int (*interrupt_register)(const struct metal_interrupt *controller, int id,
 			      metal_interrupt_handler_t isr, void *priv_data);
-    int (*interrupt_enable)(struct metal_interrupt *controller, int id);
-    int (*interrupt_disable)(struct metal_interrupt *controller, int id);
-    int (*interrupt_vector_enable)(struct metal_interrupt *controller,
+    int (*interrupt_enable)(const struct metal_interrupt *controller, int id);
+    int (*interrupt_disable)(const struct metal_interrupt *controller, int id);
+    int (*interrupt_vector_enable)(const struct metal_interrupt *controller,
                                    int id, metal_vector_mode mode);
-    int (*interrupt_vector_disable)(struct metal_interrupt *controller, int id);
-    int (*command_request)(struct metal_interrupt *controller, int cmd, void *data);
+    int (*interrupt_vector_disable)(const struct metal_interrupt *controller, int id);
+    int (*command_request)(const struct metal_interrupt *controller, int cmd, void *data);
 };
 
 /*!
@@ -55,7 +55,7 @@ struct metal_interrupt {
  *
  * @param controller The handle for the interrupt controller
  */
-inline void metal_interrupt_init(struct metal_interrupt *controller)
+inline void metal_interrupt_init(const struct metal_interrupt *controller)
 {
     return controller->vtable->interrupt_init(controller);
 }
@@ -69,7 +69,7 @@ inline void metal_interrupt_init(struct metal_interrupt *controller)
  * @param priv_data Private data for the interrupt handler
  * @return 0 upon success
  */
-inline int metal_interrupt_register_handler(struct metal_interrupt *controller,
+inline int metal_interrupt_register_handler(const struct metal_interrupt *controller,
                                           int id,
                                           metal_interrupt_handler_t handler,
                                           void *priv_data)
@@ -83,7 +83,7 @@ inline int metal_interrupt_register_handler(struct metal_interrupt *controller,
  * @param id The interrupt ID to enable
  * @return 0 upon success
  */
-inline int metal_interrupt_enable(struct metal_interrupt *controller, int id)
+inline int metal_interrupt_enable(const struct metal_interrupt *controller, int id)
 {
     return controller->vtable->interrupt_enable(controller, id);
 }
@@ -94,7 +94,7 @@ inline int metal_interrupt_enable(struct metal_interrupt *controller, int id)
  * @param id The interrupt ID to disable
  * @return 0 upon success
  */
-inline int metal_interrupt_disable(struct metal_interrupt *controller, int id)
+inline int metal_interrupt_disable(const struct metal_interrupt *controller, int id)
 {
     return controller->vtable->interrupt_disable(controller, id);
 }
@@ -106,7 +106,7 @@ inline int metal_interrupt_disable(struct metal_interrupt *controller, int id)
  * @param mode The interrupt mode type to enable
  * @return 0 upon success
  */
-inline int metal_interrupt_vector_enable(struct metal_interrupt *controller,
+inline int metal_interrupt_vector_enable(const struct metal_interrupt *controller,
                                        int id, metal_vector_mode mode)
 {
     return controller->vtable->interrupt_vector_enable(controller, id, mode);
@@ -118,13 +118,13 @@ inline int metal_interrupt_vector_enable(struct metal_interrupt *controller,
  * @param id The interrupt ID to disable
  * @return 0 upon success
  */
-inline int metal_interrupt_vector_disable(struct metal_interrupt *controller, int id)
+inline int metal_interrupt_vector_disable(const struct metal_interrupt *controller, int id)
 {
     return controller->vtable->interrupt_vector_disable(controller, id);
 }
 
 /* Utilities function to controll, manages devices via a given interrupt controller */
-inline int _metal_interrupt_command_request(struct metal_interrupt *controller,
+inline int _metal_interrupt_command_request(const struct metal_interrupt *controller,
 					 int cmd, void *data)
 {
     return controller->vtable->command_request(controller, cmd, data);

--- a/metal/led.h
+++ b/metal/led.h
@@ -12,11 +12,11 @@
 struct metal_led;
 
 struct metal_led_vtable {
-    int (*led_exist)(struct metal_led *led, char *label);
-    void (*led_enable)(struct metal_led *led);
-    void (*led_on)(struct metal_led *led);
-    void (*led_off)(struct metal_led *led);
-    void (*led_toggle)(struct metal_led *led);
+    int (*led_exist)(const struct metal_led *led, char *label);
+    void (*led_enable)(const struct metal_led *led);
+    void (*led_on)(const struct metal_led *led);
+    void (*led_off)(const struct metal_led *led);
+    void (*led_toggle)(const struct metal_led *led);
 };
 
 /*!
@@ -31,7 +31,7 @@ struct metal_led {
  * @param label The DeviceTree label for the desired LED
  * @return A handle to the LED, or NULL if none is found for the requested label
  */
-struct metal_led* metal_led_get(char *label);
+const struct metal_led* metal_led_get(char *label);
 
 /*!
  * @brief Get a handle for a channel of an RGB LED
@@ -39,30 +39,30 @@ struct metal_led* metal_led_get(char *label);
  * @param color The color for the LED in the DeviceTree
  * @return A handle to the LED, or NULL if none is found for the requested label and color
  */
-struct metal_led* metal_led_get_rgb(char *label, char *color);
+const struct metal_led* metal_led_get_rgb(char *label, char *color);
 
 /*!
  * @brief Enable an LED
  * @param led The handle for the LED
  */
-inline void metal_led_enable(struct metal_led *led) { led->vtable->led_enable(led); }
+inline void metal_led_enable(const struct metal_led *led) { led->vtable->led_enable(led); }
 
 /*!
  * @brief Turn an LED on
  * @param led The handle for the LED
  */
-inline void metal_led_on(struct metal_led *led) { led->vtable->led_on(led); }
+inline void metal_led_on(const struct metal_led *led) { led->vtable->led_on(led); }
 
 /*!
  * @brief Turn an LED off
  * @param led The handle for the LED
  */
-inline void metal_led_off(struct metal_led *led) { led->vtable->led_off(led); }
+inline void metal_led_off(const struct metal_led *led) { led->vtable->led_off(led); }
 
 /*!
  * @brief Toggle the on/off state of an LED
  * @param led The handle for the LED
  */
-inline void metal_led_toggle(struct metal_led *led) { led->vtable->led_toggle(led); }
+inline void metal_led_toggle(const struct metal_led *led) { led->vtable->led_toggle(led); }
 
 #endif

--- a/metal/pmp.h
+++ b/metal/pmp.h
@@ -73,7 +73,7 @@ struct metal_pmp {
 /*!
  * @brief Get the PMP device handle
  */
-struct metal_pmp *metal_pmp_get_device(void);
+const struct metal_pmp *metal_pmp_get_device(void);
 
 /*!
  * @brief Initialize the PMP
@@ -87,7 +87,7 @@ struct metal_pmp *metal_pmp_get_device(void);
  * If any regions are fused to preset values by the implementation or locked,
  * the PMP region will silently remain uninitialized.
  */
-void metal_pmp_init(struct metal_pmp *pmp);
+void metal_pmp_init(const struct metal_pmp *pmp);
 
 /*!
  * @brief Configure a PMP region
@@ -97,7 +97,7 @@ void metal_pmp_init(struct metal_pmp *pmp);
  * @param address The desired address of the PMP region
  * @return 0 upon success
  */
-int metal_pmp_set_region(struct metal_pmp *pmp, unsigned int region, struct metal_pmp_config config, size_t address);
+int metal_pmp_set_region(const struct metal_pmp *pmp, unsigned int region, const struct metal_pmp_config config, size_t address);
 
 /*! 
  * @brief Get the configuration for a PMP region
@@ -107,7 +107,7 @@ int metal_pmp_set_region(struct metal_pmp *pmp, unsigned int region, struct meta
  * @param address Variable to store the PMP region address
  * @return 0 if the region is read successfully
  */
-int metal_pmp_get_region(struct metal_pmp *pmp, unsigned int region, struct metal_pmp_config *config, size_t *address);
+int metal_pmp_get_region(const struct metal_pmp *pmp, unsigned int region, struct metal_pmp_config *config, size_t *address);
 
 /*!
  * @brief Lock a PMP region
@@ -115,7 +115,7 @@ int metal_pmp_get_region(struct metal_pmp *pmp, unsigned int region, struct meta
  * @param region The PMP region to lock
  * @return 0 if the region is successfully locked
  */
-int metal_pmp_lock(struct metal_pmp *pmp, unsigned int region);
+int metal_pmp_lock(const struct metal_pmp *pmp, unsigned int region);
 
 /*!
  * @brief Set the address for a PMP region
@@ -124,7 +124,7 @@ int metal_pmp_lock(struct metal_pmp *pmp, unsigned int region);
  * @param address The desired address of the PMP region
  * @return 0 if the address is successfully set
  */
-int metal_pmp_set_address(struct metal_pmp *pmp, unsigned int region, size_t address);
+int metal_pmp_set_address(const struct metal_pmp *pmp, unsigned int region, size_t address);
 
 /*!
  * @brief Get the address of a PMP region
@@ -132,7 +132,7 @@ int metal_pmp_set_address(struct metal_pmp *pmp, unsigned int region, size_t add
  * @param region The PMP region to read
  * @return The address of the PMP region, or 0 if the region could not be read
  */
-size_t metal_pmp_get_address(struct metal_pmp *pmp, unsigned int region);
+size_t metal_pmp_get_address(const struct metal_pmp *pmp, unsigned int region);
 
 /*!
  * @brief Set the addressing mode of a PMP region
@@ -141,7 +141,7 @@ size_t metal_pmp_get_address(struct metal_pmp *pmp, unsigned int region);
  * @param mode The PMP addressing mode to set
  * @return 0 if the addressing mode is successfully set
  */
-int metal_pmp_set_address_mode(struct metal_pmp *pmp, unsigned int region, enum metal_pmp_address_mode mode);
+int metal_pmp_set_address_mode(const struct metal_pmp *pmp, unsigned int region, enum metal_pmp_address_mode mode);
 
 /*!
  * @brief Get the addressing mode of a PMP region
@@ -149,7 +149,7 @@ int metal_pmp_set_address_mode(struct metal_pmp *pmp, unsigned int region, enum 
  * @param region The PMP region to read
  * @return The address mode of the PMP region
  */
-enum metal_pmp_address_mode metal_pmp_get_address_mode(struct metal_pmp *pmp, unsigned int region);
+enum metal_pmp_address_mode metal_pmp_get_address_mode(const struct metal_pmp *pmp, unsigned int region);
 
 /*!
  * @brief Set the executable bit for a PMP region
@@ -158,7 +158,7 @@ enum metal_pmp_address_mode metal_pmp_get_address_mode(struct metal_pmp *pmp, un
  * @param X The desired value of the executable bit
  * @return 0 if the executable bit is successfully set
  */
-int metal_pmp_set_executable(struct metal_pmp *pmp, unsigned int region, int X);
+int metal_pmp_set_executable(const struct metal_pmp *pmp, unsigned int region, int X);
 
 /*!
  * @brief Get the executable bit for a PMP region
@@ -166,7 +166,7 @@ int metal_pmp_set_executable(struct metal_pmp *pmp, unsigned int region, int X);
  * @param region The PMP region to read
  * @return the value of the executable bit
  */
-int metal_pmp_get_executable(struct metal_pmp *pmp, unsigned int region);
+int metal_pmp_get_executable(const struct metal_pmp *pmp, unsigned int region);
 
 /*!
  * @brief Set the writable bit for a PMP region
@@ -175,7 +175,7 @@ int metal_pmp_get_executable(struct metal_pmp *pmp, unsigned int region);
  * @param W The desired value of the writable bit
  * @return 0 if the writable bit is successfully set
  */
-int metal_pmp_set_writeable(struct metal_pmp *pmp, unsigned int region, int W);
+int metal_pmp_set_writeable(const struct metal_pmp *pmp, unsigned int region, int W);
 
 /*!
  * @brief Get the writable bit for a PMP region
@@ -183,7 +183,7 @@ int metal_pmp_set_writeable(struct metal_pmp *pmp, unsigned int region, int W);
  * @param region The PMP region to read
  * @return the value of the writable bit
  */
-int metal_pmp_get_writeable(struct metal_pmp *pmp, unsigned int region);
+int metal_pmp_get_writeable(const struct metal_pmp *pmp, unsigned int region);
 
 /*!
  * @brief Set the readable bit for a PMP region
@@ -192,7 +192,7 @@ int metal_pmp_get_writeable(struct metal_pmp *pmp, unsigned int region);
  * @param R The desired value of the readable bit
  * @return 0 if the readable bit is successfully set
  */
-int metal_pmp_set_readable(struct metal_pmp *pmp, unsigned int region, int R);
+int metal_pmp_set_readable(const struct metal_pmp *pmp, unsigned int region, int R);
 
 /*!
  * @brief Set the readable bit for a PMP region
@@ -200,6 +200,6 @@ int metal_pmp_set_readable(struct metal_pmp *pmp, unsigned int region, int R);
  * @param region The PMP region to read
  * @return the value of the readable bit
  */
-int metal_pmp_get_readable(struct metal_pmp *pmp, unsigned int region);
+int metal_pmp_get_readable(const struct metal_pmp *pmp, unsigned int region);
 
 #endif

--- a/metal/spi.h
+++ b/metal/spi.h
@@ -28,10 +28,10 @@ struct metal_spi_config {
 };
 
 struct metal_spi_vtable {
-    void (*init)(struct metal_spi *spi, int baud_rate);
-    int (*transfer)(struct metal_spi *spi, struct metal_spi_config *config, size_t len, char *tx_buf, char *rx_buf);
-    int (*get_baud_rate)(struct metal_spi *spi);
-    int (*set_baud_rate)(struct metal_spi *spi, int baud_rate);
+    void (*init)(const struct metal_spi *spi, int baud_rate);
+    int (*transfer)(const struct metal_spi *spi, const struct metal_spi_config *config, size_t len, char *tx_buf, char *rx_buf);
+    int (*get_baud_rate)(const struct metal_spi *spi);
+    int (*set_baud_rate)(const struct metal_spi *spi, int baud_rate);
 };
 
 /*! @brief A handle for a SPI device */
@@ -42,13 +42,13 @@ struct metal_spi {
 /*! @brief Get a handle for a SPI device
  * @param device_num The index of the desired SPI device
  * @return A handle to the SPI device, or NULL if the device does not exist*/
-struct metal_spi *metal_spi_get_device(int device_num);
+const struct metal_spi *metal_spi_get_device(int device_num);
 
 /*! @brief Initialize a SPI device with a certain baud rate
  * @param spi The handle for the SPI device to initialize
  * @param baud_rate The baud rate to set the SPI device to
  */
-inline void metal_spi_init(struct metal_spi *spi, int baud_rate) { spi->vtable->init(spi, baud_rate); }
+inline void metal_spi_init(const struct metal_spi *spi, int baud_rate) { spi->vtable->init(spi, baud_rate); }
 
 /*! @brief Perform a SPI transfer
  * @param spi The handle for the SPI device to perform the transfer
@@ -58,7 +58,7 @@ inline void metal_spi_init(struct metal_spi *spi, int baud_rate) { spi->vtable->
  * @param rx_buf The buffer to receive data into. Must be len bytes long. If NULL, the SPI will ignore received bytes.
  * @return 0 if the transfer succeeds
  */
-inline int metal_spi_transfer(struct metal_spi *spi, struct metal_spi_config *config, size_t len, char *tx_buf, char *rx_buf) {
+inline int metal_spi_transfer(const struct metal_spi *spi, const struct metal_spi_config *config, size_t len, char *tx_buf, char *rx_buf) {
     return spi->vtable->transfer(spi, config, len, tx_buf, rx_buf);
 }
 
@@ -66,13 +66,13 @@ inline int metal_spi_transfer(struct metal_spi *spi, struct metal_spi_config *co
  * @param spi The handle for the SPI device
  * @return The baud rate in Hz
  */
-inline int metal_spi_get_baud_rate(struct metal_spi *spi) { return spi->vtable->get_baud_rate(spi); }
+inline int metal_spi_get_baud_rate(const struct metal_spi *spi) { return spi->vtable->get_baud_rate(spi); }
 
 /*! @brief Set the current baud rate of the SPI device
  * @param spi The handle for the SPI device
  * @param baud_rate The desired baud rate of the SPI device
  * @return 0 if the baud rate is successfully changed
  */
-inline int metal_spi_set_baud_rate(struct metal_spi *spi, int baud_rate) { return spi->vtable->set_baud_rate(spi, baud_rate); }
+inline int metal_spi_set_baud_rate(const struct metal_spi *spi, int baud_rate) { return spi->vtable->set_baud_rate(spi, baud_rate); }
 
 #endif

--- a/metal/switch.h
+++ b/metal/switch.h
@@ -14,9 +14,9 @@
 struct metal_switch;
 
 struct metal_switch_vtable {
-    int (*switch_exist)(struct metal_switch *sw, char *label);
-    struct metal_interrupt* (*interrupt_controller)(struct metal_switch *sw);
-    int (*get_interrupt_id)(struct metal_switch *sw);
+    int (*switch_exist)(const struct metal_switch *sw, char *label);
+    const struct metal_interrupt* (*interrupt_controller)(const struct metal_switch *sw);
+    int (*get_interrupt_id)(const struct metal_switch *sw);
 };
 
 /*!
@@ -31,21 +31,21 @@ struct metal_switch {
  * @param label The DeviceTree label for the desired switch
  * @return A handle to the switch, or NULL if none is found for the requested label
  */
-struct metal_switch* metal_switch_get(char *label);
+const struct metal_switch* metal_switch_get(char *label);
 
 /*!
  * @brief Get the interrupt controller for a switch
  * @param sw The handle for the switch
  * @return The interrupt controller handle
  */
-inline struct metal_interrupt*
-    metal_switch_interrupt_controller(struct metal_switch *sw) { return sw->vtable->interrupt_controller(sw); }
+inline const struct metal_interrupt*
+    metal_switch_interrupt_controller(const struct metal_switch *sw) { return sw->vtable->interrupt_controller(sw); }
 
 /*!
  * @brief Get the interrupt id for a switch
  * @param sw The handle for the switch
  * @return The interrupt ID for the switch
  */
-inline int metal_switch_get_interrupt_id(struct metal_switch *sw) { return sw->vtable->get_interrupt_id(sw); }
+inline int metal_switch_get_interrupt_id(const struct metal_switch *sw) { return sw->vtable->get_interrupt_id(sw); }
 
 #endif

--- a/metal/uart.h
+++ b/metal/uart.h
@@ -14,13 +14,13 @@
 struct metal_uart;
 
 struct metal_uart_vtable {
-    void (*init)(struct metal_uart *uart, int baud_rate);
-    int (*putc)(struct metal_uart *uart, unsigned char c);
-    int (*getc)(struct metal_uart *uart, unsigned char *c);
-    int (*get_baud_rate)(struct metal_uart *uart);
-    int (*set_baud_rate)(struct metal_uart *uart, int baud_rate);
-    struct metal_interrupt* (*controller_interrupt)(struct metal_uart *uart);
-    int (*get_interrupt_id)(struct metal_uart *uart);
+    void (*init)(const struct metal_uart *uart, int baud_rate);
+    int (*putc)(const struct metal_uart *uart, unsigned char c);
+    int (*getc)(const struct metal_uart *uart, unsigned char *c);
+    int (*get_baud_rate)(const struct metal_uart *uart);
+    int (*set_baud_rate)(const struct metal_uart *uart, int baud_rate);
+    struct metal_interrupt* (*controller_interrupt)(const struct metal_uart *uart);
+    int (*get_interrupt_id)(const struct metal_uart *uart);
 };
 
 /*!
@@ -39,7 +39,7 @@ struct metal_uart {
  * @param uart The UART device handle
  * @param baud_rate the baud rate to set the UART to
  */
-inline void metal_uart_init(struct metal_uart *uart, int baud_rate) { return uart->vtable->init(uart, baud_rate); }
+inline void metal_uart_init(const struct metal_uart *uart, int baud_rate) { return uart->vtable->init(uart, baud_rate); }
 
 /*!
  * @brief Output a character over the UART
@@ -47,7 +47,7 @@ inline void metal_uart_init(struct metal_uart *uart, int baud_rate) { return uar
  * @param c The character to send over the UART
  * @return 0 upon success
  */
-inline int metal_uart_putc(struct metal_uart *uart, unsigned char c) { return uart->vtable->putc(uart, c); }
+inline int metal_uart_putc(const struct metal_uart *uart, unsigned char c) { return uart->vtable->putc(uart, c); }
 
 /*!
  * @brief Read a character sent over the UART
@@ -55,14 +55,14 @@ inline int metal_uart_putc(struct metal_uart *uart, unsigned char c) { return ua
  * @param c The varible to hold the read character
  * @return 0 upon success
  */
-inline int metal_uart_getc(struct metal_uart *uart, unsigned char *c) { return uart->vtable->getc(uart, c); }
+inline int metal_uart_getc(const struct metal_uart *uart, unsigned char *c) { return uart->vtable->getc(uart, c); }
 
 /*!
  * @brief Get the baud rate of the UART peripheral
  * @param uart The UART device handle
  * @return The current baud rate of the UART
  */
-inline int metal_uart_get_baud_rate(struct metal_uart *uart) { return uart->vtable->get_baud_rate(uart); }
+inline int metal_uart_get_baud_rate(const struct metal_uart *uart) { return uart->vtable->get_baud_rate(uart); }
 
 /*!
  * @brief Set the baud rate of the UART peripheral
@@ -70,7 +70,7 @@ inline int metal_uart_get_baud_rate(struct metal_uart *uart) { return uart->vtab
  * @param baud_rate The baud rate to configure
  * @return the new baud rate of the UART
  */
-inline int metal_uart_set_baud_rate(struct metal_uart *uart, int baud_rate) { return uart->vtable->set_baud_rate(uart, baud_rate); }
+inline int metal_uart_set_baud_rate(const struct metal_uart *uart, int baud_rate) { return uart->vtable->set_baud_rate(uart, baud_rate); }
 
 /*!
  * @brief Get the interrupt controller of the UART peripheral
@@ -82,13 +82,13 @@ inline int metal_uart_set_baud_rate(struct metal_uart *uart, int baud_rate) { re
  * @param uart The UART device handle
  * @return The handle for the UART interrupt controller
  */
-inline struct metal_interrupt* metal_uart_interrupt_controller(struct metal_uart *uart) { return uart->vtable->controller_interrupt(uart); }
+inline struct metal_interrupt* metal_uart_interrupt_controller(const struct metal_uart *uart) { return uart->vtable->controller_interrupt(uart); }
 
 /*!
  * @brief Get the interrupt ID of the UART controller
  * @param uart The UART device handle
  * @return The UART interrupt id
  */
-inline int metal_uart_get_interrupt_id(struct metal_uart *uart) { return uart->vtable->get_interrupt_id(uart); }
+inline int metal_uart_get_interrupt_id(const struct metal_uart *uart) { return uart->vtable->get_interrupt_id(uart); }
 
 #endif

--- a/src/button.c
+++ b/src/button.c
@@ -4,17 +4,17 @@
 #include <metal/button.h>
 #include <metal/machine.h>
 
-struct metal_button* metal_button_get (char *label)
+const struct metal_button* metal_button_get (char *label)
 {
     int i;
-    struct metal_button *button;
+    const struct metal_button *button;
 
     if ((__METAL_DT_MAX_BUTTONS == 0) || (label == NULL)) {
         return NULL;
     }
 
     for (i = 0; i < __METAL_DT_MAX_BUTTONS; i++) {
-        button = (struct metal_button*)__metal_button_table[i];
+        button = (const struct metal_button*)__metal_button_table[i];
         if (button->vtable->button_exist(button, label)) {
             return button;
         }
@@ -22,6 +22,6 @@ struct metal_button* metal_button_get (char *label)
     return NULL;
 }
 
-extern inline struct metal_interrupt*
-    metal_button_interrupt_controller(struct metal_button *button);
-extern inline int metal_button_get_interrupt_id(struct metal_button *button);
+extern inline const struct metal_interrupt*
+    metal_button_interrupt_controller(const struct metal_button *button);
+extern inline int metal_button_get_interrupt_id(const struct metal_button *button);

--- a/src/clock.c
+++ b/src/clock.c
@@ -4,6 +4,6 @@
 #include <metal/clock.h>
 
 extern inline long metal_clock_get_rate_hz(const struct metal_clock *clk);
-extern inline long metal_clock_set_rate_hz(struct metal_clock *clk, long hz);
-extern inline void metal_clock_register_post_rate_change_callback(struct metal_clock *clk, metal_clock_post_rate_change_callback cb, void *priv);
-extern inline void metal_clock_register_pre_rate_change_callback(struct metal_clock *clk, metal_clock_pre_rate_change_callback cb, void *priv);
+extern inline long metal_clock_set_rate_hz(const struct metal_clock *clk, long hz);
+extern inline void metal_clock_register_post_rate_change_callback(const struct metal_clock *clk, metal_clock_post_rate_change_callback cb, void *priv);
+extern inline void metal_clock_register_pre_rate_change_callback(const struct metal_clock *clk, metal_clock_pre_rate_change_callback cb, void *priv);

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -4,7 +4,7 @@
 #include <metal/cpu.h>
 #include <metal/machine.h>
 
-struct metal_cpu* metal_cpu_get(int hartid)
+const struct metal_cpu* metal_cpu_get(int hartid)
 {
     if (hartid < __METAL_DT_MAX_HARTS) {
         return &(__metal_cpu_table[hartid]->cpu);
@@ -12,34 +12,34 @@ struct metal_cpu* metal_cpu_get(int hartid)
     return NULL;
 }
 
-extern inline unsigned long long metal_cpu_get_timer(struct metal_cpu *cpu);
+extern inline unsigned long long metal_cpu_get_timer(const struct metal_cpu *cpu);
 
-extern inline unsigned long long metal_cpu_get_timebase(struct metal_cpu *cpu);
+extern inline unsigned long long metal_cpu_get_timebase(const struct metal_cpu *cpu);
 
-extern inline unsigned long long metal_cpu_get_mtime(struct metal_cpu *cpu);
+extern inline unsigned long long metal_cpu_get_mtime(const struct metal_cpu *cpu);
 
-extern inline int metal_cpu_set_mtimecmp(struct metal_cpu *cpu, unsigned long long time);
+extern inline int metal_cpu_set_mtimecmp(const struct metal_cpu *cpu, unsigned long long time);
 
-extern inline struct metal_interrupt* metal_cpu_timer_interrupt_controller(struct metal_cpu *cpu);
+extern inline struct metal_interrupt* metal_cpu_timer_interrupt_controller(const struct metal_cpu *cpu);
 
-extern inline int metal_cpu_timer_get_interrupt_id(struct metal_cpu *cpu);
+extern inline int metal_cpu_timer_get_interrupt_id(const struct metal_cpu *cpu);
 
-extern inline struct metal_interrupt* metal_cpu_software_interrupt_controller(struct metal_cpu *cpu);
+extern inline struct metal_interrupt* metal_cpu_software_interrupt_controller(const struct metal_cpu *cpu);
 
-extern inline int metal_cpu_software_get_interrupt_id(struct metal_cpu *cpu);
+extern inline int metal_cpu_software_get_interrupt_id(const struct metal_cpu *cpu);
 
-extern inline int metal_cpu_software_set_ipi(struct metal_cpu *cpu, int hartid);
+extern inline int metal_cpu_software_set_ipi(const struct metal_cpu *cpu, int hartid);
 
-extern inline int metal_cpu_software_clear_ipi(struct metal_cpu *cpu, int hartid);
+extern inline int metal_cpu_software_clear_ipi(const struct metal_cpu *cpu, int hartid);
 
-extern inline int metal_cpu_get_msip(struct metal_cpu *cpu, int hartid);
+extern inline int metal_cpu_get_msip(const struct metal_cpu *cpu, int hartid);
 
-extern inline struct metal_interrupt* metal_cpu_interrupt_controller(struct metal_cpu *cpu);
+extern inline struct metal_interrupt* metal_cpu_interrupt_controller(const struct metal_cpu *cpu);
 
-extern inline int metal_cpu_exception_register(struct metal_cpu *cpu, int ecode, metal_exception_handler_t handler);
+extern inline int metal_cpu_exception_register(const struct metal_cpu *cpu, int ecode, metal_exception_handler_t handler);
 
-extern inline int metal_cpu_get_instruction_length(struct metal_cpu *cpu, uintptr_t epc);
+extern inline int metal_cpu_get_instruction_length(const struct metal_cpu *cpu, uintptr_t epc);
 
-extern inline uintptr_t metal_cpu_get_exception_pc(struct metal_cpu *cpu);
+extern inline uintptr_t metal_cpu_get_exception_pc(const struct metal_cpu *cpu);
 
-extern inline int metal_cpu_set_exception_pc(struct metal_cpu *cpu, uintptr_t epc);
+extern inline int metal_cpu_set_exception_pc(const struct metal_cpu *cpu, uintptr_t epc);

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -20,11 +20,11 @@ extern inline unsigned long long metal_cpu_get_mtime(const struct metal_cpu *cpu
 
 extern inline int metal_cpu_set_mtimecmp(const struct metal_cpu *cpu, unsigned long long time);
 
-extern inline struct metal_interrupt* metal_cpu_timer_interrupt_controller(const struct metal_cpu *cpu);
+extern inline const struct metal_interrupt* metal_cpu_timer_interrupt_controller(const struct metal_cpu *cpu);
 
 extern inline int metal_cpu_timer_get_interrupt_id(const struct metal_cpu *cpu);
 
-extern inline struct metal_interrupt* metal_cpu_software_interrupt_controller(const struct metal_cpu *cpu);
+extern inline const struct metal_interrupt* metal_cpu_software_interrupt_controller(const struct metal_cpu *cpu);
 
 extern inline int metal_cpu_software_get_interrupt_id(const struct metal_cpu *cpu);
 
@@ -34,7 +34,7 @@ extern inline int metal_cpu_software_clear_ipi(const struct metal_cpu *cpu, int 
 
 extern inline int metal_cpu_get_msip(const struct metal_cpu *cpu, int hartid);
 
-extern inline struct metal_interrupt* metal_cpu_interrupt_controller(const struct metal_cpu *cpu);
+extern inline const struct metal_interrupt* metal_cpu_interrupt_controller(const struct metal_cpu *cpu);
 
 extern inline int metal_cpu_exception_register(const struct metal_cpu *cpu, int ecode, metal_exception_handler_t handler);
 

--- a/src/drivers/fixed-clock.c
+++ b/src/drivers/fixed-clock.c
@@ -10,7 +10,7 @@ long __metal_driver_fixed_clock_get_rate_hz(const struct metal_clock *gclk)
     return clk->rate;
 }
 
-long __metal_driver_fixed_clock_set_rate_hz(struct metal_clock *gclk, long target_hz)
+long __metal_driver_fixed_clock_set_rate_hz(const struct metal_clock *gclk, long target_hz)
 {
     return __metal_driver_fixed_clock_get_rate_hz(gclk);
 }

--- a/src/drivers/riscv,clint0.c
+++ b/src/drivers/riscv,clint0.c
@@ -36,7 +36,7 @@ void __metal_driver_riscv_clint0_init (const struct metal_interrupt *controller)
     struct __metal_driver_riscv_clint0 *clint =
                               (struct __metal_driver_riscv_clint0 *)(controller);
 
-    if ( !clint->init_done ) {
+    if ( !clint->data->init_done ) {
         const struct metal_interrupt *intc = clint->interrupt_parent;
 
 	/* Register its interrupts with with parent controller, aka sw and timerto its default isr */
@@ -45,7 +45,7 @@ void __metal_driver_riscv_clint0_init (const struct metal_interrupt *controller)
 					     clint->interrupt_lines[i],
 					     NULL, clint);
 	}
-	clint->init_done = 1;
+	clint->data->init_done = 1;
     }	
 }
 

--- a/src/drivers/riscv,clint0.c
+++ b/src/drivers/riscv,clint0.c
@@ -31,13 +31,13 @@ int __metal_clint0_mtime_set (struct __metal_driver_riscv_clint0 *clint, unsigne
     return 0;
 }
 
-void __metal_driver_riscv_clint0_init (struct metal_interrupt *controller)
+void __metal_driver_riscv_clint0_init (const struct metal_interrupt *controller)
 {
     struct __metal_driver_riscv_clint0 *clint =
                               (struct __metal_driver_riscv_clint0 *)(controller);
 
     if ( !clint->init_done ) {
-        struct metal_interrupt *intc = clint->interrupt_parent;
+        const struct metal_interrupt *intc = clint->interrupt_parent;
 
 	/* Register its interrupts with with parent controller, aka sw and timerto its default isr */
         for (int i = 0; i < clint->num_interrupts; i++) {
@@ -49,14 +49,14 @@ void __metal_driver_riscv_clint0_init (struct metal_interrupt *controller)
     }	
 }
 
-int __metal_driver_riscv_clint0_register (struct metal_interrupt *controller,
+int __metal_driver_riscv_clint0_register (const struct metal_interrupt *controller,
                                         int id, metal_interrupt_handler_t isr,
                                         void *priv)
 {
     int rc = -1;
     struct __metal_driver_riscv_clint0 *clint =
                               (struct __metal_driver_riscv_clint0 *)(controller);
-    struct metal_interrupt *intc = clint->interrupt_parent;
+    const struct metal_interrupt *intc = clint->interrupt_parent;
 
     /* Register its interrupts with parent controller */
     if (intc) {
@@ -65,14 +65,14 @@ int __metal_driver_riscv_clint0_register (struct metal_interrupt *controller,
     return rc;
 }
 
-int __metal_driver_riscv_clint0_enable (struct metal_interrupt *controller, int id)
+int __metal_driver_riscv_clint0_enable (const struct metal_interrupt *controller, int id)
 {
     int rc = -1;
     struct __metal_driver_riscv_clint0 *clint =
                               (struct __metal_driver_riscv_clint0 *)(controller);
 
     if ( id ) {
-        struct metal_interrupt *intc = clint->interrupt_parent;
+        const struct metal_interrupt *intc = clint->interrupt_parent;
         
         /* Enable its interrupts with parent controller */
         if (intc) {
@@ -81,14 +81,14 @@ int __metal_driver_riscv_clint0_enable (struct metal_interrupt *controller, int 
     }
 }
 
-int __metal_driver_riscv_clint0_disable (struct metal_interrupt *controller, int id)
+int __metal_driver_riscv_clint0_disable (const struct metal_interrupt *controller, int id)
 {
     int rc = -1;
     struct __metal_driver_riscv_clint0 *clint =
                               (struct __metal_driver_riscv_clint0 *)(controller);
 
     if ( id ) {
-        struct metal_interrupt *intc = clint->interrupt_parent;
+        const struct metal_interrupt *intc = clint->interrupt_parent;
         
         /* Disable its interrupts with parent controller */
         if (intc) {
@@ -97,7 +97,7 @@ int __metal_driver_riscv_clint0_disable (struct metal_interrupt *controller, int
     }
 }
 
-int __metal_driver_riscv_clint0_command_request (struct metal_interrupt *controller,
+int __metal_driver_riscv_clint0_command_request (const struct metal_interrupt *controller,
                                                int command, void *data)
 {
     int hartid;

--- a/src/drivers/riscv,cpu.c
+++ b/src/drivers/riscv,cpu.c
@@ -205,7 +205,7 @@ int __metal_valid_interrupt_id (int id)
 }
 
  
-int __metal_local_interrupt_enable (struct metal_interrupt *controller,
+int __metal_local_interrupt_enable (const struct metal_interrupt *controller,
 				  metal_interrupt_id_e id, int enable)
 {
     int rc = 0;
@@ -271,7 +271,7 @@ int __metal_local_interrupt_enable (struct metal_interrupt *controller,
     return rc;
 }
 
-int __metal_exception_register (struct metal_interrupt *controller,
+int __metal_exception_register (const struct metal_interrupt *controller,
                               int ecode, metal_exception_handler_t isr)
 {
     struct __metal_driver_riscv_cpu_intc *intc = (void *)(controller);
@@ -283,7 +283,7 @@ int __metal_exception_register (struct metal_interrupt *controller,
     return -1;
 }
 
-void __metal_driver_riscv_cpu_controller_interrupt_init (struct metal_interrupt *controller)
+void __metal_driver_riscv_cpu_controller_interrupt_init (const struct metal_interrupt *controller)
 {
     struct __metal_driver_riscv_cpu_intc *intc = (void *)(controller);
 
@@ -302,7 +302,7 @@ void __metal_driver_riscv_cpu_controller_interrupt_init (struct metal_interrupt 
     }
 }
 
-int __metal_driver_riscv_cpu_controller_interrupt_register(struct metal_interrupt *controller,
+int __metal_driver_riscv_cpu_controller_interrupt_register(const struct metal_interrupt *controller,
 							 int id, metal_interrupt_handler_t isr,
 							 void *priv)
 {
@@ -353,19 +353,19 @@ int __metal_driver_riscv_cpu_controller_interrupt_register(struct metal_interrup
     return rc;
 }
 
-int __metal_driver_riscv_cpu_controller_interrupt_enable (struct metal_interrupt *controller,
+int __metal_driver_riscv_cpu_controller_interrupt_enable (const struct metal_interrupt *controller,
                                                         int id)
 {
     return __metal_local_interrupt_enable(controller, id, METAL_ENABLE);
 }
 
-int __metal_driver_riscv_cpu_controller_interrupt_disable (struct metal_interrupt *controller,
+int __metal_driver_riscv_cpu_controller_interrupt_disable (const struct metal_interrupt *controller,
                                                          int id)
 {   
     return __metal_local_interrupt_enable(controller, id, METAL_DISABLE);
 }
 
-int __metal_driver_riscv_cpu_controller_interrupt_enable_vector(struct metal_interrupt *controller,
+int __metal_driver_riscv_cpu_controller_interrupt_enable_vector(const struct metal_interrupt *controller,
                                                              int id, metal_vector_mode mode)
 {
     struct __metal_driver_riscv_cpu_intc *intc = (void *)(controller);
@@ -383,7 +383,7 @@ int __metal_driver_riscv_cpu_controller_interrupt_enable_vector(struct metal_int
     return -1;
 }
 
-int __metal_driver_riscv_cpu_controller_interrupt_disable_vector(struct metal_interrupt *controller,
+int __metal_driver_riscv_cpu_controller_interrupt_disable_vector(const struct metal_interrupt *controller,
                                                               int id)
 {
     struct __metal_driver_riscv_cpu_intc *intc = (void *)(controller);
@@ -395,7 +395,7 @@ int __metal_driver_riscv_cpu_controller_interrupt_disable_vector(struct metal_in
     return -1;
 }
 
-int __metal_driver_riscv_cpu_controller_command_request (struct metal_interrupt *controller,
+int __metal_driver_riscv_cpu_controller_command_request (const struct metal_interrupt *controller,
 						       int cmd, void *data)
 {
     /* NOP for now, unless local interrupt lines the like of clic, clint, plic */
@@ -439,7 +439,7 @@ unsigned long long __metal_driver_cpu_timebase_get(const struct metal_cpu *cpu)
 unsigned long long  __metal_driver_cpu_mtime_get (const struct metal_cpu *cpu)
 {
     unsigned long long time = 0;
-    struct metal_interrupt *tmr_intc;
+    const struct metal_interrupt *tmr_intc;
     struct __metal_driver_riscv_cpu_intc *intc;
     struct __metal_driver_cpu *_cpu = (void *)cpu;
 
@@ -457,7 +457,7 @@ unsigned long long  __metal_driver_cpu_mtime_get (const struct metal_cpu *cpu)
 int __metal_driver_cpu_mtimecmp_set (const struct metal_cpu *cpu, unsigned long long time)
 {
     int rc = -1;
-    struct metal_interrupt *tmr_intc;
+    const struct metal_interrupt *tmr_intc;
     struct __metal_driver_riscv_cpu_intc *intc;
     struct __metal_driver_cpu *_cpu = (void *)cpu;
 
@@ -472,7 +472,7 @@ int __metal_driver_cpu_mtimecmp_set (const struct metal_cpu *cpu, unsigned long 
     return rc;
 }
 
-struct metal_interrupt *
+const struct metal_interrupt *
 __metal_driver_cpu_timer_controller_interrupt(const struct metal_cpu *cpu)
 {
 #ifdef __METAL_DT_RISCV_CLINT0_HANDLE
@@ -492,7 +492,7 @@ int __metal_driver_cpu_get_timer_interrupt_id(const struct metal_cpu *cpu)
     return METAL_INTERRUPT_ID_TMR;
 }
 
-struct metal_interrupt *
+const struct metal_interrupt *
 __metal_driver_cpu_sw_controller_interrupt(const struct metal_cpu *cpu)
 {
 #ifdef __METAL_DT_RISCV_CLINT0_HANDLE
@@ -515,7 +515,7 @@ int __metal_driver_cpu_get_sw_interrupt_id(const struct metal_cpu *cpu)
 int __metal_driver_cpu_set_sw_ipi (const struct metal_cpu *cpu, int hartid)
 {
     int rc = -1;
-    struct metal_interrupt *sw_intc;
+    const struct metal_interrupt *sw_intc;
     struct __metal_driver_riscv_cpu_intc *intc;
     struct __metal_driver_cpu *_cpu = (void *)cpu;
 
@@ -533,7 +533,7 @@ int __metal_driver_cpu_set_sw_ipi (const struct metal_cpu *cpu, int hartid)
 int __metal_driver_cpu_clear_sw_ipi (const struct metal_cpu *cpu, int hartid)
 {
     int rc = -1;
-    struct metal_interrupt *sw_intc;
+    const struct metal_interrupt *sw_intc;
     struct __metal_driver_riscv_cpu_intc *intc;
     struct __metal_driver_cpu *_cpu = (void *)cpu;
 
@@ -551,7 +551,7 @@ int __metal_driver_cpu_clear_sw_ipi (const struct metal_cpu *cpu, int hartid)
 int __metal_driver_cpu_get_msip (const struct metal_cpu *cpu, int hartid)
 {
     int rc = 0;
-    struct metal_interrupt *sw_intc;
+    const struct metal_interrupt *sw_intc;
     struct __metal_driver_riscv_cpu_intc *intc;
     struct __metal_driver_cpu *_cpu = (void *)cpu;
 
@@ -566,11 +566,11 @@ int __metal_driver_cpu_get_msip (const struct metal_cpu *cpu, int hartid)
     return rc;
 }
 
-struct metal_interrupt *
+const struct metal_interrupt *
 __metal_driver_cpu_controller_interrupt(const struct metal_cpu *cpu)
 {
     struct __metal_driver_cpu *cpu0 = (void *)cpu;
-    return (struct metal_interrupt *)cpu0->interrupt_controller;
+    return (const struct metal_interrupt *)cpu0->interrupt_controller;
 }
 
 int __metal_driver_cpu_enable_interrupt(const struct metal_cpu *cpu, void *priv)

--- a/src/drivers/riscv,plic0.c
+++ b/src/drivers/riscv,plic0.c
@@ -70,12 +70,12 @@ void __metal_plic0_handler (int id, void *priv)
     __metal_plic0_complete_interrupt(plic, idx);
 }
 
-void __metal_driver_riscv_plic0_init (struct metal_interrupt *controller)
+void __metal_driver_riscv_plic0_init (const struct metal_interrupt *controller)
 {
     struct __metal_driver_riscv_plic0 *plic = (void *)(controller);
 
     if ( !plic->init_done ) {
-        struct metal_interrupt *intc;
+        const struct metal_interrupt *intc;
 
         intc = plic->interrupt_parent;
 
@@ -104,7 +104,7 @@ void __metal_driver_riscv_plic0_init (struct metal_interrupt *controller)
     }
 }
 
-int __metal_driver_riscv_plic0_register (struct metal_interrupt *controller,
+int __metal_driver_riscv_plic0_register (const struct metal_interrupt *controller,
 			               int id, metal_interrupt_handler_t isr,
 			               void *priv)
 {
@@ -130,7 +130,7 @@ int __metal_driver_riscv_plic0_register (struct metal_interrupt *controller,
     return 0;
 }
 
-int __metal_driver_riscv_plic0_enable (struct metal_interrupt *controller, int id)
+int __metal_driver_riscv_plic0_enable (const struct metal_interrupt *controller, int id)
 {
     struct __metal_driver_riscv_plic0 *plic = (void *)(controller);
     unsigned int idx = id - METAL_INTERRUPT_ID_GL0;
@@ -143,7 +143,7 @@ int __metal_driver_riscv_plic0_enable (struct metal_interrupt *controller, int i
     return 0;
 }
 
-int __metal_driver_riscv_plic0_disable (struct metal_interrupt *controller, int id)
+int __metal_driver_riscv_plic0_disable (const struct metal_interrupt *controller, int id)
 {
     struct __metal_driver_riscv_plic0 *plic = (void *)(controller);
     unsigned int idx = id - METAL_INTERRUPT_ID_GL0;

--- a/src/drivers/riscv,plic0.c
+++ b/src/drivers/riscv,plic0.c
@@ -62,9 +62,9 @@ void __metal_plic0_handler (int id, void *priv)
     unsigned int idx = __metal_plic0_claim_interrupt(plic);
 
     if ( (idx <= plic->num_interrupts) &&
-	 (plic->metal_exint_table[idx].handler) ) {
-	plic->metal_exint_table[idx].handler(idx,
-				  plic->metal_exint_table[idx].exint_data);
+	 (plic->data->metal_exint_table[idx].handler) ) {
+	plic->data->metal_exint_table[idx].handler(idx,
+				  plic->data->metal_exint_table[idx].exint_data);
     }
 
     __metal_plic0_complete_interrupt(plic, idx);
@@ -74,7 +74,7 @@ void __metal_driver_riscv_plic0_init (const struct metal_interrupt *controller)
 {
     struct __metal_driver_riscv_plic0 *plic = (void *)(controller);
 
-    if ( !plic->init_done ) {
+    if ( !plic->data->init_done ) {
         const struct metal_interrupt *intc;
 
         intc = plic->interrupt_parent;
@@ -85,9 +85,9 @@ void __metal_driver_riscv_plic0_init (const struct metal_interrupt *controller)
 	for (int i = 0; i <= (plic->num_interrupts); i++) {
 	    __metal_plic0_enable(plic, i, METAL_DISABLE);
 	    __metal_plic0_set_priority(plic, i, 0);
-	    plic->metal_exint_table[i].handler = NULL;
-	    plic->metal_exint_table[i].sub_int = NULL;
-	    plic->metal_exint_table[i].exint_data = NULL;
+	    plic->data->metal_exint_table[i].handler = NULL;
+	    plic->data->metal_exint_table[i].sub_int = NULL;
+	    plic->data->metal_exint_table[i].exint_data = NULL;
 	}
 
 	__metal_plic0_set_threshold(plic, 0);
@@ -100,7 +100,7 @@ void __metal_driver_riscv_plic0_init (const struct metal_interrupt *controller)
 	intc->vtable->interrupt_register(intc,
 					 plic->interrupt_line,
 					 __metal_plic0_handler, plic);
-        plic->init_done = 1;
+        plic->data->init_done = 1;
     }
 }
 
@@ -118,13 +118,13 @@ int __metal_driver_riscv_plic0_register (const struct metal_interrupt *controlle
     if (isr) {
         __metal_plic0_enable(plic, idx, METAL_ENABLE);
         __metal_plic0_set_priority(plic ,idx, 2);
-	plic->metal_exint_table[idx].handler = isr;
-	plic->metal_exint_table[idx].exint_data = priv;
+	plic->data->metal_exint_table[idx].handler = isr;
+	plic->data->metal_exint_table[idx].exint_data = priv;
     } else {
         __metal_plic0_enable(plic, idx, METAL_ENABLE);
         __metal_plic0_set_priority(plic, idx, 1);
-	plic->metal_exint_table[idx].handler = __metal_plic0_default_handler;
-	plic->metal_exint_table[idx].sub_int = priv;
+	plic->data->metal_exint_table[idx].handler = __metal_plic0_default_handler;
+	plic->data->metal_exint_table[idx].sub_int = priv;
     }
 
     return 0;

--- a/src/drivers/sifive,clic0.c
+++ b/src/drivers/sifive,clic0.c
@@ -313,7 +313,7 @@ void __metal_clic0_default_handler (int id, void *priv) {
     metal_shutdown(300);
 }
 
-void __metal_driver_sifive_clic0_init (struct metal_interrupt *controller)
+void __metal_driver_sifive_clic0_init (const struct metal_interrupt *controller)
 {
     struct __metal_driver_sifive_clic0 *clic =
                               (struct __metal_driver_sifive_clic0 *)(controller);
@@ -321,7 +321,7 @@ void __metal_driver_sifive_clic0_init (struct metal_interrupt *controller)
     if ( !clic->init_done ) {
         int level;
         struct __metal_clic_cfg cfg = __metal_clic_defaultcfg;
-        struct metal_interrupt *intc = clic->interrupt_parent;
+        const struct metal_interrupt *intc = clic->interrupt_parent;
 
         /* Initialize ist parent controller, aka cpu_intc. */
         intc->vtable->interrupt_init(intc);
@@ -355,14 +355,14 @@ void __metal_driver_sifive_clic0_init (struct metal_interrupt *controller)
     }	
 }
 
-int __metal_driver_sifive_clic0_register (struct metal_interrupt *controller,
+int __metal_driver_sifive_clic0_register (const struct metal_interrupt *controller,
                                         int id, metal_interrupt_handler_t isr,
                                         void *priv)
 {
     int rc = -1;
     struct __metal_driver_sifive_clic0 *clic =
                               (struct __metal_driver_sifive_clic0 *)(controller);
-    struct metal_interrupt *intc = clic->interrupt_parent;
+    const struct metal_interrupt *intc = clic->interrupt_parent;
 
     /* Register its interrupts with parent controller */
     if ( id < METAL_INTERRUPT_ID_LC0) {
@@ -387,21 +387,21 @@ int __metal_driver_sifive_clic0_register (struct metal_interrupt *controller,
     return rc;
 }
 
-int __metal_driver_sifive_clic0_enable (struct metal_interrupt *controller, int id)
+int __metal_driver_sifive_clic0_enable (const struct metal_interrupt *controller, int id)
 {
     struct __metal_driver_sifive_clic0 *clic =
                               (struct __metal_driver_sifive_clic0 *)(controller);
     return __metal_clic0_interrupt_enable(clic, id);
 }
 
-int __metal_driver_sifive_clic0_disable (struct metal_interrupt *controller, int id)
+int __metal_driver_sifive_clic0_disable (const struct metal_interrupt *controller, int id)
 {
     struct __metal_driver_sifive_clic0 *clic =
                               (struct __metal_driver_sifive_clic0 *)(controller);
     return __metal_clic0_interrupt_disable(clic, id);
 }
 
-int __metal_driver_sifive_clic0_enable_interrupt_vector(struct metal_interrupt *controller,
+int __metal_driver_sifive_clic0_enable_interrupt_vector(const struct metal_interrupt *controller,
                                                       int id, metal_vector_mode mode)
 {
     struct __metal_driver_sifive_clic0 *clic =
@@ -428,7 +428,7 @@ int __metal_driver_sifive_clic0_enable_interrupt_vector(struct metal_interrupt *
     return -1;
 }
 
-int __metal_driver_sifive_clic0_disable_interrupt_vector(struct metal_interrupt *controller, int id)
+int __metal_driver_sifive_clic0_disable_interrupt_vector(const struct metal_interrupt *controller, int id)
 {
     struct __metal_driver_sifive_clic0 *clic =
                               (struct __metal_driver_sifive_clic0 *)(controller);
@@ -446,7 +446,7 @@ int __metal_driver_sifive_clic0_disable_interrupt_vector(struct metal_interrupt 
     return -1;
 }
 
-int __metal_driver_sifive_clic0_command_request (struct metal_interrupt *controller,
+int __metal_driver_sifive_clic0_command_request (const struct metal_interrupt *controller,
                                                int command, void *data)
 {
     int hartid;

--- a/src/drivers/sifive,clic0.c
+++ b/src/drivers/sifive,clic0.c
@@ -304,8 +304,8 @@ void __metal_clic0_handler (int id, void *priv)
     struct __metal_driver_sifive_clic0 *clic = priv;
 
     idx = id - METAL_INTERRUPT_ID_LC0;
-    if ( (idx < clic->num_subinterrupts) && (clic->metal_mtvt_table[idx]) ) {
-        clic->metal_mtvt_table[idx](id, clic->metal_exint_table[idx].exint_data);
+    if ( (idx < clic->num_subinterrupts) && (clic->data->metal_mtvt_table[idx]) ) {
+        clic->data->metal_mtvt_table[idx](id, clic->data->metal_exint_table[idx].exint_data);
     }
 }
 
@@ -318,7 +318,7 @@ void __metal_driver_sifive_clic0_init (const struct metal_interrupt *controller)
     struct __metal_driver_sifive_clic0 *clic =
                               (struct __metal_driver_sifive_clic0 *)(controller);
 
-    if ( !clic->init_done ) {
+    if ( !clic->data->init_done ) {
         int level;
         struct __metal_clic_cfg cfg = __metal_clic_defaultcfg;
         const struct metal_interrupt *intc = clic->interrupt_parent;
@@ -345,13 +345,13 @@ void __metal_driver_sifive_clic0_init (const struct metal_interrupt *controller)
 
         level = (1 << cfg.nlbits) - 1;
         for (int i = 0; i < clic->num_subinterrupts; i++) {
-            clic->metal_mtvt_table[i] = NULL;
-            clic->metal_exint_table[i].sub_int = NULL;
-            clic->metal_exint_table[i].exint_data = NULL;
+            clic->data->metal_mtvt_table[i] = NULL;
+            clic->data->metal_exint_table[i].sub_int = NULL;
+            clic->data->metal_exint_table[i].exint_data = NULL;
             __metal_clic0_interrupt_disable(clic, i);
             __metal_clic0_interrupt_set_level(clic, i, level);
         }
-	clic->init_done = 1;
+	clic->data->init_done = 1;
     }	
 }
 
@@ -376,11 +376,11 @@ int __metal_driver_sifive_clic0_register (const struct metal_interrupt *controll
     id -= METAL_INTERRUPT_ID_LC0;
     if (id < clic->num_subinterrupts) {
         if ( isr) {
-            clic->metal_mtvt_table[id] = isr;
-            clic->metal_exint_table[id].exint_data = priv;        
+            clic->data->metal_mtvt_table[id] = isr;
+            clic->data->metal_exint_table[id].exint_data = priv;        
         } else {
-            clic->metal_mtvt_table[id] = __metal_clic0_default_handler;
-            clic->metal_exint_table[id].sub_int = priv;
+            clic->data->metal_mtvt_table[id] = __metal_clic0_default_handler;
+            clic->data->metal_exint_table[id].sub_int = priv;
         }
         rc = 0;
     }
@@ -413,7 +413,7 @@ int __metal_driver_sifive_clic0_enable_interrupt_vector(const struct metal_inter
             return 0;
         }
         if (mode == METAL_HARDWARE_VECTOR_MODE) {
-            __metal_controller_interrupt_vector(mode, &clic->metal_mtvt_table);
+            __metal_controller_interrupt_vector(mode, &clic->data->metal_mtvt_table);
             return 0;
         }
     }

--- a/src/drivers/sifive,fe310-g000,hfrosc.c
+++ b/src/drivers/sifive,fe310-g000,hfrosc.c
@@ -19,7 +19,7 @@ long __metal_driver_sifive_fe310_g000_hfrosc_get_rate_hz(const struct metal_cloc
     return metal_clock_get_rate_hz(clk->ref) / ((cfg & CONFIG_DIVIDER) + 1);
 }
 
-long __metal_driver_sifive_fe310_g000_hfrosc_set_rate_hz(struct metal_clock *clock, long rate)
+long __metal_driver_sifive_fe310_g000_hfrosc_set_rate_hz(const struct metal_clock *clock, long rate)
 {
     return __metal_driver_sifive_fe310_g000_hfrosc_get_rate_hz(clock);
 }

--- a/src/drivers/sifive,fe310-g000,hfxosc.c
+++ b/src/drivers/sifive,fe310-g000,hfxosc.c
@@ -17,7 +17,7 @@ long __metal_driver_sifive_fe310_g000_hfxosc_get_rate_hz(const struct metal_cloc
     return metal_clock_get_rate_hz(clk->ref);
 }
 
-long __metal_driver_sifive_fe310_g000_hfxosc_set_rate_hz(struct metal_clock *clock, long rate)
+long __metal_driver_sifive_fe310_g000_hfxosc_set_rate_hz(const struct metal_clock *clock, long rate)
 {
     return __metal_driver_sifive_fe310_g000_hfxosc_get_rate_hz(clock);
 }

--- a/src/drivers/sifive,fe310-g000,pll.c
+++ b/src/drivers/sifive,fe310-g000,pll.c
@@ -146,12 +146,12 @@ static void metal_sifive_fe310_g000_pll_init(void) {
 
 #endif /* __METAL_DT_SIFIVE_FE310_G000__PLL_HANDLE */
 
-void __metal_driver_sifive_fe310_g000_pll_init(struct __metal_driver_sifive_fe310_g000_pll *pll) {
+void __metal_driver_sifive_fe310_g000_pll_init(const struct __metal_driver_sifive_fe310_g000_pll *pll) {
     __metal_io_u32 *pllcfg = (__metal_io_u32 *) (pll->config_base->base + pll->config_offset);
 
     /* If the PLL clock has had a _pre_rate_change_callback configured, call it */
-    if(pll->clock._pre_rate_change_callback != NULL)
-        pll->clock._pre_rate_change_callback(pll->clock._pre_rate_change_callback_priv);
+    if(pll->clock.data->_pre_rate_change_callback != NULL)
+        pll->clock.data->_pre_rate_change_callback(pll->clock.data->_pre_rate_change_callback_priv);
 
     /* If we're running off of the PLL, switch off before we start configuring it*/
     if((__METAL_ACCESS_ONCE(pllcfg) & PLL_SEL) == 0)
@@ -167,8 +167,8 @@ void __metal_driver_sifive_fe310_g000_pll_init(struct __metal_driver_sifive_fe31
     pll->vtable->clock.set_rate_hz(&(pll->clock), pll->init_rate);
 
     /* If the PLL clock has had a rate_change_callback configured, call it */
-    if(pll->clock._post_rate_change_callback != NULL)
-        pll->clock._post_rate_change_callback(pll->clock._post_rate_change_callback_priv);
+    if(pll->clock.data->_post_rate_change_callback != NULL)
+        pll->clock.data->_post_rate_change_callback(pll->clock.data->_post_rate_change_callback_priv);
 }
 
 long __metal_driver_sifive_fe310_g000_pll_get_rate_hz(const struct metal_clock *clock)
@@ -274,7 +274,7 @@ static void configure_pll(__metal_io_u32 *pllcfg, __metal_io_u32 *plloutdiv, str
     while((__METAL_ACCESS_ONCE(pllcfg) & PLL_LOCK) == 0) ;
 }
 
-long __metal_driver_sifive_fe310_g000_pll_set_rate_hz(struct metal_clock *clock, long rate)
+long __metal_driver_sifive_fe310_g000_pll_set_rate_hz(const struct metal_clock *clock, long rate)
 {
     struct __metal_driver_sifive_fe310_g000_pll *clk = (void *)clock;
     __metal_io_u32 *pllcfg = (__metal_io_u32 *) (clk->config_base->base + clk->config_offset);

--- a/src/drivers/sifive,global-external-interrupts0.c
+++ b/src/drivers/sifive,global-external-interrupts0.c
@@ -10,7 +10,7 @@ void __metal_driver_sifive_global_external_interrupt_init(const struct metal_int
     struct __metal_driver_sifive_global_external_interrupts0 *global0;
 
     global0 = (struct __metal_driver_sifive_global_external_interrupts0 *)(controller);
-    if ( !global0->init_done ) {
+    if ( !global0->data->init_done ) {
         const struct metal_interrupt *intc = global0->interrupt_parent;
 
 	/* Register its interrupts with with parent controller, aka all external to default isr */
@@ -19,7 +19,7 @@ void __metal_driver_sifive_global_external_interrupt_init(const struct metal_int
 					     global0->interrupt_lines[i],
 					     NULL, global0);
 	}
-        global0->init_done = 1;
+        global0->data->init_done = 1;
     }
 }
 

--- a/src/drivers/sifive,global-external-interrupts0.c
+++ b/src/drivers/sifive,global-external-interrupts0.c
@@ -5,13 +5,13 @@
 #include <metal/shutdown.h>
 #include <metal/drivers/sifive,global-external-interrupts0.h>
 
-void __metal_driver_sifive_global_external_interrupt_init(struct metal_interrupt *controller)
+void __metal_driver_sifive_global_external_interrupt_init(const struct metal_interrupt *controller)
 {
     struct __metal_driver_sifive_global_external_interrupts0 *global0;
 
     global0 = (struct __metal_driver_sifive_global_external_interrupts0 *)(controller);
     if ( !global0->init_done ) {
-        struct metal_interrupt *intc = global0->interrupt_parent;
+        const struct metal_interrupt *intc = global0->interrupt_parent;
 
 	/* Register its interrupts with with parent controller, aka all external to default isr */
         for (int i = 0; i < global0->num_interrupts; i++) {
@@ -23,7 +23,7 @@ void __metal_driver_sifive_global_external_interrupt_init(struct metal_interrupt
     }
 }
 
-int __metal_driver_sifive_global_external_interrupt_register(struct metal_interrupt *controller,
+int __metal_driver_sifive_global_external_interrupt_register(const struct metal_interrupt *controller,
                                                            int id, metal_interrupt_handler_t isr,
                                                            void *priv)
 {
@@ -32,7 +32,7 @@ int __metal_driver_sifive_global_external_interrupt_register(struct metal_interr
                               (struct __metal_driver_sifive_global_external_interrupts0 *)(controller);
 
     if (id != 0) {
-        struct metal_interrupt *intc = global0->interrupt_parent;
+        const struct metal_interrupt *intc = global0->interrupt_parent;
 
         /* Enable its interrupts with parent controller */
         if (intc) {
@@ -42,14 +42,14 @@ int __metal_driver_sifive_global_external_interrupt_register(struct metal_interr
     return rc;
 }
 
-int __metal_driver_sifive_global_external_interrupt_enable(struct metal_interrupt *controller, int id)
+int __metal_driver_sifive_global_external_interrupt_enable(const struct metal_interrupt *controller, int id)
 {
     int rc = -1;
     struct __metal_driver_sifive_global_external_interrupts0 *global0 =
                               (struct __metal_driver_sifive_global_external_interrupts0 *)(controller);
 
     if (id != 0) {
-        struct metal_interrupt *intc = global0->interrupt_parent;
+        const struct metal_interrupt *intc = global0->interrupt_parent;
 
         /* Enable its interrupts with parent controller */
         if (intc) {
@@ -59,14 +59,14 @@ int __metal_driver_sifive_global_external_interrupt_enable(struct metal_interrup
     return rc;
 }
 
-int __metal_driver_sifive_global_external_interrupt_disable(struct metal_interrupt *controller, int id)
+int __metal_driver_sifive_global_external_interrupt_disable(const struct metal_interrupt *controller, int id)
 {
     int rc = -1;
     struct __metal_driver_sifive_global_external_interrupts0 *global0 =
                               (struct __metal_driver_sifive_global_external_interrupts0 *)(controller);
 
     if (id != 0) {
-        struct metal_interrupt *intc = global0->interrupt_parent;
+        const struct metal_interrupt *intc = global0->interrupt_parent;
 
         /* Enable its interrupts with parent controller */
         if (intc) {
@@ -76,7 +76,7 @@ int __metal_driver_sifive_global_external_interrupt_disable(struct metal_interru
     return rc;
 }
 
-int __metal_driver_sifive_global_external_command_request (struct metal_interrupt *controller,
+int __metal_driver_sifive_global_external_command_request (const struct metal_interrupt *controller,
                                                          int command, void *data)
 {
     int index;

--- a/src/drivers/sifive,gpio-buttons.c
+++ b/src/drivers/sifive,gpio-buttons.c
@@ -5,7 +5,7 @@
 #include <metal/drivers/riscv,cpu.h>
 #include <metal/drivers/sifive,gpio-buttons.h>
 
-int  __metal_driver_button_exist (struct metal_button *button, char *label)
+int  __metal_driver_button_exist (const struct metal_button *button, char *label)
 {
     struct __metal_driver_sifive_gpio_button *but = (void *)(button);
 
@@ -15,15 +15,15 @@ int  __metal_driver_button_exist (struct metal_button *button, char *label)
     return 0;
 }
 
-struct metal_interrupt *
-__metal_driver_button_interrupt_controller(struct metal_button *button)
+const struct metal_interrupt *
+__metal_driver_button_interrupt_controller(const struct metal_button *button)
 {
     struct __metal_driver_sifive_gpio_button *but = (void *)(button);
 
     return but->interrupt_parent;
 }
 
-int __metal_driver_button_get_interrupt_id(struct metal_button *button)
+int __metal_driver_button_get_interrupt_id(const struct metal_button *button)
 {
     int max_irq;
     struct __metal_driver_sifive_gpio_button *but = (void *)(button);

--- a/src/drivers/sifive,gpio-leds.c
+++ b/src/drivers/sifive,gpio-leds.c
@@ -4,7 +4,7 @@
 #include <string.h>
 #include <metal/drivers/sifive,gpio-leds.h>
 
-int  __metal_driver_led_exist (struct metal_led *led, char *label)
+int  __metal_driver_led_exist (const struct metal_led *led, char *label)
 {
     struct __metal_driver_sifive_gpio_led *_led = (void *)(led);
 
@@ -14,7 +14,7 @@ int  __metal_driver_led_exist (struct metal_led *led, char *label)
     return 0;
 }
 
-void __metal_driver_led_enable (struct metal_led *led)
+void __metal_driver_led_enable (const struct metal_led *led)
 {
     struct __metal_driver_sifive_gpio_led *_led = (void *)(led);
 
@@ -25,7 +25,7 @@ void __metal_driver_led_enable (struct metal_led *led)
     }
 }
 
-void __metal_driver_led_on (struct metal_led *led)
+void __metal_driver_led_on (const struct metal_led *led)
 {
     struct __metal_driver_sifive_gpio_led *_led = (void *)(led);
 
@@ -34,7 +34,7 @@ void __metal_driver_led_on (struct metal_led *led)
     }
 }
 
-void __metal_driver_led_off (struct metal_led *led)
+void __metal_driver_led_off (const struct metal_led *led)
 {
     struct __metal_driver_sifive_gpio_led *_led = (void *)(led);
 
@@ -43,7 +43,7 @@ void __metal_driver_led_off (struct metal_led *led)
     }
 }
 
-void __metal_driver_led_toggle (struct metal_led *led)
+void __metal_driver_led_toggle (const struct metal_led *led)
 {
     struct __metal_driver_sifive_gpio_led *_led = (void *)(led);
 

--- a/src/drivers/sifive,gpio-switches.c
+++ b/src/drivers/sifive,gpio-switches.c
@@ -5,7 +5,7 @@
 #include <metal/drivers/riscv,cpu.h>
 #include <metal/drivers/sifive,gpio-switches.h>
 
-int  __metal_driver_switch_exist (struct metal_switch *flip, char *label)
+int  __metal_driver_switch_exist (const struct metal_switch *flip, char *label)
 {
     struct __metal_driver_sifive_gpio_switch *swch = (void *)(flip);
 
@@ -15,15 +15,15 @@ int  __metal_driver_switch_exist (struct metal_switch *flip, char *label)
     return 0;
 }
 
-struct metal_interrupt *
-__metal_driver_switch_interrupt_controller(struct metal_switch *flip)
+const struct metal_interrupt *
+__metal_driver_switch_interrupt_controller(const struct metal_switch *flip)
 {
     struct __metal_driver_sifive_gpio_switch *swch = (void *)(flip);
 
     return swch->interrupt_parent;
 }
 
-int __metal_driver_switch_get_interrupt_id(struct metal_switch *flip)
+int __metal_driver_switch_get_interrupt_id(const struct metal_switch *flip)
 {
     int max_irq;
     struct __metal_driver_sifive_gpio_switch *swch = (void *)(flip);

--- a/src/drivers/sifive,local-external-interrupts0.c
+++ b/src/drivers/sifive,local-external-interrupts0.c
@@ -4,13 +4,13 @@
 #include <metal/io.h>
 #include <metal/drivers/sifive,local-external-interrupts0.h>
 
-void __metal_driver_sifive_local_external_interrupt_init(struct metal_interrupt *controller)
+void __metal_driver_sifive_local_external_interrupt_init(const struct metal_interrupt *controller)
 {
     struct __metal_driver_sifive_local_external_interrupts0 *local0;
 
     local0 = (struct __metal_driver_sifive_local_external_interrupts0 *)(controller);
     if ( !local0->init_done ) {
-        struct metal_interrupt *intc = local0->interrupt_parent;
+        const struct metal_interrupt *intc = local0->interrupt_parent;
 
 	/* Register its interruptswith with parent controller, aka all external to default isr */
         for (int i = 0; i < local0->num_interrupts; i++) {
@@ -22,7 +22,7 @@ void __metal_driver_sifive_local_external_interrupt_init(struct metal_interrupt 
     }
 }
 
-int __metal_driver_sifive_local_external_interrupt_register(struct metal_interrupt *controller,
+int __metal_driver_sifive_local_external_interrupt_register(const struct metal_interrupt *controller,
                                                           int id, metal_interrupt_handler_t isr,
                                                           void *priv)
 {
@@ -31,7 +31,7 @@ int __metal_driver_sifive_local_external_interrupt_register(struct metal_interru
                               (struct __metal_driver_sifive_local_external_interrupts0 *)(controller);
 
     if (id != 0) {
-        struct metal_interrupt *intc = local0->interrupt_parent;
+        const struct metal_interrupt *intc = local0->interrupt_parent;
 
         /* Enable its interrupts with parent controller */
         if (intc) {
@@ -41,14 +41,14 @@ int __metal_driver_sifive_local_external_interrupt_register(struct metal_interru
     return rc;
 }
 
-int __metal_driver_sifive_local_external_interrupt_enable(struct metal_interrupt *controller, int id)
+int __metal_driver_sifive_local_external_interrupt_enable(const struct metal_interrupt *controller, int id)
 {
     int rc = -1;
     struct __metal_driver_sifive_local_external_interrupts0 *local0 =
                               (struct __metal_driver_sifive_local_external_interrupts0 *)(controller);
 
     if (id != 0) {
-        struct metal_interrupt *intc = local0->interrupt_parent;
+        const struct metal_interrupt *intc = local0->interrupt_parent;
 
         /* Enable its interrupts with parent controller */
         if (intc) {
@@ -58,14 +58,14 @@ int __metal_driver_sifive_local_external_interrupt_enable(struct metal_interrupt
     return rc;
 }
 
-int __metal_driver_sifive_local_external_interrupt_disable(struct metal_interrupt *controller, int id)
+int __metal_driver_sifive_local_external_interrupt_disable(const struct metal_interrupt *controller, int id)
 {
     int rc = -1;
     struct __metal_driver_sifive_local_external_interrupts0 *local0 =
                               (struct __metal_driver_sifive_local_external_interrupts0 *)(controller);
 
     if (id != 0) {
-        struct metal_interrupt *intc = local0->interrupt_parent;
+        const struct metal_interrupt *intc = local0->interrupt_parent;
 
         /* Enable its interrupts with parent controller */
         if (intc) {
@@ -75,7 +75,7 @@ int __metal_driver_sifive_local_external_interrupt_disable(struct metal_interrup
     return rc;
 }
 
-int __metal_driver_sifive_local_external_command_request (struct metal_interrupt *controller,
+int __metal_driver_sifive_local_external_command_request (const struct metal_interrupt *controller,
                                                         int command, void *data)
 {
     int index;

--- a/src/drivers/sifive,local-external-interrupts0.c
+++ b/src/drivers/sifive,local-external-interrupts0.c
@@ -9,7 +9,7 @@ void __metal_driver_sifive_local_external_interrupt_init(const struct metal_inte
     struct __metal_driver_sifive_local_external_interrupts0 *local0;
 
     local0 = (struct __metal_driver_sifive_local_external_interrupts0 *)(controller);
-    if ( !local0->init_done ) {
+    if ( !local0->data->init_done ) {
         const struct metal_interrupt *intc = local0->interrupt_parent;
 
 	/* Register its interruptswith with parent controller, aka all external to default isr */
@@ -18,7 +18,7 @@ void __metal_driver_sifive_local_external_interrupt_init(const struct metal_inte
 					   local0->interrupt_lines[i],
 					   NULL, local0);
 	}
-        local0->init_done = 1;
+        local0->data->init_done = 1;
     }
 }
 

--- a/src/interrupt.c
+++ b/src/interrupt.c
@@ -4,21 +4,21 @@
 #include <metal/interrupt.h>
 #include <metal/machine.h>
 
-extern inline void metal_interrupt_init(struct metal_interrupt *controller);
+extern inline void metal_interrupt_init(const struct metal_interrupt *controller);
 
-extern inline int metal_interrupt_register_handler(struct metal_interrupt *controller,
+extern inline int metal_interrupt_register_handler(const struct metal_interrupt *controller,
 						 int id,
 						 metal_interrupt_handler_t handler,
 						 void *priv);
 
-extern inline int metal_interrupt_enable(struct metal_interrupt *controller, int id);
+extern inline int metal_interrupt_enable(const struct metal_interrupt *controller, int id);
 
-extern inline int metal_interrupt_disable(struct metal_interrupt *controller, int id);
+extern inline int metal_interrupt_disable(const struct metal_interrupt *controller, int id);
 
-extern inline int metal_interrupt_vector_enable(struct metal_interrupt *controller,
+extern inline int metal_interrupt_vector_enable(const struct metal_interrupt *controller,
                                                      int id, metal_vector_mode mode);
 
-extern inline int metal_interrupt_vector_disable(struct metal_interrupt *controller, int id);
+extern inline int metal_interrupt_vector_disable(const struct metal_interrupt *controller, int id);
 
-extern inline int _metal_interrupt_command_request(struct metal_interrupt *controller,
+extern inline int _metal_interrupt_command_request(const struct metal_interrupt *controller,
                                          	int cmd, void *data);

--- a/src/led.c
+++ b/src/led.c
@@ -5,10 +5,10 @@
 #include <metal/led.h>
 #include <metal/machine.h>
 
-struct metal_led* metal_led_get_rgb (char *label, char *color)
+const struct metal_led* metal_led_get_rgb (char *label, char *color)
 {
     int i;
-    struct metal_led *led;
+    const struct metal_led *led;
     char led_label[100];
 
     if ((__METAL_DT_MAX_LEDS == 0) ||
@@ -19,7 +19,7 @@ struct metal_led* metal_led_get_rgb (char *label, char *color)
     strcpy(led_label, label);
     strcat(led_label, color);
     for (i = 0; i < __METAL_DT_MAX_LEDS; i++) {
-        led = (struct metal_led*)__metal_led_table[i];
+        led = (const struct metal_led*)__metal_led_table[i];
         if (led->vtable->led_exist(led, led_label)) {
 	    return led;
 	}
@@ -27,12 +27,12 @@ struct metal_led* metal_led_get_rgb (char *label, char *color)
     return NULL;
 }
 
-struct metal_led* metal_led_get (char *label)
+const struct metal_led* metal_led_get (char *label)
 {
     return metal_led_get_rgb(label, "");
 }
 
-extern inline void metal_led_enable(struct metal_led *led);
-extern inline void metal_led_on(struct metal_led *led);
-extern inline void metal_led_off(struct metal_led *led);
-extern inline void metal_led_toggle(struct metal_led *led);
+extern inline void metal_led_enable(const struct metal_led *led);
+extern inline void metal_led_on(const struct metal_led *led);
+extern inline void metal_led_off(const struct metal_led *led);
+extern inline void metal_led_toggle(const struct metal_led *led);

--- a/src/pmp.c
+++ b/src/pmp.c
@@ -5,9 +5,9 @@
 #include <metal/pmp.h>
 
 #define CONFIG_TO_INT(_config) (*((size_t *) &(_config)))
-#define INT_TO_CONFIG(_int) (*((struct metal_pmp_config *) &(_int)))
+#define INT_TO_CONFIG(_int) (*((const struct metal_pmp_config *) &(_int)))
 
-struct metal_pmp *metal_pmp_get_device(void)
+const struct metal_pmp *metal_pmp_get_device(void)
 {
 #ifdef __METAL_DT_PMP_HANDLE
     return __METAL_DT_PMP_HANDLE;
@@ -16,9 +16,9 @@ struct metal_pmp *metal_pmp_get_device(void)
 #endif
 }
 
-void metal_pmp_init(struct metal_pmp *pmp)
+void metal_pmp_init(const struct metal_pmp *pmp)
 {
-    struct metal_pmp_config init_config = {
+    const struct metal_pmp_config init_config = {
         .L = METAL_PMP_UNLOCKED,
         .A = METAL_PMP_OFF,
         .X = 0,
@@ -31,9 +31,9 @@ void metal_pmp_init(struct metal_pmp *pmp)
     }
 }
 
-int metal_pmp_set_region(struct metal_pmp *pmp,
+int metal_pmp_set_region(const struct metal_pmp *pmp,
                        unsigned int region,
-                       struct metal_pmp_config config,
+                       const struct metal_pmp_config config,
                        size_t address)
 {
     struct metal_pmp_config old_config;
@@ -201,7 +201,7 @@ int metal_pmp_set_region(struct metal_pmp *pmp,
     return 0;
 }
 
-int metal_pmp_get_region(struct metal_pmp *pmp,
+int metal_pmp_get_region(const struct metal_pmp *pmp,
                        unsigned int region,
                        struct metal_pmp_config *config,
                        size_t *address)
@@ -330,7 +330,7 @@ int metal_pmp_get_region(struct metal_pmp *pmp,
     return 0;
 }
 
-int metal_pmp_lock(struct metal_pmp *pmp, unsigned int region)
+int metal_pmp_lock(const struct metal_pmp *pmp, unsigned int region)
 {
     struct metal_pmp_config config;
     size_t address;
@@ -353,7 +353,7 @@ int metal_pmp_lock(struct metal_pmp *pmp, unsigned int region)
 }
 
 
-int metal_pmp_set_address(struct metal_pmp *pmp, unsigned int region, size_t address)
+int metal_pmp_set_address(const struct metal_pmp *pmp, unsigned int region, size_t address)
 {
     struct metal_pmp_config config;
     size_t old_address;
@@ -369,7 +369,7 @@ int metal_pmp_set_address(struct metal_pmp *pmp, unsigned int region, size_t add
     return rc;
 }
 
-size_t metal_pmp_get_address(struct metal_pmp *pmp, unsigned int region)
+size_t metal_pmp_get_address(const struct metal_pmp *pmp, unsigned int region)
 {
     struct metal_pmp_config config;
     size_t address = 0;
@@ -380,7 +380,7 @@ size_t metal_pmp_get_address(struct metal_pmp *pmp, unsigned int region)
 }
 
 
-int metal_pmp_set_address_mode(struct metal_pmp *pmp, unsigned int region, enum metal_pmp_address_mode mode)
+int metal_pmp_set_address_mode(const struct metal_pmp *pmp, unsigned int region, enum metal_pmp_address_mode mode)
 {
     struct metal_pmp_config config;
     size_t address;
@@ -398,7 +398,7 @@ int metal_pmp_set_address_mode(struct metal_pmp *pmp, unsigned int region, enum 
     return rc;
 }
 
-enum metal_pmp_address_mode metal_pmp_get_address_mode(struct metal_pmp *pmp, unsigned int region)
+enum metal_pmp_address_mode metal_pmp_get_address_mode(const struct metal_pmp *pmp, unsigned int region)
 {
     struct metal_pmp_config config;
     size_t address = 0;
@@ -409,7 +409,7 @@ enum metal_pmp_address_mode metal_pmp_get_address_mode(struct metal_pmp *pmp, un
 }
 
 
-int metal_pmp_set_executable(struct metal_pmp *pmp, unsigned int region, int X)
+int metal_pmp_set_executable(const struct metal_pmp *pmp, unsigned int region, int X)
 {
     struct metal_pmp_config config;
     size_t address;
@@ -427,7 +427,7 @@ int metal_pmp_set_executable(struct metal_pmp *pmp, unsigned int region, int X)
     return rc;
 }
 
-int metal_pmp_get_executable(struct metal_pmp *pmp, unsigned int region)
+int metal_pmp_get_executable(const struct metal_pmp *pmp, unsigned int region)
 {
     struct metal_pmp_config config;
     size_t address = 0;
@@ -438,7 +438,7 @@ int metal_pmp_get_executable(struct metal_pmp *pmp, unsigned int region)
 }
 
 
-int metal_pmp_set_writeable(struct metal_pmp *pmp, unsigned int region, int W)
+int metal_pmp_set_writeable(const struct metal_pmp *pmp, unsigned int region, int W)
 {
     struct metal_pmp_config config;
     size_t address;
@@ -456,7 +456,7 @@ int metal_pmp_set_writeable(struct metal_pmp *pmp, unsigned int region, int W)
     return rc;
 }
 
-int metal_pmp_get_writeable(struct metal_pmp *pmp, unsigned int region)
+int metal_pmp_get_writeable(const struct metal_pmp *pmp, unsigned int region)
 {
     struct metal_pmp_config config;
     size_t address = 0;
@@ -467,7 +467,7 @@ int metal_pmp_get_writeable(struct metal_pmp *pmp, unsigned int region)
 }
 
 
-int metal_pmp_set_readable(struct metal_pmp *pmp, unsigned int region, int R)
+int metal_pmp_set_readable(const struct metal_pmp *pmp, unsigned int region, int R)
 {
     struct metal_pmp_config config;
     size_t address;
@@ -485,7 +485,7 @@ int metal_pmp_set_readable(struct metal_pmp *pmp, unsigned int region, int R)
     return rc;
 }
 
-int metal_pmp_get_readable(struct metal_pmp *pmp, unsigned int region)
+int metal_pmp_get_readable(const struct metal_pmp *pmp, unsigned int region)
 {
     struct metal_pmp_config config;
     size_t address = 0;

--- a/src/spi.c
+++ b/src/spi.c
@@ -4,16 +4,16 @@
 #include <metal/machine.h>
 #include <metal/spi.h>
 
-extern inline void metal_spi_init(struct metal_spi *spi, int baud_rate);
-extern inline int metal_spi_transfer(struct metal_spi *spi, struct metal_spi_config *config, size_t len, char *tx_buf, char *rx_buf);
-extern inline int metal_spi_get_baud_rate(struct metal_spi *spi);
-extern inline int metal_spi_set_baud_rate(struct metal_spi *spi, int baud_rate);
+extern inline void metal_spi_init(const struct metal_spi *spi, int baud_rate);
+extern inline int metal_spi_transfer(const struct metal_spi *spi, const struct metal_spi_config *config, size_t len, char *tx_buf, char *rx_buf);
+extern inline int metal_spi_get_baud_rate(const struct metal_spi *spi);
+extern inline int metal_spi_set_baud_rate(const struct metal_spi *spi, int baud_rate);
 
-struct metal_spi *metal_spi_get_device(int device_num)
+const struct metal_spi *metal_spi_get_device(int device_num)
 {
     if(device_num >= __METAL_DT_MAX_SPIS) {
         return NULL;
     }
 
-    return (struct metal_spi *) __metal_spi_table[device_num];
+    return (const struct metal_spi *) __metal_spi_table[device_num];
 }

--- a/src/switch.c
+++ b/src/switch.c
@@ -4,17 +4,17 @@
 #include <metal/switch.h>
 #include <metal/machine.h>
 
-struct metal_switch* metal_switch_get (char *label)
+const struct metal_switch* metal_switch_get (char *label)
 {
     int i;
-    struct metal_switch *flip;
+    const struct metal_switch *flip;
 
     if ((__METAL_DT_MAX_BUTTONS == 0) || (label == NULL)) {
         return NULL;
     }
 
     for (i = 0; i < __METAL_DT_MAX_BUTTONS; i++) {
-        flip = (struct metal_switch*)__metal_switch_table[i];
+        flip = (const struct metal_switch*)__metal_switch_table[i];
         if (flip->vtable->switch_exist(flip, label)) {
             return flip;
         }
@@ -22,6 +22,6 @@ struct metal_switch* metal_switch_get (char *label)
     return NULL;
 }
 
-extern inline struct metal_interrupt*
-    metal_switch_interrupt_controller(struct metal_switch *flip);
-extern inline int metal_switch_get_interrupt_id(struct metal_switch *flip);
+extern inline const struct metal_interrupt*
+    metal_switch_interrupt_controller(const struct metal_switch *flip);
+extern inline int metal_switch_get_interrupt_id(const struct metal_switch *flip);

--- a/src/timer.c
+++ b/src/timer.c
@@ -12,7 +12,7 @@
  * timer on a system. */
 int metal_timer_get_cyclecount(int hartid, unsigned long long *mcc)
 {
-    struct metal_cpu *cpu = metal_cpu_get(hartid);
+    const struct metal_cpu *cpu = metal_cpu_get(hartid);
 
     if ( cpu ) {
         *mcc = metal_cpu_get_timer(cpu);
@@ -23,7 +23,7 @@ int metal_timer_get_cyclecount(int hartid, unsigned long long *mcc)
 
 int metal_timer_get_timebase_frequency(int hartid, unsigned long long *timebase)
 {
-    struct metal_cpu *cpu = metal_cpu_get(hartid);
+    const struct metal_cpu *cpu = metal_cpu_get(hartid);
 
     if ( cpu ) {
         *timebase = metal_cpu_get_timebase(cpu);
@@ -34,7 +34,7 @@ int metal_timer_get_timebase_frequency(int hartid, unsigned long long *timebase)
 
 int metal_timer_get_machine_time(int hartid)
 {
-    struct metal_cpu *cpu = metal_cpu_get(hartid);
+    const struct metal_cpu *cpu = metal_cpu_get(hartid);
        
     if ( cpu ) {
        return metal_cpu_get_mtime(cpu);
@@ -44,7 +44,7 @@ int metal_timer_get_machine_time(int hartid)
 
 int metal_timer_set_machine_time(int hartid, unsigned long long time)
 {
-    struct metal_cpu *cpu = metal_cpu_get(hartid);
+    const struct metal_cpu *cpu = metal_cpu_get(hartid);
 
     if ( cpu ) {
        return metal_cpu_set_mtimecmp(cpu, time);

--- a/src/uart.c
+++ b/src/uart.c
@@ -3,8 +3,8 @@
 
 #include <metal/uart.h>
 
-extern inline void metal_uart_init(struct metal_uart *uart, int baud_rate);
-extern inline int metal_uart_putc(struct metal_uart *uart, unsigned char c);
-extern inline int metal_uart_getc(struct metal_uart *uart, unsigned char *c);
-extern inline int metal_uart_get_baud_rate(struct metal_uart *uart);
-extern inline int metal_uart_set_baud_rate(struct metal_uart *uart, int baud_rate);
+extern inline void metal_uart_init(const struct metal_uart *uart, int baud_rate);
+extern inline int metal_uart_putc(const struct metal_uart *uart, unsigned char c);
+extern inline int metal_uart_getc(const struct metal_uart *uart, unsigned char *c);
+extern inline int metal_uart_get_baud_rate(const struct metal_uart *uart);
+extern inline int metal_uart_set_baud_rate(const struct metal_uart *uart, int baud_rate);


### PR DESCRIPTION
Moves driver data and structs into ROM where possible. Mutable data is moved into a sub-struct which can be kept in RAM.