### PR TITLE
Fix inlining of Metal Lock API

### DIFF
--- a/metal/lock.h
+++ b/metal/lock.h
@@ -4,10 +4,16 @@
 #ifndef METAL__LOCK_H
 #define METAL__LOCK_H
 
+#include <metal/memory.h>
+#include <metal/compiler.h>
+
 /*!
  * @file lock.h
  * @brief An API for creating and using a software lock/mutex
  */
+
+/* TODO: How can we make the exception code platform-independant? */
+#define _METAL_STORE_AMO_ACCESS_FAULT 7
 
 /*!
  * @def METAL_LOCK_DECLARE
@@ -35,7 +41,26 @@ struct metal_lock {
  * If the lock cannot be initialized, attempts to take or give the lock
  * will result in a Store/AMO access fault.
  */
-inline int metal_lock_init(struct metal_lock *lock);
+inline int metal_lock_init(struct metal_lock *lock) {
+#ifdef __riscv_atomic
+    /* Get a handle for the memory which holds the lock state */
+    struct metal_memory *lock_mem = metal_get_memory_from_address((uintptr_t) &(lock->_state));
+    if(!lock_mem) {
+        return 1;
+    }
+
+    /* If the memory doesn't support atomics, report an error */
+    if(!metal_memory_supports_atomics(lock_mem)) {
+        return 2;
+    }
+
+    lock->_state = 0;
+
+    return 0;
+#else
+    return 3;
+#endif
+}
 
 /*!
  * @brief Take a lock
@@ -45,7 +70,31 @@ inline int metal_lock_init(struct metal_lock *lock);
  * If the lock initialization failed, attempts to take a lock will result in
  * a Store/AMO access fault.
  */
-inline int metal_lock_take(struct metal_lock *lock);
+inline int metal_lock_take(struct metal_lock *lock) {
+#ifdef __riscv_atomic
+    int old = 1;
+    int new = 1;
+
+    while(old != 0) {
+        __asm__ volatile("amoswap.w.aq %[old], %[new], (%[state])"
+                         : [old] "=r" (old)
+                         : [new] "r" (new), [state] "r" (&(lock->_state))
+                         : "memory");
+    }
+
+    return 0;
+#else
+    /* Store the memory address in mtval like a normal store/amo access fault */
+    __asm__ ("csrw mtval, %[state]"
+             :: [state] "r" (&(lock->_state)));
+
+    /* Trigger a Store/AMO access fault */
+    _metal_trap(_METAL_STORE_AMO_ACCESS_FAULT);
+
+    /* If execution returns, indicate failure */
+    return 1;
+#endif
+}
 
 /*!
  * @brief Give back a held lock
@@ -55,6 +104,24 @@ inline int metal_lock_take(struct metal_lock *lock);
  * If the lock initialization failed, attempts to give a lock will result in
  * a Store/AMO access fault.
  */
-inline int metal_lock_give(struct metal_lock *lock);
+inline int metal_lock_give(struct metal_lock *lock) {
+#ifdef __riscv_atomic
+    __asm__ volatile("amoswap.w.rl x0, x0, (%[state])"
+                     :: [state] "r" (&(lock->_state))
+                     : "memory");
+
+    return 0;
+#else
+    /* Store the memory address in mtval like a normal store/amo access fault */
+    __asm__ ("csrw mtval, %[state]"
+             :: [state] "r" (&(lock->_state)));
+
+    /* Trigger a Store/AMO access fault */
+    _metal_trap(_METAL_STORE_AMO_ACCESS_FAULT);
+
+    /* If execution returns, indicate failure */
+    return 1;
+#endif
+}
 
 #endif /* METAL__LOCK_H */

--- a/src/lock.c
+++ b/src/lock.c
@@ -2,74 +2,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 #include <metal/lock.h>
-#include <metal/memory.h>
-#include <metal/compiler.h>
 
-#define METAL_STORE_AMO_ACCESS_FAULT 7
-
-inline int metal_lock_init(struct metal_lock *lock) {
-#ifdef __riscv_atomic
-    /* Get a handle for the memory which holds the lock state */
-    struct metal_memory *lock_mem = metal_get_memory_from_address((uintptr_t) &(lock->_state));
-    if(!lock_mem) {
-        return 1;
-    }
-
-    /* If the memory doesn't support atomics, report an error */
-    if(!metal_memory_supports_atomics(lock_mem)) {
-        return 2;
-    }
-
-    lock->_state = 0;
-
-    return 0;
-#else
-    return 3;
-#endif
-}
-
-inline int metal_lock_take(struct metal_lock *lock) {
-#ifdef __riscv_atomic
-    int old = 1;
-    int new = 1;
-
-    while(old != 0) {
-        __asm__ volatile("amoswap.w.aq %[old], %[new], (%[state])"
-                         : [old] "=r" (old)
-                         : [new] "r" (new), [state] "r" (&(lock->_state))
-                         : "memory");
-    }
-
-    return 0;
-#else
-    /* Store the memory address in mtval like a normal store/amo access fault */
-    __asm__ ("csrw mtval, %[state]"
-             :: [state] "r" (&(lock->_state)));
-
-    /* Trigger a Store/AMO access fault */
-    _metal_trap(METAL_STORE_AMO_ACCESS_FAULT);
-
-    /* If execution returns, indicate failure */
-    return 1;
-#endif
-}
-
-inline int metal_lock_give(struct metal_lock *lock) {
-#ifdef __riscv_atomic
-    __asm__ volatile("amoswap.w.rl x0, x0, (%[state])"
-                     :: [state] "r" (&(lock->_state))
-                     : "memory");
-
-    return 0;
-#else
-    /* Store the memory address in mtval like a normal store/amo access fault */
-    __asm__ ("csrw mtval, %[state]"
-             :: [state] "r" (&(lock->_state)));
-
-    /* Trigger a Store/AMO access fault */
-    _metal_trap(METAL_STORE_AMO_ACCESS_FAULT);
-
-    /* If execution returns, indicate failure */
-    return 1;
-#endif
-}
+extern inline int metal_lock_init(struct metal_lock *lock);
+extern inline int metal_lock_take(struct metal_lock *lock);
+extern inline int metal_lock_give(struct metal_lock *lock);


### PR DESCRIPTION
Declaring the functions inline in the header and defining them in the
source file was breaking the linker. Define and declare the functions in
the header and declare them extern inline in the source file.