### PR TITLE
Create a public atomic lock API

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -96,6 +96,7 @@ nobase_include_HEADERS = \
 	metal/io.h \
 	metal/itim.h \
 	metal/led.h \
+	metal/lock.h \
 	metal/machine.h \
 	metal/memory.h \
 	metal/pmp.h \
@@ -161,6 +162,7 @@ libriscv__mmachine__@MACHINE_NAME@_a_SOURCES = \
 	src/gpio.c \
 	src/interrupt.c \
 	src/led.c \
+	src/lock.c \
 	src/memory.c \
 	src/pmp.c \
 	src/shutdown.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -167,6 +167,7 @@ libriscv__mmachine__@MACHINE_NAME@_a_SOURCES = \
 	src/spi.c \
 	src/switch.c \
 	src/timer.c \
+	src/trap.S \
 	src/tty.c \
 	src/uart.c
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -224,12 +224,14 @@ am_libriscv__mmachine__@MACHINE_NAME@_a_OBJECTS = src/drivers/libriscv__mmachine
 	src/libriscv__mmachine__@MACHINE_NAME@_a-gpio.$(OBJEXT) \
 	src/libriscv__mmachine__@MACHINE_NAME@_a-interrupt.$(OBJEXT) \
 	src/libriscv__mmachine__@MACHINE_NAME@_a-led.$(OBJEXT) \
+	src/libriscv__mmachine__@MACHINE_NAME@_a-lock.$(OBJEXT) \
 	src/libriscv__mmachine__@MACHINE_NAME@_a-memory.$(OBJEXT) \
 	src/libriscv__mmachine__@MACHINE_NAME@_a-pmp.$(OBJEXT) \
 	src/libriscv__mmachine__@MACHINE_NAME@_a-shutdown.$(OBJEXT) \
 	src/libriscv__mmachine__@MACHINE_NAME@_a-spi.$(OBJEXT) \
 	src/libriscv__mmachine__@MACHINE_NAME@_a-switch.$(OBJEXT) \
 	src/libriscv__mmachine__@MACHINE_NAME@_a-timer.$(OBJEXT) \
+	src/libriscv__mmachine__@MACHINE_NAME@_a-trap.$(OBJEXT) \
 	src/libriscv__mmachine__@MACHINE_NAME@_a-tty.$(OBJEXT) \
 	src/libriscv__mmachine__@MACHINE_NAME@_a-uart.$(OBJEXT)
 libriscv__mmachine__@MACHINE_NAME@_a_OBJECTS =  \
@@ -486,6 +488,7 @@ nobase_include_HEADERS = \
 	metal/io.h \
 	metal/itim.h \
 	metal/led.h \
+	metal/lock.h \
 	metal/machine.h \
 	metal/memory.h \
 	metal/pmp.h \
@@ -531,12 +534,14 @@ libriscv__mmachine__@MACHINE_NAME@_a_SOURCES = \
 	src/gpio.c \
 	src/interrupt.c \
 	src/led.c \
+	src/lock.c \
 	src/memory.c \
 	src/pmp.c \
 	src/shutdown.c \
 	src/spi.c \
 	src/switch.c \
 	src/timer.c \
+	src/trap.S \
 	src/tty.c \
 	src/uart.c
 
@@ -809,6 +814,8 @@ src/libriscv__mmachine__@MACHINE_NAME@_a-interrupt.$(OBJEXT):  \
 	src/$(am__dirstamp) src/$(DEPDIR)/$(am__dirstamp)
 src/libriscv__mmachine__@MACHINE_NAME@_a-led.$(OBJEXT):  \
 	src/$(am__dirstamp) src/$(DEPDIR)/$(am__dirstamp)
+src/libriscv__mmachine__@MACHINE_NAME@_a-lock.$(OBJEXT):  \
+	src/$(am__dirstamp) src/$(DEPDIR)/$(am__dirstamp)
 src/libriscv__mmachine__@MACHINE_NAME@_a-memory.$(OBJEXT):  \
 	src/$(am__dirstamp) src/$(DEPDIR)/$(am__dirstamp)
 src/libriscv__mmachine__@MACHINE_NAME@_a-pmp.$(OBJEXT):  \
@@ -820,6 +827,8 @@ src/libriscv__mmachine__@MACHINE_NAME@_a-spi.$(OBJEXT):  \
 src/libriscv__mmachine__@MACHINE_NAME@_a-switch.$(OBJEXT):  \
 	src/$(am__dirstamp) src/$(DEPDIR)/$(am__dirstamp)
 src/libriscv__mmachine__@MACHINE_NAME@_a-timer.$(OBJEXT):  \
+	src/$(am__dirstamp) src/$(DEPDIR)/$(am__dirstamp)
+src/libriscv__mmachine__@MACHINE_NAME@_a-trap.$(OBJEXT):  \
 	src/$(am__dirstamp) src/$(DEPDIR)/$(am__dirstamp)
 src/libriscv__mmachine__@MACHINE_NAME@_a-tty.$(OBJEXT):  \
 	src/$(am__dirstamp) src/$(DEPDIR)/$(am__dirstamp)
@@ -908,12 +917,14 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-gpio.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-interrupt.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-led.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-lock.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-memory.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-pmp.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-shutdown.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-spi.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-switch.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-timer.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-trap.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-tty.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-uart.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/drivers/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-fixed-clock.Po@am__quote@
@@ -967,6 +978,20 @@ src/libriscv__mmachine__@MACHINE_NAME@_a-entry.obj: src/entry.S
 @AMDEP_TRUE@@am__fastdepCCAS_FALSE@	$(AM_V_CPPAS)source='src/entry.S' object='src/libriscv__mmachine__@MACHINE_NAME@_a-entry.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCCAS_FALSE@	DEPDIR=$(DEPDIR) $(CCASDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCCAS_FALSE@	$(AM_V_CPPAS@am__nodep@)$(CCAS) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libriscv__mmachine__@MACHINE_NAME@_a_CCASFLAGS) $(CCASFLAGS) -c -o src/libriscv__mmachine__@MACHINE_NAME@_a-entry.obj `if test -f 'src/entry.S'; then $(CYGPATH_W) 'src/entry.S'; else $(CYGPATH_W) '$(srcdir)/src/entry.S'; fi`
+
+src/libriscv__mmachine__@MACHINE_NAME@_a-trap.o: src/trap.S
+@am__fastdepCCAS_TRUE@	$(AM_V_CPPAS)$(CCAS) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libriscv__mmachine__@MACHINE_NAME@_a_CCASFLAGS) $(CCASFLAGS) -MT src/libriscv__mmachine__@MACHINE_NAME@_a-trap.o -MD -MP -MF src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-trap.Tpo -c -o src/libriscv__mmachine__@MACHINE_NAME@_a-trap.o `test -f 'src/trap.S' || echo '$(srcdir)/'`src/trap.S
+@am__fastdepCCAS_TRUE@	$(AM_V_at)$(am__mv) src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-trap.Tpo src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-trap.Po
+@AMDEP_TRUE@@am__fastdepCCAS_FALSE@	$(AM_V_CPPAS)source='src/trap.S' object='src/libriscv__mmachine__@MACHINE_NAME@_a-trap.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCCAS_FALSE@	DEPDIR=$(DEPDIR) $(CCASDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCCAS_FALSE@	$(AM_V_CPPAS@am__nodep@)$(CCAS) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libriscv__mmachine__@MACHINE_NAME@_a_CCASFLAGS) $(CCASFLAGS) -c -o src/libriscv__mmachine__@MACHINE_NAME@_a-trap.o `test -f 'src/trap.S' || echo '$(srcdir)/'`src/trap.S
+
+src/libriscv__mmachine__@MACHINE_NAME@_a-trap.obj: src/trap.S
+@am__fastdepCCAS_TRUE@	$(AM_V_CPPAS)$(CCAS) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libriscv__mmachine__@MACHINE_NAME@_a_CCASFLAGS) $(CCASFLAGS) -MT src/libriscv__mmachine__@MACHINE_NAME@_a-trap.obj -MD -MP -MF src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-trap.Tpo -c -o src/libriscv__mmachine__@MACHINE_NAME@_a-trap.obj `if test -f 'src/trap.S'; then $(CYGPATH_W) 'src/trap.S'; else $(CYGPATH_W) '$(srcdir)/src/trap.S'; fi`
+@am__fastdepCCAS_TRUE@	$(AM_V_at)$(am__mv) src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-trap.Tpo src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-trap.Po
+@AMDEP_TRUE@@am__fastdepCCAS_FALSE@	$(AM_V_CPPAS)source='src/trap.S' object='src/libriscv__mmachine__@MACHINE_NAME@_a-trap.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCCAS_FALSE@	DEPDIR=$(DEPDIR) $(CCASDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCCAS_FALSE@	$(AM_V_CPPAS@am__nodep@)$(CCAS) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libriscv__mmachine__@MACHINE_NAME@_a_CCASFLAGS) $(CCASFLAGS) -c -o src/libriscv__mmachine__@MACHINE_NAME@_a-trap.obj `if test -f 'src/trap.S'; then $(CYGPATH_W) 'src/trap.S'; else $(CYGPATH_W) '$(srcdir)/src/trap.S'; fi`
 
 .c.o:
 @am__fastdepCC_TRUE@	$(AM_V_CC)depbase=`echo $@ | sed 's|[^/]*$$|$(DEPDIR)/&|;s|\.o$$||'`;\
@@ -1319,6 +1344,20 @@ src/libriscv__mmachine__@MACHINE_NAME@_a-led.obj: src/led.c
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/led.c' object='src/libriscv__mmachine__@MACHINE_NAME@_a-led.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libriscv__mmachine__@MACHINE_NAME@_a_CFLAGS) $(CFLAGS) -c -o src/libriscv__mmachine__@MACHINE_NAME@_a-led.obj `if test -f 'src/led.c'; then $(CYGPATH_W) 'src/led.c'; else $(CYGPATH_W) '$(srcdir)/src/led.c'; fi`
+
+src/libriscv__mmachine__@MACHINE_NAME@_a-lock.o: src/lock.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libriscv__mmachine__@MACHINE_NAME@_a_CFLAGS) $(CFLAGS) -MT src/libriscv__mmachine__@MACHINE_NAME@_a-lock.o -MD -MP -MF src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-lock.Tpo -c -o src/libriscv__mmachine__@MACHINE_NAME@_a-lock.o `test -f 'src/lock.c' || echo '$(srcdir)/'`src/lock.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-lock.Tpo src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-lock.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/lock.c' object='src/libriscv__mmachine__@MACHINE_NAME@_a-lock.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libriscv__mmachine__@MACHINE_NAME@_a_CFLAGS) $(CFLAGS) -c -o src/libriscv__mmachine__@MACHINE_NAME@_a-lock.o `test -f 'src/lock.c' || echo '$(srcdir)/'`src/lock.c
+
+src/libriscv__mmachine__@MACHINE_NAME@_a-lock.obj: src/lock.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libriscv__mmachine__@MACHINE_NAME@_a_CFLAGS) $(CFLAGS) -MT src/libriscv__mmachine__@MACHINE_NAME@_a-lock.obj -MD -MP -MF src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-lock.Tpo -c -o src/libriscv__mmachine__@MACHINE_NAME@_a-lock.obj `if test -f 'src/lock.c'; then $(CYGPATH_W) 'src/lock.c'; else $(CYGPATH_W) '$(srcdir)/src/lock.c'; fi`
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-lock.Tpo src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-lock.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/lock.c' object='src/libriscv__mmachine__@MACHINE_NAME@_a-lock.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libriscv__mmachine__@MACHINE_NAME@_a_CFLAGS) $(CFLAGS) -c -o src/libriscv__mmachine__@MACHINE_NAME@_a-lock.obj `if test -f 'src/lock.c'; then $(CYGPATH_W) 'src/lock.c'; else $(CYGPATH_W) '$(srcdir)/src/lock.c'; fi`
 
 src/libriscv__mmachine__@MACHINE_NAME@_a-memory.o: src/memory.c
 @am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libriscv__mmachine__@MACHINE_NAME@_a_CFLAGS) $(CFLAGS) -MT src/libriscv__mmachine__@MACHINE_NAME@_a-memory.o -MD -MP -MF src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-memory.Tpo -c -o src/libriscv__mmachine__@MACHINE_NAME@_a-memory.o `test -f 'src/memory.c' || echo '$(srcdir)/'`src/memory.c

--- a/doc/sphinx/apiref/lock.rst
+++ b/doc/sphinx/apiref/lock.rst
@@ -1,0 +1,6 @@
+Locks
+=======
+
+.. doxygenfile:: metal/lock.h
+   :project: metal
+

--- a/metal/compiler.h
+++ b/metal/compiler.h
@@ -15,4 +15,6 @@
 #define __METAL_SET_FIELD(reg, mask, val) \
         (((reg) & ~(mask)) | (((val) * ((mask) & ~((mask) << 1))) & (mask)))
 
+void _metal_trap(int ecode);
+
 #endif

--- a/metal/lock.h
+++ b/metal/lock.h
@@ -35,7 +35,7 @@ struct metal_lock {
  * If the lock cannot be initialized, attempts to take or give the lock
  * will result in a Store/AMO access fault.
  */
-int metal_lock_init(struct metal_lock *lock);
+inline int metal_lock_init(struct metal_lock *lock);
 
 /*!
  * @brief Take a lock
@@ -45,7 +45,7 @@ int metal_lock_init(struct metal_lock *lock);
  * If the lock initialization failed, attempts to take a lock will result in
  * a Store/AMO access fault.
  */
-int metal_lock_take(struct metal_lock *lock);
+inline int metal_lock_take(struct metal_lock *lock);
 
 /*!
  * @brief Give back a held lock
@@ -55,6 +55,6 @@ int metal_lock_take(struct metal_lock *lock);
  * If the lock initialization failed, attempts to give a lock will result in
  * a Store/AMO access fault.
  */
-int metal_lock_give(struct metal_lock *lock);
+inline int metal_lock_give(struct metal_lock *lock);
 
 #endif /* METAL__LOCK_H */

--- a/metal/lock.h
+++ b/metal/lock.h
@@ -1,0 +1,60 @@
+/* Copyright 2019 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef METAL__LOCK_H
+#define METAL__LOCK_H
+
+/*!
+ * @file lock.h
+ * @brief An API for creating and using a software lock/mutex
+ */
+
+/*!
+ * @def METAL_LOCK_DECLARE
+ * @brief Declare a lock
+ *
+ * Locks must be declared with METAL_LOCK_DECLARE to ensure that the lock
+ * is linked into a memory region which supports atomic memory operations.
+ */
+#define METAL_LOCK_DECLARE(name) \
+		__attribute__((section(".data.locks"))) \
+		struct metal_lock name
+
+/*!
+ * @brief A handle for a lock
+ */
+struct metal_lock {
+	int _state;
+};
+
+/*!
+ * @brief Initialize a lock
+ * @param lock The handle for a lock
+ * @return 0 if the lock is successfully initialized. A non-zero code indicates failure.
+ *
+ * If the lock cannot be initialized, attempts to take or give the lock
+ * will result in a Store/AMO access fault.
+ */
+int metal_lock_init(struct metal_lock *lock);
+
+/*!
+ * @brief Take a lock
+ * @param lock The handle for a lock
+ * @return 0 if the lock is successfully taken
+ *
+ * If the lock initialization failed, attempts to take a lock will result in
+ * a Store/AMO access fault.
+ */
+int metal_lock_take(struct metal_lock *lock);
+
+/*!
+ * @brief Give back a held lock
+ * @param lock The handle for a lock
+ * @return 0 if the lock is successfully given
+ *
+ * If the lock initialization failed, attempts to give a lock will result in
+ * a Store/AMO access fault.
+ */
+int metal_lock_give(struct metal_lock *lock);
+
+#endif /* METAL__LOCK_H */

--- a/src/lock.c
+++ b/src/lock.c
@@ -1,0 +1,63 @@
+/* Copyright 2019 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include <metal/lock.h>
+#include <metal/compiler.h>
+
+#define METAL_STORE_AMO_ACCESS_FAULT 7
+
+inline int metal_lock_init(struct metal_lock *lock) {
+#ifdef __riscv_atomic
+    lock->_state = 0;
+
+    return 0;
+#else
+    return 1;
+#endif
+}
+
+inline int metal_lock_take(struct metal_lock *lock) {
+#ifdef __riscv_atomic
+    int old = 1;
+    int new = 1;
+
+    while(old != 0) {
+        __asm__ volatile("amoswap.w.aq %[old], %[new], (%[state])"
+                         : [old] "=r" (old)
+                         : [new] "r" (new), [state] "r" (&(lock->_state))
+                         : "memory");
+    }
+
+    return 0;
+#else
+    /* Store the memory address in mtval like a normal store/amo access fault */
+    __asm__ ("csrw mtval, %[state]"
+             :: [state] "r" (&(lock->_state)));
+
+    /* Trigger a Store/AMO access fault */
+    _metal_trap(METAL_STORE_AMO_ACCESS_FAULT);
+
+    /* If execution returns, indicate failure */
+    return 1;
+#endif
+}
+
+inline int metal_lock_give(struct metal_lock *lock) {
+#ifdef __riscv_atomic
+    __asm__ volatile("amoswap.w.rl x0, x0, (%[state])"
+                     :: [state] "r" (&(lock->_state))
+                     : "memory");
+
+    return 0;
+#else
+    /* Store the memory address in mtval like a normal store/amo access fault */
+    __asm__ ("csrw mtval, %[state]"
+             :: [state] "r" (&(lock->_state)));
+
+    /* Trigger a Store/AMO access fault */
+    _metal_trap(METAL_STORE_AMO_ACCESS_FAULT);
+
+    /* If execution returns, indicate failure */
+    return 1;
+#endif
+}

--- a/src/trap.S
+++ b/src/trap.S
@@ -1,0 +1,53 @@
+/* Copyright 2019 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#define METAL_MSTATUS_MIE_SHIFT 8
+#define METAL_MSTATUS_MPP_M     3
+#define METAL_MSTATUS_MPP_SHIFT 11
+
+#define METAL_MTVEC_MODE_MASK   3
+
+/* void _metal_trap(int ecode)
+ *
+ * Trigger a machine-mode trap with exception code ecode
+ */
+.global _metal_trap
+.type _metal_trap, @function
+
+_metal_trap:
+
+    /* Store the instruction which called _metal_trap in mepc */
+    addi t0, ra, -1
+    csrw mepc, t0
+
+    /* Set mcause to the desired exception code */
+    csrw mcause, a0
+
+    /* Read mstatus */
+    csrr t0, mstatus
+
+    /* Set MIE=0 */
+    li t1, -1
+    xori t1, t1, METAL_MSTATUS_MIE_SHIFT
+    and t0, t0, t1
+
+    /* Set MPP=M */
+    li t1, METAL_MSTATUS_MPP_M
+    slli t1, t1, METAL_MSTATUS_MPP_SHIFT
+    or t0, t0, t1
+
+    /* Write mstatus */
+    csrw mstatus, t0
+
+    /* Read mtvec */
+    csrr t0, mtvec
+
+    /*
+     * Mask the mtvec MODE bits
+     * Exceptions always jump to mtvec.BASE regradless of the vectoring mode.
+     */
+    andi t0, t0, METAL_MTVEC_MODE_MASK
+
+    /* Jump to mtvec */
+    jr t0
+


### PR DESCRIPTION
@palmer-dabbelt  This will fail to compile on targets without the atomic extension with an error like:

```
freedom-e-sdk/freedom-metal/src/lock.c: Assembler messages:
freedom-e-sdk/freedom-metal/src/lock.c:18: Error: unrecognized opcode `amoswap.w.aq a5,a5,(a4)'
freedom-e-sdk/freedom-metal/src/lock.c:29: Error: unrecognized opcode `amoswap.w.rl x0,x0,(a5)'
```

What do you think is the correct solution here? If there's a way to detect the arch with the preprocessor that would probably be ideal.

Closes #76 