### PR TITLE
Make crt0.S compatible with RV32E

### DIFF
--- a/gloss/crt0.S
+++ b/gloss/crt0.S
@@ -71,9 +71,9 @@ _start:
   bge t1, t2, 2f
 
 1:
-  lw   t3, 0(t0)
+  lw   a0, 0(t0)
   addi t0, t0, 4
-  sw   t3, 0(t1)
+  sw   a0, 0(t1)
   addi t1, t1, 4
   blt  t1, t2, 1b
 2:
@@ -87,9 +87,9 @@ _start:
   bge t1, t2, 2f
 
 1:
-  lw   t3, 0(t0)
+  lw   a0, 0(t0)
   addi t0, t0, 4
-  sw   t3, 0(t1)
+  sw   a0, 0(t1)
   addi t1, t1, 4
   blt  t1, t2, 1b
 2:


### PR DESCRIPTION
Replaces the t3 register with a0 so that crt0.S is compatible with both
the I and E base integer ISA.