### PR TITLE
Detect target PMP granularity

### DIFF
--- a/metal/pmp.h
+++ b/metal/pmp.h
@@ -68,6 +68,9 @@ struct metal_pmp {
      * @brief The number of regions in the PMP
      */
     const int num_regions;
+
+    /* The minimum granularity of the PMP region. Set by metal_pmp_init */
+    uintptr_t _granularity;
 };
 
 /*!

--- a/src/pmp.c
+++ b/src/pmp.c
@@ -78,6 +78,11 @@ int metal_pmp_set_region(struct metal_pmp *pmp,
         return 2;
     }
 
+    if(config.A == METAL_PMP_NA4 && pmp->_granularity > 4) {
+        /* The requested granularity is too small */
+        return 3;
+    }
+
     rc = metal_pmp_get_region(pmp, region, &old_config, &old_address);
     if(rc) {
         /* Error reading region */
@@ -86,7 +91,7 @@ int metal_pmp_set_region(struct metal_pmp *pmp,
 
     if(old_config.L == METAL_PMP_LOCKED) {
         /* Cannot modify locked region */
-        return 3;
+        return 4;
     }
 
     /* Update the address first, because if the region is being locked we won't


### PR DESCRIPTION
Detect target PMP granularity at PMP initialization.

Fail attempts to configure PMP regions when the requested granularity is smaller than the supported size.