### PR TITLE
Multicore Support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -70,6 +70,7 @@ endif # PRECONFIGURED
 nobase_include_HEADERS = \
 	metal/machine/@MACHINE_NAME@.h \
 	metal/drivers/fixed-clock.h \
+	metal/drivers/fixed-factor-clock.h \
 	metal/drivers/riscv,clint0.h \
 	metal/drivers/riscv,cpu.h \
 	metal/drivers/riscv,plic0.h \
@@ -138,6 +139,7 @@ libriscv__mmachine__@MACHINE_NAME@_a_CCASFLAGS = @MENV_METAL@ @MMACHINE_MACHINE_
 
 libriscv__mmachine__@MACHINE_NAME@_a_SOURCES = \
 	src/drivers/fixed-clock.c \
+	src/drivers/fixed-factor-clock.c \
 	src/drivers/riscv,clint0.c \
 	src/drivers/riscv,cpu.c \
 	src/drivers/riscv,plic0.c \

--- a/Makefile.in
+++ b/Makefile.in
@@ -200,6 +200,7 @@ libriscv__menv__metal_a_OBJECTS =  \
 libriscv__mmachine__@MACHINE_NAME@_a_AR = $(AR) $(ARFLAGS)
 libriscv__mmachine__@MACHINE_NAME@_a_LIBADD =
 am_libriscv__mmachine__@MACHINE_NAME@_a_OBJECTS = src/drivers/libriscv__mmachine__@MACHINE_NAME@_a-fixed-clock.$(OBJEXT) \
+	src/drivers/libriscv__mmachine__@MACHINE_NAME@_a-fixed-factor-clock.$(OBJEXT) \
 	src/drivers/libriscv__mmachine__@MACHINE_NAME@_a-riscv,clint0.$(OBJEXT) \
 	src/drivers/libriscv__mmachine__@MACHINE_NAME@_a-riscv,cpu.$(OBJEXT) \
 	src/drivers/libriscv__mmachine__@MACHINE_NAME@_a-riscv,plic0.$(OBJEXT) \
@@ -462,6 +463,7 @@ spec_DATA = riscv__mmachine__@MACHINE_NAME@.specs \
 nobase_include_HEADERS = \
 	metal/machine/@MACHINE_NAME@.h \
 	metal/drivers/fixed-clock.h \
+	metal/drivers/fixed-factor-clock.h \
 	metal/drivers/riscv,clint0.h \
 	metal/drivers/riscv,cpu.h \
 	metal/drivers/riscv,plic0.h \
@@ -510,6 +512,7 @@ libriscv__mmachine__@MACHINE_NAME@_a_CFLAGS = @MENV_METAL@ @MMACHINE_MACHINE_NAM
 libriscv__mmachine__@MACHINE_NAME@_a_CCASFLAGS = @MENV_METAL@ @MMACHINE_MACHINE_NAME@
 libriscv__mmachine__@MACHINE_NAME@_a_SOURCES = \
 	src/drivers/fixed-clock.c \
+	src/drivers/fixed-factor-clock.c \
 	src/drivers/riscv,clint0.c \
 	src/drivers/riscv,cpu.c \
 	src/drivers/riscv,plic0.c \
@@ -743,6 +746,9 @@ src/drivers/$(DEPDIR)/$(am__dirstamp):
 src/drivers/libriscv__mmachine__@MACHINE_NAME@_a-fixed-clock.$(OBJEXT):  \
 	src/drivers/$(am__dirstamp) \
 	src/drivers/$(DEPDIR)/$(am__dirstamp)
+src/drivers/libriscv__mmachine__@MACHINE_NAME@_a-fixed-factor-clock.$(OBJEXT):  \
+	src/drivers/$(am__dirstamp) \
+	src/drivers/$(DEPDIR)/$(am__dirstamp)
 src/drivers/libriscv__mmachine__@MACHINE_NAME@_a-riscv,clint0.$(OBJEXT):  \
 	src/drivers/$(am__dirstamp) \
 	src/drivers/$(DEPDIR)/$(am__dirstamp)
@@ -928,6 +934,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-tty.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-uart.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/drivers/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-fixed-clock.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/drivers/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-fixed-factor-clock.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/drivers/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-riscv,clint0.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/drivers/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-riscv,cpu.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/drivers/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-riscv,plic0.Po@am__quote@
@@ -1022,6 +1029,20 @@ src/drivers/libriscv__mmachine__@MACHINE_NAME@_a-fixed-clock.obj: src/drivers/fi
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/drivers/fixed-clock.c' object='src/drivers/libriscv__mmachine__@MACHINE_NAME@_a-fixed-clock.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libriscv__mmachine__@MACHINE_NAME@_a_CFLAGS) $(CFLAGS) -c -o src/drivers/libriscv__mmachine__@MACHINE_NAME@_a-fixed-clock.obj `if test -f 'src/drivers/fixed-clock.c'; then $(CYGPATH_W) 'src/drivers/fixed-clock.c'; else $(CYGPATH_W) '$(srcdir)/src/drivers/fixed-clock.c'; fi`
+
+src/drivers/libriscv__mmachine__@MACHINE_NAME@_a-fixed-factor-clock.o: src/drivers/fixed-factor-clock.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libriscv__mmachine__@MACHINE_NAME@_a_CFLAGS) $(CFLAGS) -MT src/drivers/libriscv__mmachine__@MACHINE_NAME@_a-fixed-factor-clock.o -MD -MP -MF src/drivers/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-fixed-factor-clock.Tpo -c -o src/drivers/libriscv__mmachine__@MACHINE_NAME@_a-fixed-factor-clock.o `test -f 'src/drivers/fixed-factor-clock.c' || echo '$(srcdir)/'`src/drivers/fixed-factor-clock.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/drivers/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-fixed-factor-clock.Tpo src/drivers/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-fixed-factor-clock.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/drivers/fixed-factor-clock.c' object='src/drivers/libriscv__mmachine__@MACHINE_NAME@_a-fixed-factor-clock.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libriscv__mmachine__@MACHINE_NAME@_a_CFLAGS) $(CFLAGS) -c -o src/drivers/libriscv__mmachine__@MACHINE_NAME@_a-fixed-factor-clock.o `test -f 'src/drivers/fixed-factor-clock.c' || echo '$(srcdir)/'`src/drivers/fixed-factor-clock.c
+
+src/drivers/libriscv__mmachine__@MACHINE_NAME@_a-fixed-factor-clock.obj: src/drivers/fixed-factor-clock.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libriscv__mmachine__@MACHINE_NAME@_a_CFLAGS) $(CFLAGS) -MT src/drivers/libriscv__mmachine__@MACHINE_NAME@_a-fixed-factor-clock.obj -MD -MP -MF src/drivers/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-fixed-factor-clock.Tpo -c -o src/drivers/libriscv__mmachine__@MACHINE_NAME@_a-fixed-factor-clock.obj `if test -f 'src/drivers/fixed-factor-clock.c'; then $(CYGPATH_W) 'src/drivers/fixed-factor-clock.c'; else $(CYGPATH_W) '$(srcdir)/src/drivers/fixed-factor-clock.c'; fi`
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/drivers/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-fixed-factor-clock.Tpo src/drivers/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-fixed-factor-clock.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/drivers/fixed-factor-clock.c' object='src/drivers/libriscv__mmachine__@MACHINE_NAME@_a-fixed-factor-clock.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libriscv__mmachine__@MACHINE_NAME@_a_CFLAGS) $(CFLAGS) -c -o src/drivers/libriscv__mmachine__@MACHINE_NAME@_a-fixed-factor-clock.obj `if test -f 'src/drivers/fixed-factor-clock.c'; then $(CYGPATH_W) 'src/drivers/fixed-factor-clock.c'; else $(CYGPATH_W) '$(srcdir)/src/drivers/fixed-factor-clock.c'; fi`
 
 src/drivers/libriscv__mmachine__@MACHINE_NAME@_a-riscv,clint0.o: src/drivers/riscv,clint0.c
 @am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libriscv__mmachine__@MACHINE_NAME@_a_CFLAGS) $(CFLAGS) -MT src/drivers/libriscv__mmachine__@MACHINE_NAME@_a-riscv,clint0.o -MD -MP -MF src/drivers/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-riscv,clint0.Tpo -c -o src/drivers/libriscv__mmachine__@MACHINE_NAME@_a-riscv,clint0.o `test -f 'src/drivers/riscv,clint0.c' || echo '$(srcdir)/'`src/drivers/riscv,clint0.c

--- a/gloss/crt0.S
+++ b/gloss/crt0.S
@@ -48,13 +48,21 @@ _start:
    * to define its own stack pointer.  We also align the stack pointer here
    * because the only RISC-V ABI that's currently defined mandates 16-byte
    * stack alignment. */
-  la sp, metal_segment_stack_end
+  la sp, _sp
+
+  /* Increment by hartid number of stack sizes */
+  li t0, 0
+  la t1, __stack_size
+1:
+  beq t0, a0, 1f
+  add sp, sp, t1
+  addi t0, t0, 1
+  j 1b
+1:
   andi sp, sp, -16
 
-  /* For now we only run on single-hart systems and assume that we're always on
-   * hart 0. */
-1:
-  bnez a0, 1b
+  /* If we're not hart 0, skip the initialization work */
+  bnez a0, _skip_init
 
   /* Embedded systems frequently require relocating the data segment before C
    * code can be run -- for example, the data segment may exist in flash upon
@@ -118,6 +126,8 @@ _start:
   call atexit
   call __libc_init_array
 
+_skip_init:
+
   /* Check RISC-V isa and enable FS bits if Floating Point architecture. */
   csrr a5, misa
   li   a4, 0x10028
@@ -135,7 +145,7 @@ _start:
   li a0, 1     /* argc=1 */
   la a1, argv  /* argv = {"libgloss", NULL} */
   la a2, envp  /* envp = {NULL} */
-  call main
+  call secondary_main
 
   /* Call exit to handle libc's cleanup routines.  Under normal contains this
    * shouldn't even get called, but I'm still not using a tail call here
@@ -163,6 +173,34 @@ _fini:
 .size _init, .-_init
 .size _fini, .-_fini
 
+/* By default, secondary_main will cause secondary harts to spin forever.
+ * Users can redefine secondary_main themselves to run code on secondary harts */
+.weak   secondary_main
+.global secondary_main
+.type   secondary_main, @function
+
+secondary_main:
+  addi sp, sp, -16
+#if __riscv_xlen == 32
+  sw ra, 4(sp)
+#else
+  sd ra, 8(sp)
+#endif
+  csrr t0, mhartid
+  beqz t0, 2f
+1:
+  wfi
+  j 1b
+2:
+  call main
+#if __riscv_xlen == 32
+  lw ra, 4(sp)
+#else
+  ld ra, 8(sp)
+#endif
+  addi sp, sp, 16
+  ret
+
 /* This shim allows main() to be passed a set of arguments that can satisfy the
  * requirements of the C API. */
 .section .rodata.libgloss.start
@@ -172,3 +210,4 @@ envp:
 .dc.a 0
 name:
 .asciz "libgloss"
+

--- a/metal/cpu.h
+++ b/metal/cpu.h
@@ -51,6 +51,16 @@ struct metal_cpu {
  */
 struct metal_cpu* metal_cpu_get(int hartid);
 
+/*! @brief Get the hartid of the CPU hart executing this function
+ *
+ * @return The hartid of the current CPU hart */
+int metal_cpu_get_current_hartid();
+
+/*! @brief Get the number of CPU harts
+ * 
+ * @return The number of CPU harts */
+int metal_cpu_get_num_harts();
+
 /*! @brief Get the CPU cycle count timer value
  *
  * Get the value of the cycle count timer for a given CPU

--- a/metal/drivers/fixed-factor-clock.h
+++ b/metal/drivers/fixed-factor-clock.h
@@ -1,0 +1,32 @@
+/* Copyright 2018 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef METAL__DRIVERS__FIXED_FACTOR_CLOCK_H
+#define METAL__DRIVERS__FIXED_FACTOR_CLOCK_H
+
+struct __metal_driver_fixed_factor_clock;
+
+#include <metal/compiler.h>
+#include <metal/clock.h>
+
+struct __metal_driver_vtable_fixed_factor_clock {
+    struct __metal_clock_vtable clock;
+};
+
+long __metal_driver_fixed_factor_clock_get_rate_hz(const struct metal_clock *gclk);
+long __metal_driver_fixed_factor_clock_set_rate_hz(struct metal_clock *gclk, long target_hz);
+
+__METAL_DECLARE_VTABLE(__metal_driver_vtable_fixed_factor_clock) = {
+    .clock.get_rate_hz = __metal_driver_fixed_factor_clock_get_rate_hz,
+    .clock.set_rate_hz = __metal_driver_fixed_factor_clock_set_rate_hz,
+};
+
+struct __metal_driver_fixed_factor_clock {
+    struct metal_clock clock;
+    const struct __metal_driver_vtable_fixed_factor_clock *vtable;
+    struct metal_clock *parent;
+    long mult;
+    long div;
+};
+
+#endif

--- a/metal/drivers/riscv,clint0.h
+++ b/metal/drivers/riscv,clint0.h
@@ -32,15 +32,18 @@ __METAL_DECLARE_VTABLE(__metal_driver_vtable_riscv_clint0) = {
     .clint_vtable.command_request    = __metal_driver_riscv_clint0_command_request,
 };
 
+#define __METAL_MACHINE_MACROS
+#include <metal/machine.h>
 struct __metal_driver_riscv_clint0 {
     struct metal_interrupt controller;
     const struct __metal_driver_vtable_riscv_clint0 *vtable;
     const unsigned long control_base;
     const unsigned long control_size;
     int init_done;
-    struct metal_interrupt *interrupt_parent;
+    struct metal_interrupt *interrupt_parents[__METAL_CLINT_NUM_PARENTS];
+    const int interrupt_lines[__METAL_CLINT_NUM_PARENTS];
     const int num_interrupts;
-    const int interrupt_lines[];
 };
+#undef __METAL_MACHINE_MACROS
 
 #endif

--- a/metal/drivers/riscv,plic0.h
+++ b/metal/drivers/riscv,plic0.h
@@ -33,8 +33,8 @@ struct __metal_driver_riscv_plic0 {
     const struct __metal_driver_vtable_riscv_plic0 *vtable;
     const unsigned long control_base;
     const unsigned long control_size;
-    struct metal_interrupt *interrupt_parent;
-    const int interrupt_line;
+    struct metal_interrupt *interrupt_parents[__METAL_PLIC_NUM_PARENTS];
+    const int interrupt_lines[__METAL_PLIC_NUM_PARENTS];
     int max_priority;
     int num_interrupts;
     int init_done;

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -12,6 +12,20 @@ struct metal_cpu* metal_cpu_get(int hartid)
     return NULL;
 }
 
+int metal_cpu_get_current_hartid()
+{
+#ifdef __riscv
+    int mhartid;
+    asm volatile("csrr %0, mhartid" : "=r" (mhartid));
+    return mhartid;
+#endif
+}
+
+int metal_cpu_get_num_harts()
+{
+    return __METAL_DT_MAX_HARTS;
+}
+
 extern inline unsigned long long metal_cpu_get_timer(struct metal_cpu *cpu);
 
 extern inline unsigned long long metal_cpu_get_timebase(struct metal_cpu *cpu);

--- a/src/drivers/fixed-factor-clock.c
+++ b/src/drivers/fixed-factor-clock.c
@@ -1,0 +1,22 @@
+/* Copyright 2018 SiFive, Inc. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include <metal/drivers/fixed-factor-clock.h>
+#include <stddef.h>
+
+long __metal_driver_fixed_factor_clock_get_rate_hz(const struct metal_clock *gclk)
+{
+    const struct __metal_driver_fixed_factor_clock *clk = (void *)gclk;
+
+    long parent_rate = 1;
+    if(clk->parent) {
+        parent_rate = clk->parent->vtable->get_rate_hz(clk->parent);
+    }
+
+    return clk->mult * parent_rate / clk->div;
+}
+
+long __metal_driver_fixed_factor_clock_set_rate_hz(struct metal_clock *gclk, long target_hz)
+{
+    return __metal_driver_fixed_factor_clock_get_rate_hz(gclk);
+}


### PR DESCRIPTION
Depends on #77 and #56

PR contains:
- crt0 defines a weak `secondary_main` which can be redefined by the user to startup secondary harts
- PLIC and CLINT modified to support multiple parent interrupt controllers
- A driver for fixed-factor-clock (Used in the HiFive Unleashed)
- A public API for querying the current hartid and the total number of harts