### PR TITLE
Update metal to use inline functions produce in metal-header

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -73,6 +73,7 @@ nobase_include_HEADERS = \
 	metal/drivers/sifive,spi0.h \
 	metal/drivers/sifive,test0.h \
 	metal/drivers/sifive,uart0.h \
+	metal/machine/inline.h \
 	metal/machine/platform.h \
 	metal/button.h \
 	metal/clock.h \
@@ -85,7 +86,6 @@ nobase_include_HEADERS = \
 	metal/led.h \
 	metal/lock.h \
 	metal/machine.h \
-	metal/machine-inline.h \
 	metal/memory.h \
 	metal/pmp.h \
 	metal/privilege.h \
@@ -101,7 +101,7 @@ metal/machine.h: @MACHINE_HEADER@
 	@mkdir -p $(dir $@)
 	cp $< $@
 
-metal/machine-inline.h: @MACHINE_INLINE@
+metal/machine/inline.h: @MACHINE_INLINE@
 	@mkdir -p $(dir $@)
 	cp $< $@
 
@@ -142,7 +142,7 @@ libriscv__mmachine__@MACHINE_NAME@_a_CCASFLAGS = @MENV_METAL@ @MMACHINE_MACHINE_
 # This will generate these sources before the compilation step
 BUILT_SOURCES = \
 	metal/machine.h \
-	metal/machine-inline.h \
+	metal/machine/inline.h \
 	metal/machine/platform.h \
 	riscv__menv__metal.specs \
 	riscv__mmachine__@MACHINE_NAME@.specs

--- a/Makefile.am
+++ b/Makefile.am
@@ -85,6 +85,7 @@ nobase_include_HEADERS = \
 	metal/led.h \
 	metal/lock.h \
 	metal/machine.h \
+	metal/machine-inline.h \
 	metal/memory.h \
 	metal/pmp.h \
 	metal/privilege.h \
@@ -97,6 +98,10 @@ nobase_include_HEADERS = \
 
 if PRECONFIGURED
 metal/machine.h: @MACHINE_HEADER@
+	@mkdir -p $(dir $@)
+	cp $< $@
+
+metal/machine-inline.h: @MACHINE_INLINE@
 	@mkdir -p $(dir $@)
 	cp $< $@
 
@@ -137,6 +142,7 @@ libriscv__mmachine__@MACHINE_NAME@_a_CCASFLAGS = @MENV_METAL@ @MMACHINE_MACHINE_
 # This will generate these sources before the compilation step
 BUILT_SOURCES = \
 	metal/machine.h \
+	metal/machine-inline.h \
 	metal/machine/platform.h \
 	riscv__menv__metal.specs \
 	riscv__mmachine__@MACHINE_NAME@.specs
@@ -144,6 +150,7 @@ BUILT_SOURCES = \
 libriscv__mmachine__@MACHINE_NAME@_a_SOURCES = \
 	src/drivers/fixed-clock.c \
 	src/drivers/fixed-factor-clock.c \
+	src/drivers/inline.c \
 	src/drivers/riscv,clint0.c \
 	src/drivers/riscv,cpu.c \
 	src/drivers/riscv,plic0.c \

--- a/Makefile.in
+++ b/Makefile.in
@@ -485,6 +485,7 @@ nobase_include_HEADERS = \
 	metal/drivers/sifive,spi0.h \
 	metal/drivers/sifive,test0.h \
 	metal/drivers/sifive,uart0.h \
+	metal/machine/inline.h \
 	metal/machine/platform.h \
 	metal/button.h \
 	metal/clock.h \
@@ -497,7 +498,6 @@ nobase_include_HEADERS = \
 	metal/led.h \
 	metal/lock.h \
 	metal/machine.h \
-	metal/machine-inline.h \
 	metal/memory.h \
 	metal/pmp.h \
 	metal/privilege.h \
@@ -521,7 +521,7 @@ libriscv__mmachine__@MACHINE_NAME@_a_CCASFLAGS = @MENV_METAL@ @MMACHINE_MACHINE_
 # This will generate these sources before the compilation step
 BUILT_SOURCES = \
 	metal/machine.h \
-	metal/machine-inline.h \
+	metal/machine/inline.h \
 	metal/machine/platform.h \
 	riscv__menv__metal.specs \
 	riscv__mmachine__@MACHINE_NAME@.specs
@@ -2056,7 +2056,7 @@ riscv__menv__metal.specs: riscv__menv__metal.specs.in
 @PRECONFIGURED_TRUE@	@mkdir -p $(dir $@)
 @PRECONFIGURED_TRUE@	cp $< $@
 
-@PRECONFIGURED_TRUE@metal/machine-inline.h: @MACHINE_INLINE@
+@PRECONFIGURED_TRUE@metal/machine/inline.h: @MACHINE_INLINE@
 @PRECONFIGURED_TRUE@	@mkdir -p $(dir $@)
 @PRECONFIGURED_TRUE@	cp $< $@
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -201,6 +201,7 @@ libriscv__mmachine__@MACHINE_NAME@_a_AR = $(AR) $(ARFLAGS)
 libriscv__mmachine__@MACHINE_NAME@_a_LIBADD =
 am_libriscv__mmachine__@MACHINE_NAME@_a_OBJECTS = src/drivers/libriscv__mmachine__@MACHINE_NAME@_a-fixed-clock.$(OBJEXT) \
 	src/drivers/libriscv__mmachine__@MACHINE_NAME@_a-fixed-factor-clock.$(OBJEXT) \
+	src/drivers/libriscv__mmachine__@MACHINE_NAME@_a-inline.$(OBJEXT) \
 	src/drivers/libriscv__mmachine__@MACHINE_NAME@_a-riscv,clint0.$(OBJEXT) \
 	src/drivers/libriscv__mmachine__@MACHINE_NAME@_a-riscv,cpu.$(OBJEXT) \
 	src/drivers/libriscv__mmachine__@MACHINE_NAME@_a-riscv,plic0.$(OBJEXT) \
@@ -380,6 +381,7 @@ LIBS = @LIBS@
 LTLIBOBJS = @LTLIBOBJS@
 MACHINE_DTS = @MACHINE_DTS@
 MACHINE_HEADER = @MACHINE_HEADER@
+MACHINE_INLINE = @MACHINE_INLINE@
 MACHINE_LDSCRIPT = @MACHINE_LDSCRIPT@
 MACHINE_NAME = @MACHINE_NAME@
 MAINT = @MAINT@
@@ -495,6 +497,7 @@ nobase_include_HEADERS = \
 	metal/led.h \
 	metal/lock.h \
 	metal/machine.h \
+	metal/machine-inline.h \
 	metal/memory.h \
 	metal/pmp.h \
 	metal/privilege.h \
@@ -518,6 +521,7 @@ libriscv__mmachine__@MACHINE_NAME@_a_CCASFLAGS = @MENV_METAL@ @MMACHINE_MACHINE_
 # This will generate these sources before the compilation step
 BUILT_SOURCES = \
 	metal/machine.h \
+	metal/machine-inline.h \
 	metal/machine/platform.h \
 	riscv__menv__metal.specs \
 	riscv__mmachine__@MACHINE_NAME@.specs
@@ -525,6 +529,7 @@ BUILT_SOURCES = \
 libriscv__mmachine__@MACHINE_NAME@_a_SOURCES = \
 	src/drivers/fixed-clock.c \
 	src/drivers/fixed-factor-clock.c \
+	src/drivers/inline.c \
 	src/drivers/riscv,clint0.c \
 	src/drivers/riscv,cpu.c \
 	src/drivers/riscv,plic0.c \
@@ -763,6 +768,9 @@ src/drivers/libriscv__mmachine__@MACHINE_NAME@_a-fixed-clock.$(OBJEXT):  \
 src/drivers/libriscv__mmachine__@MACHINE_NAME@_a-fixed-factor-clock.$(OBJEXT):  \
 	src/drivers/$(am__dirstamp) \
 	src/drivers/$(DEPDIR)/$(am__dirstamp)
+src/drivers/libriscv__mmachine__@MACHINE_NAME@_a-inline.$(OBJEXT):  \
+	src/drivers/$(am__dirstamp) \
+	src/drivers/$(DEPDIR)/$(am__dirstamp)
 src/drivers/libriscv__mmachine__@MACHINE_NAME@_a-riscv,clint0.$(OBJEXT):  \
 	src/drivers/$(am__dirstamp) \
 	src/drivers/$(DEPDIR)/$(am__dirstamp)
@@ -952,6 +960,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-uart.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/drivers/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-fixed-clock.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/drivers/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-fixed-factor-clock.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/drivers/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-inline.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/drivers/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-riscv,clint0.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/drivers/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-riscv,cpu.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/drivers/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-riscv,plic0.Po@am__quote@
@@ -1060,6 +1069,20 @@ src/drivers/libriscv__mmachine__@MACHINE_NAME@_a-fixed-factor-clock.obj: src/dri
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/drivers/fixed-factor-clock.c' object='src/drivers/libriscv__mmachine__@MACHINE_NAME@_a-fixed-factor-clock.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libriscv__mmachine__@MACHINE_NAME@_a_CFLAGS) $(CFLAGS) -c -o src/drivers/libriscv__mmachine__@MACHINE_NAME@_a-fixed-factor-clock.obj `if test -f 'src/drivers/fixed-factor-clock.c'; then $(CYGPATH_W) 'src/drivers/fixed-factor-clock.c'; else $(CYGPATH_W) '$(srcdir)/src/drivers/fixed-factor-clock.c'; fi`
+
+src/drivers/libriscv__mmachine__@MACHINE_NAME@_a-inline.o: src/drivers/inline.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libriscv__mmachine__@MACHINE_NAME@_a_CFLAGS) $(CFLAGS) -MT src/drivers/libriscv__mmachine__@MACHINE_NAME@_a-inline.o -MD -MP -MF src/drivers/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-inline.Tpo -c -o src/drivers/libriscv__mmachine__@MACHINE_NAME@_a-inline.o `test -f 'src/drivers/inline.c' || echo '$(srcdir)/'`src/drivers/inline.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/drivers/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-inline.Tpo src/drivers/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-inline.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/drivers/inline.c' object='src/drivers/libriscv__mmachine__@MACHINE_NAME@_a-inline.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libriscv__mmachine__@MACHINE_NAME@_a_CFLAGS) $(CFLAGS) -c -o src/drivers/libriscv__mmachine__@MACHINE_NAME@_a-inline.o `test -f 'src/drivers/inline.c' || echo '$(srcdir)/'`src/drivers/inline.c
+
+src/drivers/libriscv__mmachine__@MACHINE_NAME@_a-inline.obj: src/drivers/inline.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libriscv__mmachine__@MACHINE_NAME@_a_CFLAGS) $(CFLAGS) -MT src/drivers/libriscv__mmachine__@MACHINE_NAME@_a-inline.obj -MD -MP -MF src/drivers/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-inline.Tpo -c -o src/drivers/libriscv__mmachine__@MACHINE_NAME@_a-inline.obj `if test -f 'src/drivers/inline.c'; then $(CYGPATH_W) 'src/drivers/inline.c'; else $(CYGPATH_W) '$(srcdir)/src/drivers/inline.c'; fi`
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/drivers/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-inline.Tpo src/drivers/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-inline.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/drivers/inline.c' object='src/drivers/libriscv__mmachine__@MACHINE_NAME@_a-inline.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libriscv__mmachine__@MACHINE_NAME@_a_CFLAGS) $(CFLAGS) -c -o src/drivers/libriscv__mmachine__@MACHINE_NAME@_a-inline.obj `if test -f 'src/drivers/inline.c'; then $(CYGPATH_W) 'src/drivers/inline.c'; else $(CYGPATH_W) '$(srcdir)/src/drivers/inline.c'; fi`
 
 src/drivers/libriscv__mmachine__@MACHINE_NAME@_a-riscv,clint0.o: src/drivers/riscv,clint0.c
 @am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libriscv__mmachine__@MACHINE_NAME@_a_CFLAGS) $(CFLAGS) -MT src/drivers/libriscv__mmachine__@MACHINE_NAME@_a-riscv,clint0.o -MD -MP -MF src/drivers/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-riscv,clint0.Tpo -c -o src/drivers/libriscv__mmachine__@MACHINE_NAME@_a-riscv,clint0.o `test -f 'src/drivers/riscv,clint0.c' || echo '$(srcdir)/'`src/drivers/riscv,clint0.c
@@ -2030,6 +2053,10 @@ riscv__menv__metal.specs: riscv__menv__metal.specs.in
 @PRECONFIGURED_FALSE@	$< --dtb $(filter %.dtb,$^) --output $@
 
 @PRECONFIGURED_TRUE@metal/machine.h: @MACHINE_HEADER@
+@PRECONFIGURED_TRUE@	@mkdir -p $(dir $@)
+@PRECONFIGURED_TRUE@	cp $< $@
+
+@PRECONFIGURED_TRUE@metal/machine-inline.h: @MACHINE_INLINE@
 @PRECONFIGURED_TRUE@	@mkdir -p $(dir $@)
 @PRECONFIGURED_TRUE@	cp $< $@
 

--- a/configure
+++ b/configure
@@ -593,6 +593,7 @@ MMACHINE_MACHINE_NAME
 MACHINE_DTS
 MACHINE_LDSCRIPT
 PLATFORM_HEADER
+MACHINE_INLINE
 MACHINE_HEADER
 PRECONFIGURED_FALSE
 PRECONFIGURED_TRUE
@@ -709,6 +710,7 @@ with_machine_name
 with_preconfigured
 with_builtin_libgloss
 with_machine_header
+with_machine_inline
 with_platform_header
 with_machine_ldscript
 with_machine_dts
@@ -1380,6 +1382,8 @@ Optional Packages:
   --with-bultin-libgloss  Build libgloss along with the METAL
   --with-machine-header=PATH
                           Path to the machine header file
+  --with-machine-inline=PATH
+                          Path to the machine inline file
   --with-platform-header=PATH
                           Path to the platform header file
   --with-machine-ldscript=PATH
@@ -4085,6 +4089,16 @@ fi
 
 
 
+# Check whether --with-machine-inline was given.
+if test "${with_machine_inline+set}" = set; then :
+  withval=$with_machine_inline;
+else
+  with_machine_inline="no"
+
+fi
+
+
+
 # Check whether --with-platform-header was given.
 if test "${with_platform_header+set}" = set; then :
   withval=$with_platform_header;
@@ -4226,6 +4240,17 @@ else
   { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
 $as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
 as_fn_error $? "--with-machine-header is required with the --with-preconfigured option
+See \`config.log' for more details" "$LINENO" 5; }
+
+fi
+
+    if test "x$with_machine_inline" != "xno"; then :
+  MACHINE_INLINE="$with_machine_inline"
+
+else
+  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "--with-machine-inline is required with the --with-preconfigured option
 See \`config.log' for more details" "$LINENO" 5; }
 
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -84,6 +84,12 @@ AC_ARG_WITH([machine-header],
     [with_machine_header="no"]
 )
 
+AC_ARG_WITH([machine-inline],
+    [AS_HELP_STRING([--with-machine-inline=PATH], [Path to the machine inline file])],
+    [],
+    [with_machine_inline="no"]
+)
+
 AC_ARG_WITH([platform-header],
     [AS_HELP_STRING([--with-platform-header=PATH], [Path to the platform header file])],
     [],
@@ -179,6 +185,11 @@ AS_IF([test "x$with_preconfigured" = "xyes"],
     AS_IF([test "x$with_machine_header" != "xno"],
         [AC_SUBST([MACHINE_HEADER], "$with_machine_header")],
         [AC_MSG_FAILURE([--with-machine-header is required with the --with-preconfigured option])]
+    )
+
+    AS_IF([test "x$with_machine_inline" != "xno"],
+        [AC_SUBST([MACHINE_INLINE], "$with_machine_inline")],
+        [AC_MSG_FAILURE([--with-machine-inline is required with the --with-preconfigured option])]
     )
 
     AS_IF([test "x$with_platform_header" != "xno"],

--- a/metal/compiler.h
+++ b/metal/compiler.h
@@ -4,9 +4,11 @@
 #ifndef METAL__COMPILER_H
 #define METAL__COMPILER_H
 
-#define __METAL_DECLARE_VTABLE(type)                        \
-    asm(".weak " #type);                                  \
-    const struct type type                                \
+#define __METAL_DECLARE_VTABLE(type)                      \
+    extern const struct type type;			  
+
+#define __METAL_DEFINE_VTABLE(type)                       \
+    const struct type type                                
 
 #define __METAL_GET_FIELD(reg, mask)                        \
     (((reg) & (mask)) / ((mask) & ~((mask) << 1)))

--- a/metal/drivers/fixed-clock.h
+++ b/metal/drivers/fixed-clock.h
@@ -13,18 +13,10 @@ struct __metal_driver_vtable_fixed_clock {
     struct __metal_clock_vtable clock;
 };
 
-long __metal_driver_fixed_clock_get_rate_hz(const struct metal_clock *gclk);
-long __metal_driver_fixed_clock_set_rate_hz(struct metal_clock *gclk, long target_hz);
-
-__METAL_DECLARE_VTABLE(__metal_driver_vtable_fixed_clock) = {
-    .clock.get_rate_hz = __metal_driver_fixed_clock_get_rate_hz,
-    .clock.set_rate_hz = __metal_driver_fixed_clock_set_rate_hz,
-};
+__METAL_DECLARE_VTABLE(__metal_driver_vtable_fixed_clock)
 
 struct __metal_driver_fixed_clock {
     struct metal_clock clock;
-    const struct __metal_driver_vtable_fixed_clock *vtable;
-    long rate;
 };
 
 #endif

--- a/metal/drivers/fixed-factor-clock.h
+++ b/metal/drivers/fixed-factor-clock.h
@@ -13,20 +13,10 @@ struct __metal_driver_vtable_fixed_factor_clock {
     struct __metal_clock_vtable clock;
 };
 
-long __metal_driver_fixed_factor_clock_get_rate_hz(const struct metal_clock *gclk);
-long __metal_driver_fixed_factor_clock_set_rate_hz(struct metal_clock *gclk, long target_hz);
-
-__METAL_DECLARE_VTABLE(__metal_driver_vtable_fixed_factor_clock) = {
-    .clock.get_rate_hz = __metal_driver_fixed_factor_clock_get_rate_hz,
-    .clock.set_rate_hz = __metal_driver_fixed_factor_clock_set_rate_hz,
-};
+__METAL_DECLARE_VTABLE(__metal_driver_vtable_fixed_factor_clock)
 
 struct __metal_driver_fixed_factor_clock {
     struct metal_clock clock;
-    const struct __metal_driver_vtable_fixed_factor_clock *vtable;
-    struct metal_clock *parent;
-    long mult;
-    long div;
 };
 
 #endif

--- a/metal/drivers/riscv,clint0.h
+++ b/metal/drivers/riscv,clint0.h
@@ -11,34 +11,13 @@ struct __metal_driver_vtable_riscv_clint0 {
     struct metal_interrupt_vtable clint_vtable;
 };
 
-void __metal_driver_riscv_clint0_init(struct metal_interrupt *clint);
-int __metal_driver_riscv_clint0_register(struct metal_interrupt *controller,
-                                       int id, metal_interrupt_handler_t isr,
-                                       void *priv);
-int __metal_driver_riscv_clint0_enable(struct metal_interrupt *controller, int id);
-int __metal_driver_riscv_clint0_disable(struct metal_interrupt *controller, int id);
-int __metal_driver_riscv_clint0_command_request(struct metal_interrupt *clint,
-                                              int command, void *data);
-
-__METAL_DECLARE_VTABLE(__metal_driver_vtable_riscv_clint0) = {
-    .clint_vtable.interrupt_init     = __metal_driver_riscv_clint0_init,
-    .clint_vtable.interrupt_register = __metal_driver_riscv_clint0_register,
-    .clint_vtable.interrupt_enable   = __metal_driver_riscv_clint0_enable,
-    .clint_vtable.interrupt_disable  = __metal_driver_riscv_clint0_disable,
-    .clint_vtable.command_request    = __metal_driver_riscv_clint0_command_request,
-};
+__METAL_DECLARE_VTABLE(__metal_driver_vtable_riscv_clint0)
 
 #define __METAL_MACHINE_MACROS
 #include <metal/machine.h>
 struct __metal_driver_riscv_clint0 {
     struct metal_interrupt controller;
-    const struct __metal_driver_vtable_riscv_clint0 *vtable;
-    const unsigned long control_base;
-    const unsigned long control_size;
     int init_done;
-    struct metal_interrupt *interrupt_parents[__METAL_CLINT_NUM_PARENTS];
-    const int interrupt_lines[__METAL_CLINT_NUM_PARENTS];
-    const int num_interrupts;
 };
 #undef __METAL_MACHINE_MACROS
 

--- a/metal/drivers/riscv,cpu.h
+++ b/metal/drivers/riscv,cpu.h
@@ -168,17 +168,6 @@ struct __metal_driver_vtable_riscv_cpu_intc {
   struct metal_interrupt_vtable controller_vtable;
 };
 
-void __metal_driver_riscv_cpu_controller_interrupt_init(struct metal_interrupt *controller);
-int __metal_driver_riscv_cpu_controller_interrupt_register(struct metal_interrupt *controller,
-							 int id, metal_interrupt_handler_t isr,
-							 void *priv_data);
-int __metal_driver_riscv_cpu_controller_interrupt_enable(struct metal_interrupt *controller, int id);
-int __metal_driver_riscv_cpu_controller_interrupt_disable(struct metal_interrupt *controller, int id);
-int __metal_driver_riscv_cpu_controller_interrupt_enable_vector(struct metal_interrupt *controller,
-                                                              int id, metal_vector_mode mode);
-int __metal_driver_riscv_cpu_controller_interrupt_disable_vector(struct metal_interrupt *controller, int id);
-int __metal_driver_riscv_cpu_controller_command_request(struct metal_interrupt *controller,
-						      int cmd, void *data);
 
 void __metal_interrupt_global_enable(void);
 void __metal_interrupt_global_disable(void);
@@ -191,21 +180,11 @@ inline int __metal_controller_interrupt_is_selective_vectored (void)
     return ((val & METAL_MTVEC_CLIC_VECTORED) == METAL_MTVEC_CLIC);
 }
 
-__METAL_DECLARE_VTABLE(__metal_driver_vtable_riscv_cpu_intc) = {
-    .controller_vtable.interrupt_init = __metal_driver_riscv_cpu_controller_interrupt_init,
-    .controller_vtable.interrupt_register = __metal_driver_riscv_cpu_controller_interrupt_register,
-    .controller_vtable.interrupt_enable   = __metal_driver_riscv_cpu_controller_interrupt_enable,
-    .controller_vtable.interrupt_disable  = __metal_driver_riscv_cpu_controller_interrupt_disable,
-    .controller_vtable.interrupt_vector_enable   = __metal_driver_riscv_cpu_controller_interrupt_enable_vector,
-    .controller_vtable.interrupt_vector_disable  = __metal_driver_riscv_cpu_controller_interrupt_disable_vector,
-    .controller_vtable.command_request    = __metal_driver_riscv_cpu_controller_command_request,
-};
+__METAL_DECLARE_VTABLE(__metal_driver_vtable_riscv_cpu_intc)
 
 struct __metal_driver_riscv_cpu_intc {
     struct metal_interrupt controller;
-    const struct __metal_driver_vtable_riscv_cpu_intc *vtable;
     int init_done;
-    int interrupt_controller;
     uintptr_t metal_mtvec_table[METAL_MAX_MI];
     __metal_interrupt_data metal_int_table[METAL_MAX_MI];
     metal_exception_handler_t metal_exception_table[METAL_MAX_ME];
@@ -216,52 +195,10 @@ struct __metal_driver_vtable_cpu {
   struct metal_cpu_vtable cpu_vtable;
 };
 
-unsigned long long  __metal_driver_cpu_timer_get(struct metal_cpu *cpu);
-unsigned long long  __metal_driver_cpu_timebase_get(struct metal_cpu *cpu);
-unsigned long long
-      __metal_driver_cpu_mtime_get(struct metal_cpu *cpu);
-int  __metal_driver_cpu_mtimecmp_set(struct metal_cpu *cpu, unsigned long long time);
-struct metal_interrupt*
-     __metal_driver_cpu_timer_controller_interrupt(struct metal_cpu *cpu);
-int  __metal_driver_cpu_get_timer_interrupt_id(struct metal_cpu *cpu);
-struct metal_interrupt*
-     __metal_driver_cpu_sw_controller_interrupt(struct metal_cpu *cpu);
-int  __metal_driver_cpu_get_sw_interrupt_id(struct metal_cpu *cpu);
-int  __metal_driver_cpu_set_sw_ipi(struct metal_cpu *cpu, int hartid);
-int  __metal_driver_cpu_clear_sw_ipi(struct metal_cpu *cpu, int hartid);
-int  __metal_driver_cpu_get_msip(struct metal_cpu *cpu, int hartid);
-struct metal_interrupt*
-     __metal_driver_cpu_controller_interrupt(struct metal_cpu *cpu);
-int  __metal_driver_cpu_exception_register(struct metal_cpu *cpu, int ecode,
-					 metal_exception_handler_t isr);
-int  __metal_driver_cpu_get_instruction_length(struct metal_cpu *cpu, uintptr_t epc);
-uintptr_t  __metal_driver_cpu_get_exception_pc(struct metal_cpu *cpu);
-int  __metal_driver_cpu_set_exception_pc(struct metal_cpu *cpu, uintptr_t epc);
-
-__METAL_DECLARE_VTABLE(__metal_driver_vtable_cpu) = {
-    .cpu_vtable.timer_get     = __metal_driver_cpu_timer_get,
-    .cpu_vtable.timebase_get  = __metal_driver_cpu_timebase_get,
-    .cpu_vtable.mtime_get = __metal_driver_cpu_mtime_get,
-    .cpu_vtable.mtimecmp_set = __metal_driver_cpu_mtimecmp_set,
-    .cpu_vtable.tmr_controller_interrupt = __metal_driver_cpu_timer_controller_interrupt,
-    .cpu_vtable.get_tmr_interrupt_id = __metal_driver_cpu_get_timer_interrupt_id,
-    .cpu_vtable.sw_controller_interrupt = __metal_driver_cpu_sw_controller_interrupt,
-    .cpu_vtable.get_sw_interrupt_id = __metal_driver_cpu_get_sw_interrupt_id,
-    .cpu_vtable.set_sw_ipi = __metal_driver_cpu_set_sw_ipi,
-    .cpu_vtable.clear_sw_ipi = __metal_driver_cpu_clear_sw_ipi,
-    .cpu_vtable.get_msip = __metal_driver_cpu_get_msip,
-    .cpu_vtable.controller_interrupt = __metal_driver_cpu_controller_interrupt,
-    .cpu_vtable.exception_register = __metal_driver_cpu_exception_register,
-    .cpu_vtable.get_ilen = __metal_driver_cpu_get_instruction_length,
-    .cpu_vtable.get_epc = __metal_driver_cpu_get_exception_pc,
-    .cpu_vtable.set_epc = __metal_driver_cpu_set_exception_pc,
-};
+__METAL_DECLARE_VTABLE(__metal_driver_vtable_cpu)
 
 struct __metal_driver_cpu {
     struct metal_cpu cpu;
-    const struct __metal_driver_vtable_cpu *vtable;
-    const int timebase;    
-    struct metal_interrupt *interrupt_controller;
 };
 
 #endif

--- a/metal/drivers/riscv,plic0.h
+++ b/metal/drivers/riscv,plic0.h
@@ -16,33 +16,13 @@ struct __metal_driver_vtable_riscv_plic0 {
     struct metal_interrupt_vtable plic_vtable;
 };
 
-void __metal_driver_riscv_plic0_init(struct metal_interrupt *controller);
-int __metal_driver_riscv_plic0_register(struct metal_interrupt *plic,
-				      int id, metal_interrupt_handler_t isr,
-				      void *priv_data);
-int __metal_driver_riscv_plic0_enable(struct metal_interrupt *controller, int id);
-int __metal_driver_riscv_plic0_disable(struct metal_interrupt *controller, int id);
-
-__METAL_DECLARE_VTABLE(__metal_driver_vtable_riscv_plic0) = {
-    .plic_vtable.interrupt_init = __metal_driver_riscv_plic0_init,
-    .plic_vtable.interrupt_register = __metal_driver_riscv_plic0_register,
-    .plic_vtable.interrupt_enable   = __metal_driver_riscv_plic0_enable,
-    .plic_vtable.interrupt_disable  = __metal_driver_riscv_plic0_disable,
-};
+__METAL_DECLARE_VTABLE(__metal_driver_vtable_riscv_plic0)
 
 #define __METAL_MACHINE_MACROS
 #include <metal/machine.h>
 struct __metal_driver_riscv_plic0 {
     struct metal_interrupt controller;
-    const struct __metal_driver_vtable_riscv_plic0 *vtable;
-    const unsigned long control_base;
-    const unsigned long control_size;
-    struct metal_interrupt *interrupt_parents[__METAL_PLIC_NUM_PARENTS];
-    const int interrupt_lines[__METAL_PLIC_NUM_PARENTS];
-    int max_priority;
-    int num_interrupts;
     int init_done;
-    int interrupt_controller;
     metal_interrupt_handler_t metal_exint_table[__METAL_PLIC_SUBINTERRUPTS];
     __metal_interrupt_data metal_exdata_table[__METAL_PLIC_SUBINTERRUPTS];
 };

--- a/metal/drivers/sifive,clic0.h
+++ b/metal/drivers/sifive,clic0.h
@@ -27,45 +27,13 @@ struct __metal_driver_vtable_sifive_clic0 {
     struct metal_interrupt_vtable clic_vtable;
 };
 
-void __metal_driver_sifive_clic0_init(struct metal_interrupt *clic);
-int __metal_driver_sifive_clic0_register(struct metal_interrupt *controller,
-                                       int id, metal_interrupt_handler_t isr,
-                                       void *priv);
-int __metal_driver_sifive_clic0_enable(struct metal_interrupt *controller, int id);
-int __metal_driver_sifive_clic0_disable(struct metal_interrupt *controller, int id);
-int __metal_driver_sifive_clic0_enable_interrupt_vector(struct metal_interrupt *controller,
-                                                      int id, metal_vector_mode mode);
-int __metal_driver_sifive_clic0_disable_interrupt_vector(struct metal_interrupt *controller,
-                                                       int id);
-int __metal_driver_sifive_clic0_command_request(struct metal_interrupt *clic,
-                                              int command, void *data);
-
-__METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_clic0) = {
-    .clic_vtable.interrupt_init     = __metal_driver_sifive_clic0_init,
-    .clic_vtable.interrupt_register = __metal_driver_sifive_clic0_register,
-    .clic_vtable.interrupt_enable   = __metal_driver_sifive_clic0_enable,
-    .clic_vtable.interrupt_disable  = __metal_driver_sifive_clic0_disable,
-    .clic_vtable.interrupt_vector_enable   = __metal_driver_sifive_clic0_enable_interrupt_vector,
-    .clic_vtable.interrupt_vector_disable  = __metal_driver_sifive_clic0_disable_interrupt_vector,
-    .clic_vtable.command_request    = __metal_driver_sifive_clic0_command_request,
-};
+__METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_clic0)
 
 #define __METAL_MACHINE_MACROS
 #include <metal/machine.h>
 struct __metal_driver_sifive_clic0 {
     struct metal_interrupt controller;
-    const struct __metal_driver_vtable_sifive_clic0 *vtable;
-    const unsigned long control_base;
-    const unsigned long control_size;
     int init_done;
-    struct metal_interrupt *interrupt_parent;
-    const int num_interrupts;
-    /* Hardcode max of 3 direct interrupts to core for now, SW, Timer, Ext */
-    const int interrupt_lines[3];
-    int max_levels;
-    int num_subinterrupts;
-    int num_intbits;
-    int interrupt_controller;
     metal_interrupt_handler_t metal_mtvt_table[__METAL_CLIC_SUBINTERRUPTS];
     __metal_interrupt_data metal_exint_table[__METAL_CLIC_SUBINTERRUPTS];
 };

--- a/metal/drivers/sifive,fe310-g000,hfrosc.h
+++ b/metal/drivers/sifive,fe310-g000,hfrosc.h
@@ -9,24 +9,14 @@
 #include <metal/clock.h>
 #include <metal/io.h>
 
-long __metal_driver_sifive_fe310_g000_hfrosc_get_rate_hz(const struct metal_clock *clock);
-long __metal_driver_sifive_fe310_g000_hfrosc_set_rate_hz(struct metal_clock *clock, long rate);
-
 struct __metal_driver_vtable_sifive_fe310_g000_hfrosc {
     struct __metal_clock_vtable clock;
 };
 
-__METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_fe310_g000_hfrosc) = {
-    .clock.get_rate_hz = &__metal_driver_sifive_fe310_g000_hfrosc_get_rate_hz,
-    .clock.set_rate_hz = &__metal_driver_sifive_fe310_g000_hfrosc_set_rate_hz,
-};
+__METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_fe310_g000_hfrosc)
 
 struct __metal_driver_sifive_fe310_g000_hfrosc {
     struct metal_clock clock;
-    const struct __metal_driver_vtable_sifive_fe310_g000_hfrosc *vtable;
-    const struct metal_clock *ref;
-    const struct __metal_driver_sifive_fe310_g000_prci *config_base;
-    const long config_offset;
 };
 
 #endif

--- a/metal/drivers/sifive,fe310-g000,hfxosc.h
+++ b/metal/drivers/sifive,fe310-g000,hfxosc.h
@@ -7,24 +7,14 @@
 #include <metal/clock.h>
 #include <metal/drivers/sifive,fe310-g000,prci.h>
 
-long __metal_driver_sifive_fe310_g000_hfxosc_get_rate_hz(const struct metal_clock *clock);
-long __metal_driver_sifive_fe310_g000_hfxosc_set_rate_hz(struct metal_clock *clock, long rate);
-
 struct __metal_driver_vtable_sifive_fe310_g000_hfxosc {
     struct __metal_clock_vtable clock;
 };
 
-__METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_fe310_g000_hfxosc) = {
-    .clock.get_rate_hz = __metal_driver_sifive_fe310_g000_hfxosc_get_rate_hz,
-    .clock.set_rate_hz = __metal_driver_sifive_fe310_g000_hfxosc_set_rate_hz,
-};
+__METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_fe310_g000_hfxosc)
 
 struct __metal_driver_sifive_fe310_g000_hfxosc {
     struct metal_clock clock;
-    const struct __metal_driver_vtable_sifive_fe310_g000_hfxosc *vtable;
-    const struct metal_clock *ref;
-    const struct __metal_driver_sifive_fe310_g000_prci *config_base;
-    const long config_offset;
 };
 
 #endif

--- a/metal/drivers/sifive,fe310-g000,pll.h
+++ b/metal/drivers/sifive,fe310-g000,pll.h
@@ -1,6 +1,8 @@
 /* Copyright 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 
+#include <metal/machine/platform.h>
+
 #ifndef METAL__DRIVERS__SIFIVE_FE310_G000_PLL_H
 #define METAL__DRIVERS__SIFIVE_FE310_G000_PLL_H
 
@@ -8,32 +10,17 @@ struct __metal_driver_sifive_fe310_g000_pll;
 
 #include <metal/clock.h>
 #include <metal/drivers/sifive,fe310-g000,prci.h>
-
-void __metal_driver_sifive_fe310_g000_pll_init(struct __metal_driver_sifive_fe310_g000_pll *pll);
-long __metal_driver_sifive_fe310_g000_pll_get_rate_hz(const struct metal_clock *clock);
-long __metal_driver_sifive_fe310_g000_pll_set_rate_hz(struct metal_clock *clock, long rate);
+#include <metal/machine.h>
 
 struct __metal_driver_vtable_sifive_fe310_g000_pll {
     void (*init)(struct __metal_driver_sifive_fe310_g000_pll *pll);
     struct __metal_clock_vtable clock;
 };
 
-__METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_fe310_g000_pll) = {
-    .init = __metal_driver_sifive_fe310_g000_pll_init,
-    .clock.get_rate_hz = __metal_driver_sifive_fe310_g000_pll_get_rate_hz,
-    .clock.set_rate_hz = __metal_driver_sifive_fe310_g000_pll_set_rate_hz,
-};
+__METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_fe310_g000_pll)
 
 struct __metal_driver_sifive_fe310_g000_pll {
     struct metal_clock clock;
-    const struct __metal_driver_vtable_sifive_fe310_g000_pll *vtable;
-    const struct metal_clock *pllsel0;
-    const struct metal_clock *pllref;
-    const struct __metal_driver_sifive_fe310_g000_prci *config_base;
-    const long config_offset;
-    const struct __metal_driver_sifive_fe310_g000_prci *divider_base;
-    const long divider_offset;
-    const long init_rate;
 };
 
 #endif

--- a/metal/drivers/sifive,fe310-g000,prci.h
+++ b/metal/drivers/sifive,fe310-g000,prci.h
@@ -9,23 +9,14 @@
 
 struct __metal_driver_sifive_fe310_g000_prci;
 
-long __metal_driver_sifive_fe310_g000_prci_get_reg(const struct __metal_driver_sifive_fe310_g000_prci *, long offset);
-long __metal_driver_sifive_fe310_g000_prci_set_reg(const struct __metal_driver_sifive_fe310_g000_prci *, long offset, long value);
-
 struct __metal_driver_vtable_sifive_fe310_g000_prci {
     long (*get_reg)(const struct __metal_driver_sifive_fe310_g000_prci *, long offset);
     long (*set_reg)(const struct __metal_driver_sifive_fe310_g000_prci *, long offset, long value);
 };
 
-__METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_fe310_g000_prci) = {
-    .get_reg = __metal_driver_sifive_fe310_g000_prci_get_reg,
-    .set_reg = __metal_driver_sifive_fe310_g000_prci_set_reg,
-};
+__METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_fe310_g000_prci)
 
 struct __metal_driver_sifive_fe310_g000_prci {
-    const struct __metal_driver_vtable_sifive_fe310_g000_prci *vtable;
-    const long base;
-    const long size;
 };
 
 #endif

--- a/metal/drivers/sifive,fu540-c000,l2.h
+++ b/metal/drivers/sifive,fu540-c000,l2.h
@@ -9,24 +9,14 @@ struct __metal_driver_sifive_fu540_c000_l2;
 #include <stdint.h>
 #include <metal/cache.h>
 
-void __metal_driver_sifive_fu540_c000_l2_init(struct metal_cache *l2, int ways);
-int __metal_driver_sifive_fu540_c000_l2_get_enabled_ways(struct metal_cache *l2);
-int __metal_driver_sifive_fu540_c000_l2_set_enabled_ways(struct metal_cache *l2, int ways);
-
 struct __metal_driver_vtable_sifive_fu540_c000_l2 {
 	struct __metal_cache_vtable cache;
 };
 
-__METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_fu540_c000_l2) = {
-	.cache.init = __metal_driver_sifive_fu540_c000_l2_init,
-	.cache.get_enabled_ways = __metal_driver_sifive_fu540_c000_l2_get_enabled_ways,
-	.cache.set_enabled_ways = __metal_driver_sifive_fu540_c000_l2_set_enabled_ways,
-};
+__METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_fu540_c000_l2)
 
 struct __metal_driver_sifive_fu540_c000_l2 {
 	struct metal_cache cache;
-	const struct __metal_driver_vtable_sifive_fu540_c000_l2 *vtable;
-	const uintptr_t control_base;
 };
 
 #endif

--- a/metal/drivers/sifive,global-external-interrupts0.h
+++ b/metal/drivers/sifive,global-external-interrupts0.h
@@ -11,31 +11,11 @@ struct __metal_driver_vtable_sifive_global_external_interrupts0 {
     struct metal_interrupt_vtable global0_vtable;
 };
 
-void __metal_driver_sifive_global_external_interrupt_init(struct metal_interrupt *global0);
-int __metal_driver_sifive_global_external_interrupt_register(struct metal_interrupt *controller,
-                                                           int id, metal_interrupt_handler_t isr,
-                                                           void *priv_data);
-int __metal_driver_sifive_global_external_interrupt_enable(struct metal_interrupt *controller, int id);
-int __metal_driver_sifive_global_external_interrupt_disable(struct metal_interrupt *controller, int id);
-int __metal_driver_sifive_global_external_command_request(struct metal_interrupt *clint,
-                                                        int command, void *data);
-
-__METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_global_external_interrupts0) = {
-    .global0_vtable.interrupt_init     = __metal_driver_sifive_global_external_interrupt_init,
-    .global0_vtable.interrupt_register = __metal_driver_sifive_global_external_interrupt_register,
-    .global0_vtable.interrupt_enable   = __metal_driver_sifive_global_external_interrupt_enable,
-    .global0_vtable.interrupt_disable  = __metal_driver_sifive_global_external_interrupt_disable,
-    .global0_vtable.command_request    = __metal_driver_sifive_global_external_command_request,
-};
+__METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_global_external_interrupts0)
 
 struct __metal_driver_sifive_global_external_interrupts0 {
     struct metal_interrupt irc;
-    const struct __metal_driver_vtable_sifive_global_external_interrupts0 *vtable;
     int init_done;
-    struct metal_interrupt *interrupt_parent;
-    const int num_interrupts;
-    const int interrupt_lines[];
 };
-
 
 #endif

--- a/metal/drivers/sifive,gpio-buttons.h
+++ b/metal/drivers/sifive,gpio-buttons.h
@@ -12,25 +12,10 @@ struct __metal_driver_vtable_sifive_button {
   struct metal_button_vtable button_vtable;
 };
 
-int  __metal_driver_button_exist(struct metal_button *button, char *label);
-struct metal_interrupt*
-     __metal_driver_button_interrupt_controller(struct metal_button *button);
-int  __metal_driver_button_get_interrupt_id(struct metal_button *button);
-
-__METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_button) = {
-    .button_vtable.button_exist   = __metal_driver_button_exist,
-    .button_vtable.interrupt_controller = __metal_driver_button_interrupt_controller,
-    .button_vtable.get_interrupt_id = __metal_driver_button_get_interrupt_id,
-};
+__METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_button)
 
 struct __metal_driver_sifive_gpio_button {
     struct metal_button button;
-    const struct __metal_driver_vtable_sifive_button *vtable;
-    struct metal_interrupt *interrupt_parent;
-    struct __metal_driver_sifive_gpio0 *gpio;
-    const char *label;
-    const int pin;
-    const int interrupt_line;
 };
 
 #endif

--- a/metal/drivers/sifive,gpio-leds.h
+++ b/metal/drivers/sifive,gpio-leds.h
@@ -12,26 +12,10 @@ struct __metal_driver_vtable_sifive_led {
   struct metal_led_vtable led_vtable;
 };
 
-int  __metal_driver_led_exist(struct metal_led *led, char *label);
-void __metal_driver_led_enable(struct metal_led *led);
-void __metal_driver_led_on(struct metal_led *led);
-void __metal_driver_led_off(struct metal_led *led);
-void __metal_driver_led_toggle(struct metal_led *led);
-
-__METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_led) = {
-    .led_vtable.led_exist   = __metal_driver_led_exist,
-    .led_vtable.led_enable  = __metal_driver_led_enable,
-    .led_vtable.led_on      = __metal_driver_led_on,
-    .led_vtable.led_off     = __metal_driver_led_off,
-    .led_vtable.led_toggle  = __metal_driver_led_toggle,
-};
+__METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_led)
 
 struct __metal_driver_sifive_gpio_led {
     struct metal_led led;
-    const struct __metal_driver_vtable_sifive_led *vtable;
-    struct __metal_driver_sifive_gpio0 *gpio;
-    const char *label;
-    const int pin;
 };
 
 #endif

--- a/metal/drivers/sifive,gpio-switches.h
+++ b/metal/drivers/sifive,gpio-switches.h
@@ -12,25 +12,10 @@ struct __metal_driver_vtable_sifive_switch {
   struct metal_switch_vtable switch_vtable;
 };
 
-int  __metal_driver_switch_exist(struct metal_switch *flip, char *label);
-struct metal_interrupt*
-     __metal_driver_switch_interrupt_controller(struct metal_switch *flip);
-int  __metal_driver_switch_get_interrupt_id(struct metal_switch *flip);
-
-__METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_switch) = {
-    .switch_vtable.switch_exist   = __metal_driver_switch_exist,
-    .switch_vtable.interrupt_controller = __metal_driver_switch_interrupt_controller,
-    .switch_vtable.get_interrupt_id = __metal_driver_switch_get_interrupt_id,
-};
+__METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_switch)
 
 struct __metal_driver_sifive_gpio_switch {
     struct metal_switch flip;
-    const struct __metal_driver_vtable_sifive_switch *vtable;
-    struct metal_interrupt *interrupt_parent;
-    struct __metal_driver_sifive_gpio0 *gpio;
-    const char *label;
-    const int pin;
-    const int interrupt_line;
 };
 
 #endif

--- a/metal/drivers/sifive,gpio0.h
+++ b/metal/drivers/sifive,gpio0.h
@@ -11,34 +11,12 @@ struct __metal_driver_vtable_sifive_gpio0 {
     const struct __metal_gpio_vtable gpio;
 };
 
-struct __metal_driver_sifive_gpio0;
+//struct __metal_driver_sifive_gpio0;
 
-int __metal_driver_sifive_gpio0_disable_input(struct metal_gpio *gpio, long source);
-long __metal_driver_sifive_gpio0_output(struct metal_gpio *gpio);
-int __metal_driver_sifive_gpio0_enable_output(struct metal_gpio *gpio, long source);
-int __metal_driver_sifive_gpio0_output_set(struct metal_gpio *gpio, long value);
-int __metal_driver_sifive_gpio0_output_clear(struct metal_gpio *gpio, long value);
-int __metal_driver_sifive_gpio0_output_toggle(struct metal_gpio *gpio, long value);
-int __metal_driver_sifive_gpio0_enable_io(struct metal_gpio *, long source, long dest);
-
-__METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_gpio0) = {
-    .gpio.disable_input = __metal_driver_sifive_gpio0_disable_input,
-    .gpio.output        = __metal_driver_sifive_gpio0_output,
-    .gpio.enable_output = __metal_driver_sifive_gpio0_enable_output,
-    .gpio.output_set    = __metal_driver_sifive_gpio0_output_set,
-    .gpio.output_clear  = __metal_driver_sifive_gpio0_output_clear,
-    .gpio.output_toggle = __metal_driver_sifive_gpio0_output_toggle,
-    .gpio.enable_io = __metal_driver_sifive_gpio0_enable_io,
-};
+__METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_gpio0)
 
 struct __metal_driver_sifive_gpio0 {
     struct metal_gpio gpio;
-    const struct __metal_driver_vtable_sifive_gpio0 *vtable;
-    const long base;
-    const long size;
-    struct metal_interrupt *interrupt_parent;
-    const int num_interrupts;
-    const int interrupt_lines[];
 };
 
 #endif

--- a/metal/drivers/sifive,local-external-interrupts0.h
+++ b/metal/drivers/sifive,local-external-interrupts0.h
@@ -11,30 +11,11 @@ struct __metal_driver_vtable_sifive_local_external_interrupts0 {
     struct metal_interrupt_vtable local0_vtable;
 };
 
-void __metal_driver_sifive_local_external_interrupt_init(struct metal_interrupt *local0);
-int __metal_driver_sifive_local_external_interrupt_register(struct metal_interrupt *controller,
-                                                          int id, metal_interrupt_handler_t isr,
-                                                          void *priv);
-int __metal_driver_sifive_local_external_interrupt_enable(struct metal_interrupt *controller, int id);
-int __metal_driver_sifive_local_external_interrupt_disable(struct metal_interrupt *controller, int id);
-int __metal_driver_sifive_local_external_command_request(struct metal_interrupt *clint,
-                                              	       int command, void *data);
-
-__METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_local_external_interrupts0) = {
-    .local0_vtable.interrupt_init     = __metal_driver_sifive_local_external_interrupt_init,
-    .local0_vtable.interrupt_register = __metal_driver_sifive_local_external_interrupt_register,
-    .local0_vtable.interrupt_enable   = __metal_driver_sifive_local_external_interrupt_enable,
-    .local0_vtable.interrupt_disable  = __metal_driver_sifive_local_external_interrupt_disable,
-    .local0_vtable.command_request    = __metal_driver_sifive_local_external_command_request,
-};
+__METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_local_external_interrupts0)
 
 struct __metal_driver_sifive_local_external_interrupts0 {
     struct metal_interrupt irc;
-    const struct __metal_driver_vtable_sifive_local_external_interrupts0 *vtable;
     int init_done;
-    struct metal_interrupt *interrupt_parent;
-    const int num_interrupts;
-    const int interrupt_lines[];
 };
 
 

--- a/metal/drivers/sifive,spi0.h
+++ b/metal/drivers/sifive,spi0.h
@@ -14,30 +14,13 @@ struct __metal_driver_vtable_sifive_spi0 {
     const struct metal_spi_vtable spi;
 };
 
-struct __metal_driver_sifive_spi0;
+//struct __metal_driver_sifive_spi0;
 
-void __metal_driver_sifive_spi0_init(struct metal_spi *spi, int baud_rate);
-int __metal_driver_sifive_spi0_transfer(struct metal_spi *spi, struct metal_spi_config *config, size_t len, char *tx_buf, char *rx_buf);
-int __metal_driver_sifive_spi0_get_baud_rate(struct metal_spi *spi);
-int __metal_driver_sifive_spi0_set_baud_rate(struct metal_spi *spi, int baud_rate);
-
-__METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_spi0) = {
-    .spi.init          = __metal_driver_sifive_spi0_init,
-    .spi.transfer      = __metal_driver_sifive_spi0_transfer,
-    .spi.get_baud_rate = __metal_driver_sifive_spi0_get_baud_rate,
-    .spi.set_baud_rate = __metal_driver_sifive_spi0_set_baud_rate,
-};
+__METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_spi0)
 
 struct __metal_driver_sifive_spi0 {
     struct metal_spi spi;
-    const struct __metal_driver_vtable_sifive_spi0 *vtable;
-    struct metal_clock *clock;
-    const unsigned long control_base;
-    const unsigned long control_size;
     unsigned long baud_rate;
-    struct __metal_driver_sifive_gpio0 *pinmux;
-    const unsigned long pinmux_output_selector;
-    const unsigned long pinmux_source_selector;
 };
 
 #endif

--- a/metal/drivers/sifive,spi0.h
+++ b/metal/drivers/sifive,spi0.h
@@ -14,8 +14,6 @@ struct __metal_driver_vtable_sifive_spi0 {
     const struct metal_spi_vtable spi;
 };
 
-//struct __metal_driver_sifive_spi0;
-
 __METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_spi0)
 
 struct __metal_driver_sifive_spi0 {

--- a/metal/drivers/sifive,test0.h
+++ b/metal/drivers/sifive,test0.h
@@ -11,8 +11,6 @@ struct __metal_driver_vtable_sifive_test0 {
     const struct __metal_shutdown_vtable shutdown;
 };
 
-//struct __metal_driver_sifive_test0;
-
 __METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_test0)
 
 struct __metal_driver_sifive_test0 {

--- a/metal/drivers/sifive,test0.h
+++ b/metal/drivers/sifive,test0.h
@@ -11,19 +11,12 @@ struct __metal_driver_vtable_sifive_test0 {
     const struct __metal_shutdown_vtable shutdown;
 };
 
-struct __metal_driver_sifive_test0;
+//struct __metal_driver_sifive_test0;
 
-void __metal_driver_sifive_test0_exit(const struct __metal_shutdown *test, int code) __attribute__((noreturn));
-
-__METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_test0) = {
-    .shutdown.exit       = &__metal_driver_sifive_test0_exit,
-};
+__METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_test0)
 
 struct __metal_driver_sifive_test0 {
     struct __metal_shutdown shutdown;
-    const struct __metal_driver_vtable_sifive_test0 *vtable;
-    const unsigned long base;
-    const unsigned long size;
 };
 
 

--- a/metal/drivers/sifive,uart0.h
+++ b/metal/drivers/sifive,uart0.h
@@ -17,37 +17,11 @@ struct __metal_driver_vtable_sifive_uart0 {
 
 struct __metal_driver_sifive_uart0;
 
-void __metal_driver_sifive_uart0_init(struct metal_uart *uart, int baud_rate);
-int __metal_driver_sifive_uart0_putc(struct metal_uart *uart, unsigned char c);
-int __metal_driver_sifive_uart0_getc(struct metal_uart *uart, unsigned char *c);
-int __metal_driver_sifive_uart0_get_baud_rate(struct metal_uart *guart);
-int __metal_driver_sifive_uart0_set_baud_rate(struct metal_uart *guart, int baud_rate);
-struct metal_interrupt* __metal_driver_sifive_uart0_interrupt_controller(struct metal_uart *uart);
-int __metal_driver_sifive_uart0_get_interrupt_id(struct metal_uart *uart);
-
-__METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_uart0) = {
-    .uart.init          = __metal_driver_sifive_uart0_init,
-    .uart.putc          = __metal_driver_sifive_uart0_putc,
-    .uart.getc          = __metal_driver_sifive_uart0_getc,
-    .uart.get_baud_rate = __metal_driver_sifive_uart0_get_baud_rate,
-    .uart.set_baud_rate = __metal_driver_sifive_uart0_set_baud_rate,
-    .uart.controller_interrupt = __metal_driver_sifive_uart0_interrupt_controller,
-    .uart.get_interrupt_id     = __metal_driver_sifive_uart0_get_interrupt_id,
-};
+__METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_uart0)
 
 struct __metal_driver_sifive_uart0 {
     struct metal_uart uart;
-    const struct __metal_driver_vtable_sifive_uart0 *vtable;
-    struct metal_clock *clock;
-    const unsigned long control_base;
-    const unsigned long control_size;
     unsigned long baud_rate;
-    struct __metal_driver_sifive_gpio0 *pinmux;
-    const unsigned long pinmux_output_selector;
-    const unsigned long pinmux_source_selector;
-    struct metal_interrupt *interrupt_parent;
-    const int num_interrupts;
-    const int interrupt_line;
 };
 
 

--- a/src/drivers/fixed-clock.c
+++ b/src/drivers/fixed-clock.c
@@ -11,8 +11,7 @@
 
 long __metal_driver_fixed_clock_get_rate_hz(const struct metal_clock *gclk)
 {
-    const struct __metal_driver_fixed_clock *clk = (void *)gclk;
-    return __metal_driver_fixed_clock_rate();
+    return __metal_driver_fixed_clock_rate(gclk);
 }
 
 long __metal_driver_fixed_clock_set_rate_hz(struct metal_clock *gclk, long target_hz)

--- a/src/drivers/fixed-clock.c
+++ b/src/drivers/fixed-clock.c
@@ -7,16 +7,22 @@
 
 #include <metal/drivers/fixed-clock.h>
 #include <stddef.h>
+#include <metal/machine.h>
 
 long __metal_driver_fixed_clock_get_rate_hz(const struct metal_clock *gclk)
 {
     const struct __metal_driver_fixed_clock *clk = (void *)gclk;
-    return clk->rate;
+    return __metal_driver_fixed_clock_rate();
 }
 
 long __metal_driver_fixed_clock_set_rate_hz(struct metal_clock *gclk, long target_hz)
 {
     return __metal_driver_fixed_clock_get_rate_hz(gclk);
 }
+
+__METAL_DEFINE_VTABLE(__metal_driver_vtable_fixed_clock) = {
+    .clock.get_rate_hz = __metal_driver_fixed_clock_get_rate_hz,
+    .clock.set_rate_hz = __metal_driver_fixed_clock_set_rate_hz,
+};
 
 #endif /* METAL_FIXED_CLOCK */

--- a/src/drivers/fixed-factor-clock.c
+++ b/src/drivers/fixed-factor-clock.c
@@ -7,17 +7,17 @@
 
 #include <metal/drivers/fixed-factor-clock.h>
 #include <stddef.h>
+#include <metal/machine.h>
 
 long __metal_driver_fixed_factor_clock_get_rate_hz(const struct metal_clock *gclk)
 {
-    const struct __metal_driver_fixed_factor_clock *clk = (void *)gclk;
-
+    struct metal_clock *parent = __metal_driver_fixed_factor_clock_parent(gclk);
     long parent_rate = 1;
-    if(clk->parent) {
-        parent_rate = clk->parent->vtable->get_rate_hz(clk->parent);
+    if(parent) {
+        parent_rate = parent->clock->get_rate_hz(parent);
     }
 
-    return clk->mult * parent_rate / clk->div;
+    return __metal_driver_fixed_factor_lock_mult() * parent_rate / __metal_driver_fixed_factor_clock_div();
 }
 
 long __metal_driver_fixed_factor_clock_set_rate_hz(struct metal_clock *gclk, long target_hz)
@@ -25,4 +25,8 @@ long __metal_driver_fixed_factor_clock_set_rate_hz(struct metal_clock *gclk, lon
     return __metal_driver_fixed_factor_clock_get_rate_hz(gclk);
 }
 
+__METAL_DEFINE_VTABLE(__metal_driver_vtable_fixed_factor_clock) = {
+    .clock.get_rate_hz = __metal_driver_fixed_factor_clock_get_rate_hz,
+    .clock.set_rate_hz = __metal_driver_fixed_factor_clock_set_rate_hz,
+};
 #endif /* METAL_FIXED_FACTOR_CLOCK */

--- a/src/drivers/fixed-factor-clock.c
+++ b/src/drivers/fixed-factor-clock.c
@@ -14,10 +14,10 @@ long __metal_driver_fixed_factor_clock_get_rate_hz(const struct metal_clock *gcl
     struct metal_clock *parent = __metal_driver_fixed_factor_clock_parent(gclk);
     long parent_rate = 1;
     if(parent) {
-        parent_rate = parent->clock->get_rate_hz(parent);
+        parent_rate = parent->vtable->get_rate_hz(parent);
     }
 
-    return __metal_driver_fixed_factor_lock_mult() * parent_rate / __metal_driver_fixed_factor_clock_div();
+    return __metal_driver_fixed_factor_clock_mult(gclk) * parent_rate / __metal_driver_fixed_factor_clock_div(gclk);
 }
 
 long __metal_driver_fixed_factor_clock_set_rate_hz(struct metal_clock *gclk, long target_hz)

--- a/src/drivers/inline.c
+++ b/src/drivers/inline.c
@@ -1,5 +1,5 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 
-#include <metal/machine-inline.h>
+#include <metal/machine/inline.h>
 

--- a/src/drivers/inline.c
+++ b/src/drivers/inline.c
@@ -1,0 +1,5 @@
+/* Copyright 2019 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include <metal/machine-inline.h>
+

--- a/src/drivers/riscv,clint0.c
+++ b/src/drivers/riscv,clint0.c
@@ -8,31 +8,34 @@
 #include <metal/io.h>
 #include <metal/cpu.h>
 #include <metal/drivers/riscv,clint0.h>
+#include <metal/machine.h>
 
 unsigned long long __metal_clint0_mtime_get (struct __metal_driver_riscv_clint0 *clint)
 {
     __metal_io_u32 lo, hi;
+    unsigned long control_base = __metal_driver_sifive_clint0_control_base((struct metal_interrupt *)clint);
 
     /* Guard against rollover when reading */
     do {
-	hi = __METAL_ACCESS_ONCE((__metal_io_u32 *)(clint->control_base + METAL_RISCV_CLINT0_MTIME + 4));
-	lo = __METAL_ACCESS_ONCE((__metal_io_u32 *)(clint->control_base + METAL_RISCV_CLINT0_MTIME));
-    } while (__METAL_ACCESS_ONCE((__metal_io_u32 *)(clint->control_base + METAL_RISCV_CLINT0_MTIME + 4)) != hi);
+	hi = __METAL_ACCESS_ONCE((__metal_io_u32 *)(control_base + METAL_RISCV_CLINT0_MTIME + 4));
+	lo = __METAL_ACCESS_ONCE((__metal_io_u32 *)(control_base + METAL_RISCV_CLINT0_MTIME));
+    } while (__METAL_ACCESS_ONCE((__metal_io_u32 *)(control_base + METAL_RISCV_CLINT0_MTIME + 4)) != hi);
 
     return (((unsigned long long)hi) << 32) | lo;
 }
 
 int __metal_clint0_mtime_set (struct __metal_driver_riscv_clint0 *clint, unsigned long long time)
 {   
+    unsigned long control_base = __metal_driver_sifive_clint0_control_base((struct metal_interrupt *)clint);
     /* Per spec, the RISC-V MTIME/MTIMECMP registers are 64 bit,
      * and are NOT internally latched for multiword transfers.
      * Need to be careful about sequencing to avoid triggering
      * spurious interrupts: For that set the high word to a max
      * value first.
      */
-    __METAL_ACCESS_ONCE((__metal_io_u32 *)(clint->control_base + METAL_RISCV_CLINT0_MTIMECMP_BASE + 4)) = 0xFFFFFFFF;
-    __METAL_ACCESS_ONCE((__metal_io_u32 *)(clint->control_base + METAL_RISCV_CLINT0_MTIMECMP_BASE)) = (__metal_io_u32)time;
-    __METAL_ACCESS_ONCE((__metal_io_u32 *)(clint->control_base + METAL_RISCV_CLINT0_MTIMECMP_BASE + 4)) = (__metal_io_u32)(time >> 32);
+    __METAL_ACCESS_ONCE((__metal_io_u32 *)(control_base + METAL_RISCV_CLINT0_MTIMECMP_BASE + 4)) = 0xFFFFFFFF;
+    __METAL_ACCESS_ONCE((__metal_io_u32 *)(control_base + METAL_RISCV_CLINT0_MTIMECMP_BASE)) = (__metal_io_u32)time;
+    __METAL_ACCESS_ONCE((__metal_io_u32 *)(control_base + METAL_RISCV_CLINT0_MTIMECMP_BASE + 4)) = (__metal_io_u32)(time >> 32);
     return 0;
 }
 
@@ -49,16 +52,16 @@ static struct metal_interrupt *_get_cpu_intc()
 
 void __metal_driver_riscv_clint0_init (struct metal_interrupt *controller)
 {
+    int num_interrupts = __metal_driver_sifive_clint0_num_interrupts(controller);
     struct __metal_driver_riscv_clint0 *clint =
                               (struct __metal_driver_riscv_clint0 *)(controller);
 
     if ( !clint->init_done ) {
 	/* Register its interrupts with with parent controller, aka sw and timerto its default isr */
-        for (int i = 0; i < clint->num_interrupts; i++) {
-            struct metal_interrupt *intc = clint->interrupt_parents[i];
-            intc->vtable->interrupt_register(intc,
-					     clint->interrupt_lines[i],
-					     NULL, clint);
+        for (int i = 0; i < num_interrupts; i++) {
+	  struct metal_interrupt *intc = __metal_driver_sifive_clint0_interrupt_parents(controller, i);
+	  int line = __metal_driver_sifive_clint0_interrupt_lines(controller, i);
+            intc->vtable->interrupt_register(intc, line, NULL, controller);
 	}
 	clint->init_done = 1;
     }	
@@ -69,17 +72,18 @@ int __metal_driver_riscv_clint0_register (struct metal_interrupt *controller,
                                         void *priv)
 {
     int rc = -1;
-    struct __metal_driver_riscv_clint0 *clint =
-                              (struct __metal_driver_riscv_clint0 *)(controller);
 
     struct metal_interrupt *intc = NULL;
     struct metal_interrupt *cpu_intc = _get_cpu_intc();
+    int num_interrupts = __metal_driver_sifive_clint0_num_interrupts(controller);
 
-    for(int i = 0; i < clint->num_interrupts; i++) {
-        if(cpu_intc == clint->interrupt_parents[i] && id == clint->interrupt_lines[i]) {
-            intc = clint->interrupt_parents[i]; 
+    for(int i = 0; i < num_interrupts; i++) {
+	int line = __metal_driver_sifive_clint0_interrupt_lines(controller, i);
+        intc = __metal_driver_sifive_clint0_interrupt_parents(controller, i);
+        if (cpu_intc == intc && id == line) {
             break;
         }
+	intc = NULL;
     }
 
     /* Register its interrupts with parent controller */
@@ -92,18 +96,19 @@ int __metal_driver_riscv_clint0_register (struct metal_interrupt *controller,
 int __metal_driver_riscv_clint0_enable (struct metal_interrupt *controller, int id)
 {
     int rc = -1;
-    struct __metal_driver_riscv_clint0 *clint =
-                              (struct __metal_driver_riscv_clint0 *)(controller);
 
     if ( id ) {
         struct metal_interrupt *intc = NULL;
         struct metal_interrupt *cpu_intc = _get_cpu_intc();
+	int num_interrupts = __metal_driver_sifive_clint0_num_interrupts(controller);
 
-        for(int i = 0; i < clint->num_interrupts; i++) {
-            if(cpu_intc == clint->interrupt_parents[i] && id == clint->interrupt_lines[i]) {
-                intc = clint->interrupt_parents[i]; 
+        for(int i = 0; i < num_interrupts; i++) {
+	    int line = __metal_driver_sifive_clint0_interrupt_lines(controller, i);
+	    intc = __metal_driver_sifive_clint0_interrupt_parents(controller, i);
+            if(cpu_intc == intc && id == line) {
                 break;
             }
+	    intc = NULL;
         }
         
         /* Enable its interrupts with parent controller */
@@ -116,17 +121,19 @@ int __metal_driver_riscv_clint0_enable (struct metal_interrupt *controller, int 
 int __metal_driver_riscv_clint0_disable (struct metal_interrupt *controller, int id)
 {
     int rc = -1;
-    struct __metal_driver_riscv_clint0 *clint =
-                              (struct __metal_driver_riscv_clint0 *)(controller);
 
     if ( id ) {
         struct metal_interrupt *intc = NULL;
         struct metal_interrupt *cpu_intc = _get_cpu_intc();
+	int num_interrupts = __metal_driver_sifive_clint0_num_interrupts(controller);
 
-        for(int i = 0; i < clint->num_interrupts; i++) {
-            if(cpu_intc == clint->interrupt_parents[i] && id == clint->interrupt_lines[i]) {
-                intc = clint->interrupt_parents[i]; 
+        for(int i = 0; i < num_interrupts; i++) {
+	    int line = __metal_driver_sifive_clint0_interrupt_lines(controller, i);
+	    intc = __metal_driver_sifive_clint0_interrupt_parents(controller, i);
+            if(cpu_intc == intc && id == line) {
+                break;
             }
+	    intc = NULL;
         }
         
         /* Disable its interrupts with parent controller */
@@ -143,6 +150,7 @@ int __metal_driver_riscv_clint0_command_request (struct metal_interrupt *control
     int rc = -1;
     struct __metal_driver_riscv_clint0 *clint =
                               (struct __metal_driver_riscv_clint0 *)(controller);
+    unsigned long control_base = __metal_driver_sifive_clint0_control_base(controller);
 
     switch (command) {
     case METAL_TIMER_MTIME_GET:
@@ -160,7 +168,7 @@ int __metal_driver_riscv_clint0_command_request (struct metal_interrupt *control
     case METAL_SOFTWARE_IPI_CLEAR:
 	if (data) {
 	    hartid = *(int *)data;
-            __METAL_ACCESS_ONCE((__metal_io_u32 *)(clint->control_base +
+            __METAL_ACCESS_ONCE((__metal_io_u32 *)(control_base +
 					       (hartid * 4))) = METAL_DISABLE;
             rc = 0;
         }
@@ -168,7 +176,7 @@ int __metal_driver_riscv_clint0_command_request (struct metal_interrupt *control
     case METAL_SOFTWARE_IPI_SET:
 	if (data) {
 	    hartid = *(int *)data;
-            __METAL_ACCESS_ONCE((__metal_io_u32 *)(clint->control_base +
+            __METAL_ACCESS_ONCE((__metal_io_u32 *)(control_base +
 					       (hartid * 4))) = METAL_ENABLE;
             rc = 0;
         }
@@ -177,7 +185,7 @@ int __metal_driver_riscv_clint0_command_request (struct metal_interrupt *control
         rc = 0;
 	if (data) {
 	    hartid = *(int *)data;
-            rc = __METAL_ACCESS_ONCE((__metal_io_u32 *)(clint->control_base +
+            rc = __METAL_ACCESS_ONCE((__metal_io_u32 *)(control_base +
 						    (hartid * 4)));
         }
         break;
@@ -187,5 +195,13 @@ int __metal_driver_riscv_clint0_command_request (struct metal_interrupt *control
 
     return rc;
 }
+
+__METAL_DEFINE_VTABLE(__metal_driver_vtable_riscv_clint0) = {
+    .clint_vtable.interrupt_init     = __metal_driver_riscv_clint0_init,
+    .clint_vtable.interrupt_register = __metal_driver_riscv_clint0_register,
+    .clint_vtable.interrupt_enable   = __metal_driver_riscv_clint0_enable,
+    .clint_vtable.interrupt_disable  = __metal_driver_riscv_clint0_disable,
+    .clint_vtable.command_request    = __metal_driver_riscv_clint0_command_request,
+};
 
 #endif /* METAL_RISCV_CLINT0 */

--- a/src/drivers/riscv,clint0.c
+++ b/src/drivers/riscv,clint0.c
@@ -13,7 +13,7 @@
 unsigned long long __metal_clint0_mtime_get (struct __metal_driver_riscv_clint0 *clint)
 {
     __metal_io_u32 lo, hi;
-    unsigned long control_base = __metal_driver_sifive_clint0_control_base((struct metal_interrupt *)clint);
+    unsigned long control_base = __metal_driver_sifive_clint0_control_base(&clint->controller);
 
     /* Guard against rollover when reading */
     do {
@@ -26,7 +26,7 @@ unsigned long long __metal_clint0_mtime_get (struct __metal_driver_riscv_clint0 
 
 int __metal_clint0_mtime_set (struct __metal_driver_riscv_clint0 *clint, unsigned long long time)
 {   
-    unsigned long control_base = __metal_driver_sifive_clint0_control_base((struct metal_interrupt *)clint);
+    unsigned long control_base = __metal_driver_sifive_clint0_control_base(&clint->controller);
     /* Per spec, the RISC-V MTIME/MTIMECMP registers are 64 bit,
      * and are NOT internally latched for multiword transfers.
      * Need to be careful about sequencing to avoid triggering

--- a/src/drivers/riscv,plic0.c
+++ b/src/drivers/riscv,plic0.c
@@ -8,33 +8,38 @@
 #include <metal/io.h>
 #include <metal/shutdown.h>
 #include <metal/drivers/riscv,plic0.h>
+#include <metal/machine.h>
 
 unsigned int __metal_plic0_claim_interrupt (struct __metal_driver_riscv_plic0 *plic)
 {
-    return __METAL_ACCESS_ONCE((__metal_io_u32 *)(plic->control_base +
+    unsigned long control_base = __metal_driver_sifive_plic0_control_base((struct metal_interrupt *)plic);
+    return __METAL_ACCESS_ONCE((__metal_io_u32 *)(control_base +
 					      METAL_RISCV_PLIC0_CLAIM));
 }
 
 void __metal_plic0_complete_interrupt(struct __metal_driver_riscv_plic0 *plic,
 				    unsigned int id)
 {
-    __METAL_ACCESS_ONCE((__metal_io_u32 *)(plic->control_base +
+    unsigned long control_base = __metal_driver_sifive_plic0_control_base((struct metal_interrupt *)plic);
+    __METAL_ACCESS_ONCE((__metal_io_u32 *)(control_base +
 				       METAL_RISCV_PLIC0_CLAIM)) = id;
 }
 
 void __metal_plic0_set_threshold(struct __metal_driver_riscv_plic0 *plic,
 			       unsigned int threshold)
 {
-    __METAL_ACCESS_ONCE((__metal_io_u32 *)(plic->control_base +
+    unsigned long control_base = __metal_driver_sifive_plic0_control_base((struct metal_interrupt *)plic);
+    __METAL_ACCESS_ONCE((__metal_io_u32 *)(control_base +
 				       METAL_RISCV_PLIC0_THRESHOLD)) = threshold;
 }
 
 void __metal_plic0_set_priority(struct __metal_driver_riscv_plic0 *plic,
 			      int id, unsigned int priority)
 {
-    if ( (plic->max_priority) &&
-	 (priority < plic->max_priority) ) {
-        __METAL_ACCESS_ONCE((__metal_io_u32 *)(plic->control_base +
+    unsigned long control_base = __metal_driver_sifive_plic0_control_base((struct metal_interrupt *)plic);
+    int max_priority = __metal_driver_sifive_plic0_max_priority((struct metal_interrupt *)plic);
+    if ( (max_priority) && (priority < max_priority) ) {
+        __METAL_ACCESS_ONCE((__metal_io_u32 *)(control_base +
 					   METAL_RISCV_PLIC0_PRIORITY_BASE +
 					   (id << METAL_PLIC_SOURCE_PRIORITY_SHIFT))) = priority;
     }
@@ -44,11 +49,12 @@ void __metal_plic0_enable(struct __metal_driver_riscv_plic0 *plic, int id, int e
 {
     unsigned int current;
     unsigned long hartid = __metal_myhart_id();
+    unsigned long control_base = __metal_driver_sifive_plic0_control_base((struct metal_interrupt *)plic);
 
-    current = __METAL_ACCESS_ONCE((__metal_io_u32 *)(plic->control_base +
+    current = __METAL_ACCESS_ONCE((__metal_io_u32 *)(control_base +
 						METAL_RISCV_PLIC0_ENABLE_BASE +
 						(id >> METAL_PLIC_SOURCE_SHIFT) * 4));
-    __METAL_ACCESS_ONCE((__metal_io_u32 *)(plic->control_base +
+    __METAL_ACCESS_ONCE((__metal_io_u32 *)(control_base +
 					METAL_RISCV_PLIC0_ENABLE_BASE +
 					((id >> METAL_PLIC_SOURCE_SHIFT) * 4))) =
               enable ? (current | (1 << (id & METAL_PLIC_SOURCE_MASK)))
@@ -63,9 +69,9 @@ void __metal_plic0_handler (int id, void *priv)
 {
     struct __metal_driver_riscv_plic0 *plic = priv;
     unsigned int idx = __metal_plic0_claim_interrupt(plic);
+    int num_interrupts = __metal_driver_sifive_plic0_num_interrupts((struct metal_interrupt *)plic);
 
-    if ( (idx < plic->num_interrupts) &&
-	 (plic->metal_exint_table[idx]) ) {
+    if ( (idx < num_interrupts) && (plic->metal_exint_table[idx]) ) {
 	plic->metal_exint_table[idx](idx,
 				  plic->metal_exdata_table[idx].exint_data);
     }
@@ -78,15 +84,18 @@ void __metal_driver_riscv_plic0_init (struct metal_interrupt *controller)
     struct __metal_driver_riscv_plic0 *plic = (void *)(controller);
 
     if ( !plic->init_done ) {
+        int num_interrupts, line;
         struct metal_interrupt *intc;
 
 	for(int parent = 0; parent < __METAL_PLIC_NUM_PARENTS; parent++) {
-	    intc = plic->interrupt_parents[parent];
+	    num_interrupts = __metal_driver_sifive_plic0_num_interrupts(controller);
+	    intc = __metal_driver_sifive_plic0_interrupt_parents(controller, parent);
+	    line = __metal_driver_sifive_plic0_interrupt_lines(controller, parent);
 
 	    /* Initialize ist parent controller, aka cpu_intc. */
 	    intc->vtable->interrupt_init(intc);
 
-	    for (int i = 0; i < plic->num_interrupts; i++) {
+	    for (int i = 0; i < num_interrupts; i++) {
 		__metal_plic0_enable(plic, i, METAL_DISABLE);
 		__metal_plic0_set_priority(plic, i, 0);
 		plic->metal_exint_table[i] = NULL;
@@ -97,15 +106,11 @@ void __metal_driver_riscv_plic0_init (struct metal_interrupt *controller)
 	    __metal_plic0_set_threshold(plic, 0);
 
 	    /* Register plic (ext) interrupt with with parent controller */
-	    intc->vtable->interrupt_register(intc,
-					     plic->interrupt_lines[parent],
-					     NULL, plic);
+	    intc->vtable->interrupt_register(intc, line, NULL, plic);
 	    /* Register plic handler for dispatching its device interrupts */
-	    intc->vtable->interrupt_register(intc,
-					     plic->interrupt_lines[parent],
-					     __metal_plic0_handler, plic);
+	    intc->vtable->interrupt_register(intc, line, __metal_plic0_handler, plic);
 	    /* Enable plic (ext) interrupt with with parent controller */
-	    intc->vtable->interrupt_enable(intc, plic->interrupt_lines[parent]);
+	    intc->vtable->interrupt_enable(intc, line);
 	}
         plic->init_done = 1;
     }
@@ -117,7 +122,7 @@ int __metal_driver_riscv_plic0_register (struct metal_interrupt *controller,
 {
     struct __metal_driver_riscv_plic0 *plic = (void *)(controller);
 
-    if (id >= plic->num_interrupts ) {
+    if (id >= __metal_driver_sifive_plic0_num_interrupts(controller)) {
         return -1;
     }
  
@@ -138,7 +143,7 @@ int __metal_driver_riscv_plic0_enable (struct metal_interrupt *controller, int i
 {
     struct __metal_driver_riscv_plic0 *plic = (void *)(controller);
 
-    if ( id >= plic->num_interrupts ) {
+    if (id >= __metal_driver_sifive_plic0_num_interrupts(controller)) {
         return -1;
     }
 
@@ -150,11 +155,18 @@ int __metal_driver_riscv_plic0_disable (struct metal_interrupt *controller, int 
 {
     struct __metal_driver_riscv_plic0 *plic = (void *)(controller);
 
-    if ( id >= plic->num_interrupts ) {
+    if (id >= __metal_driver_sifive_plic0_num_interrupts(controller)) {
         return -1;
     }
     __metal_plic0_enable(plic, id, METAL_DISABLE);
     return 0;
 }
+
+__METAL_DEFINE_VTABLE(__metal_driver_vtable_riscv_plic0) = {
+    .plic_vtable.interrupt_init = __metal_driver_riscv_plic0_init,
+    .plic_vtable.interrupt_register = __metal_driver_riscv_plic0_register,
+    .plic_vtable.interrupt_enable   = __metal_driver_riscv_plic0_enable,
+    .plic_vtable.interrupt_disable  = __metal_driver_riscv_plic0_disable,
+};
 
 #endif /* METAL_RISCV_PLIC0 */

--- a/src/drivers/sifive,clic0.c
+++ b/src/drivers/sifive,clic0.c
@@ -9,6 +9,7 @@
 #include <metal/io.h>
 #include <metal/shutdown.h>
 #include <metal/drivers/sifive,clic0.h>
+#include <metal/machine.h>
 
 typedef enum metal_priv_mode_ {
     METAL_PRIV_M_MODE = 0,
@@ -40,14 +41,15 @@ struct __metal_clic_cfg __metal_clic0_configuration (struct __metal_driver_sifiv
     volatile unsigned char val;
     struct __metal_clic_cfg cliccfg;
     uintptr_t hartid = __metal_myhart_id();
+    unsigned long control_base = __metal_driver_sifive_clic0_control_base((struct metal_interrupt *)clic);
 
     if ( cfg ) {
         val = cfg->nmbits << 5 | cfg->nlbits << 1 | cfg->nvbit;
-        __METAL_ACCESS_ONCE((__metal_io_u8 *)(clic->control_base +
+        __METAL_ACCESS_ONCE((__metal_io_u8 *)(control_base +
                                        METAL_SIFIVE_CLIC0_MMODE_APERTURE +
                                        METAL_SIFIVE_CLIC0_CLICCFG)) = val;
     }
-    val = __METAL_ACCESS_ONCE((__metal_io_u8 *)(clic->control_base +
+    val = __METAL_ACCESS_ONCE((__metal_io_u8 *)(control_base +
                                        METAL_SIFIVE_CLIC0_MMODE_APERTURE +
                                        METAL_SIFIVE_CLIC0_CLICCFG));
     cliccfg.nmbits = (val & METAL_SIFIVE_CLIC0_CLICCFG_NMBITS_MASK) >> 5;
@@ -60,6 +62,7 @@ int __metal_clic0_interrupt_set_mode (struct __metal_driver_sifive_clic0 *clic, 
 {
     uint8_t mask, val;
     struct __metal_clic_cfg cfg = __metal_clic0_configuration(clic, NULL);
+    unsigned long control_base = __metal_driver_sifive_clic0_control_base((struct metal_interrupt *)clic);
  
     if (mode >= (cfg.nmbits << 1)) {
         /* Do nothing, mode request same or exceed what configured in CLIC */
@@ -68,10 +71,10 @@ int __metal_clic0_interrupt_set_mode (struct __metal_driver_sifive_clic0 *clic, 
  
     /* Mask out nmbits and retain other values */
     mask = ((uint8_t)(-1)) >> cfg.nmbits;
-    val = __METAL_ACCESS_ONCE((__metal_io_u8 *)(clic->control_base +
+    val = __METAL_ACCESS_ONCE((__metal_io_u8 *)(control_base +
                                        METAL_SIFIVE_CLIC0_MMODE_APERTURE +
                                        METAL_SIFIVE_CLIC0_CLICINTCTL_BASE + id)) & mask;
-    __METAL_ACCESS_ONCE((__metal_io_u8 *)(clic->control_base +
+    __METAL_ACCESS_ONCE((__metal_io_u8 *)(control_base +
                                  METAL_SIFIVE_CLIC0_MMODE_APERTURE +
                                  METAL_SIFIVE_CLIC0_CLICINTCTL_BASE + id)) = val | (mode << (8 - cfg.nmbits));
     return 0;
@@ -81,6 +84,7 @@ int __metal_clic0_interrupt_set_level (struct __metal_driver_sifive_clic0 *clic,
 {
     uint8_t mask, nmmask, nlmask, val;
     struct __metal_clic_cfg cfg = __metal_clic0_configuration(clic, NULL);
+    unsigned long control_base = __metal_driver_sifive_clic0_control_base((struct metal_interrupt *)clic);
 
     /* Drop the LSBs that don't fit in nlbits */
     level = level >> (METAL_CLIC_MAX_NLBITS - cfg.nlbits);
@@ -89,10 +93,10 @@ int __metal_clic0_interrupt_set_level (struct __metal_driver_sifive_clic0 *clic,
     nlmask = ((uint8_t)(-1)) >> (cfg.nmbits + cfg.nlbits);
     mask = ~(nlmask | nmmask);
   
-    val = __METAL_ACCESS_ONCE((__metal_io_u8 *)(clic->control_base +
+    val = __METAL_ACCESS_ONCE((__metal_io_u8 *)(control_base +
                                        METAL_SIFIVE_CLIC0_MMODE_APERTURE +
                                        METAL_SIFIVE_CLIC0_CLICINTCTL_BASE + id));
-    __METAL_ACCESS_ONCE((__metal_io_u8 *)(clic->control_base +
+    __METAL_ACCESS_ONCE((__metal_io_u8 *)(control_base +
                                  METAL_SIFIVE_CLIC0_MMODE_APERTURE +
                                  METAL_SIFIVE_CLIC0_CLICINTCTL_BASE + id)) = __METAL_SET_FIELD(val, mask, level);
     return 0;
@@ -103,9 +107,11 @@ int __metal_clic0_interrupt_get_level (struct __metal_driver_sifive_clic0 *clic,
     int level;
     uint8_t mask, val, freebits, nlbits;
     struct __metal_clic_cfg cfg = __metal_clic0_configuration(clic, NULL);
+    unsigned long control_base = __metal_driver_sifive_clic0_control_base((struct metal_interrupt *)clic);
+    int num_intbits = __metal_driver_sifive_clic0_num_intbits((struct metal_interrupt *)clic);
 
-    if ((cfg.nmbits + cfg.nlbits) >= clic->num_intbits) {
-        nlbits = clic->num_intbits - cfg.nmbits;
+    if ((cfg.nmbits + cfg.nlbits) >= num_intbits) {
+        nlbits = num_intbits - cfg.nmbits;
     } else {
         nlbits = cfg.nlbits;
     }
@@ -116,7 +122,7 @@ int __metal_clic0_interrupt_get_level (struct __metal_driver_sifive_clic0 *clic,
     if (mask == 0) {
         level = (1 << METAL_CLIC_MAX_NLBITS) - 1;
     } else {
-        val = __METAL_ACCESS_ONCE((__metal_io_u8 *)(clic->control_base +
+        val = __METAL_ACCESS_ONCE((__metal_io_u8 *)(control_base +
                                        METAL_SIFIVE_CLIC0_MMODE_APERTURE +
                                        METAL_SIFIVE_CLIC0_CLICINTCTL_BASE + id));
         val = __METAL_GET_FIELD(val, mask);
@@ -130,19 +136,21 @@ int __metal_clic0_interrupt_set_priority (struct __metal_driver_sifive_clic0 *cl
 {
     uint8_t mask, npmask, val, npbits;
     struct __metal_clic_cfg cfg = __metal_clic0_configuration(clic, NULL);
+    unsigned long control_base = __metal_driver_sifive_clic0_control_base((struct metal_interrupt *)clic);
+    int num_intbits = __metal_driver_sifive_clic0_num_intbits((struct metal_interrupt *)clic);
 
-    if ((cfg.nmbits + cfg.nlbits) < clic->num_intbits) {
-        npbits = clic->num_intbits - (cfg.nmbits + cfg.nlbits);
+    if ((cfg.nmbits + cfg.nlbits) < num_intbits) {
+        npbits = num_intbits - (cfg.nmbits + cfg.nlbits);
         priority = priority >> (8 - npbits);
 
         mask = ((uint8_t)(-1)) >> (cfg.nmbits + cfg.nlbits + npbits);
         npmask = ~(((uint8_t)(-1)) >> (cfg.nmbits + cfg.nlbits));
         mask = ~(mask | npmask);
 
-        val = __METAL_ACCESS_ONCE((__metal_io_u8 *)(clic->control_base +
+        val = __METAL_ACCESS_ONCE((__metal_io_u8 *)(control_base +
                                        METAL_SIFIVE_CLIC0_MMODE_APERTURE +
                                        METAL_SIFIVE_CLIC0_CLICINTCTL_BASE + id));
-        __METAL_ACCESS_ONCE((__metal_io_u8 *)(clic->control_base +
+        __METAL_ACCESS_ONCE((__metal_io_u8 *)(control_base +
                                      METAL_SIFIVE_CLIC0_MMODE_APERTURE +
                                      METAL_SIFIVE_CLIC0_CLICINTCTL_BASE + id)) = __METAL_SET_FIELD(val, mask, priority);
     }
@@ -154,9 +162,11 @@ int __metal_clic0_interrupt_get_priority (struct __metal_driver_sifive_clic0 *cl
     int priority;
     uint8_t mask, val, freebits, nlbits;
     struct __metal_clic_cfg cfg = __metal_clic0_configuration(clic, NULL);
+    unsigned long control_base = __metal_driver_sifive_clic0_control_base((struct metal_interrupt *)clic);
+    int num_intbits = __metal_driver_sifive_clic0_num_intbits((struct metal_interrupt *)clic);
 
-    if ((cfg.nmbits + cfg.nlbits) >= clic->num_intbits) {
-        nlbits = clic->num_intbits - cfg.nmbits;
+    if ((cfg.nmbits + cfg.nlbits) >= num_intbits) {
+        nlbits = num_intbits - cfg.nmbits;
     } else {
         nlbits = cfg.nlbits;
     }
@@ -167,7 +177,7 @@ int __metal_clic0_interrupt_get_priority (struct __metal_driver_sifive_clic0 *cl
     if (mask == 0) {
         priority = (1 << METAL_CLIC_MAX_NLBITS) - 1;
     } else {                           
-        val = __METAL_ACCESS_ONCE((__metal_io_u8 *)(clic->control_base +
+        val = __METAL_ACCESS_ONCE((__metal_io_u8 *)(control_base +
                                        METAL_SIFIVE_CLIC0_MMODE_APERTURE +
                                        METAL_SIFIVE_CLIC0_CLICINTCTL_BASE + id));
         priority = __METAL_GET_FIELD(val, freebits);
@@ -178,14 +188,16 @@ int __metal_clic0_interrupt_get_priority (struct __metal_driver_sifive_clic0 *cl
 int __metal_clic0_interrupt_set_vector (struct __metal_driver_sifive_clic0 *clic, int id, int enable)
 {   
     uint8_t mask, val;
+    unsigned long control_base = __metal_driver_sifive_clic0_control_base((struct metal_interrupt *)clic);
+    int num_intbits = __metal_driver_sifive_clic0_num_intbits((struct metal_interrupt *)clic);
 
-    mask = 1 << (8 - clic->num_intbits);
-    val = __METAL_ACCESS_ONCE((__metal_io_u8 *)(clic->control_base +
+    mask = 1 << (8 - num_intbits);
+    val = __METAL_ACCESS_ONCE((__metal_io_u8 *)(control_base +
                                        METAL_SIFIVE_CLIC0_MMODE_APERTURE +
                                        METAL_SIFIVE_CLIC0_CLICINTCTL_BASE + id));
     /* Ensure its value is 1 bit wide */
     enable &= 0x1;
-    __METAL_ACCESS_ONCE((__metal_io_u8 *)(clic->control_base +
+    __METAL_ACCESS_ONCE((__metal_io_u8 *)(control_base +
                                  METAL_SIFIVE_CLIC0_MMODE_APERTURE +
                                  METAL_SIFIVE_CLIC0_CLICINTCTL_BASE + id)) = __METAL_SET_FIELD(val, mask, enable);
     return 0;
@@ -194,9 +206,11 @@ int __metal_clic0_interrupt_set_vector (struct __metal_driver_sifive_clic0 *clic
 int __metal_clic0_interrupt_is_vectored (struct __metal_driver_sifive_clic0 *clic, int id)
 {
     uint8_t mask, val;
+    unsigned long control_base = __metal_driver_sifive_clic0_control_base((struct metal_interrupt *)clic);
+    int num_intbits = __metal_driver_sifive_clic0_num_intbits((struct metal_interrupt *)clic);
 
-    mask = 1 << (8 - clic->num_intbits);
-    val = __METAL_ACCESS_ONCE((__metal_io_u8 *)(clic->control_base +
+    mask = 1 << (8 - num_intbits);
+    val = __METAL_ACCESS_ONCE((__metal_io_u8 *)(control_base +
                                        METAL_SIFIVE_CLIC0_MMODE_APERTURE +
                                        METAL_SIFIVE_CLIC0_CLICINTCTL_BASE + id));
     return __METAL_GET_FIELD(val, mask);
@@ -204,10 +218,13 @@ int __metal_clic0_interrupt_is_vectored (struct __metal_driver_sifive_clic0 *cli
 
 int __metal_clic0_interrupt_enable (struct __metal_driver_sifive_clic0 *clic, int id)
 {
-    if (id >= clic->num_subinterrupts) {
+    unsigned long control_base = __metal_driver_sifive_clic0_control_base((struct metal_interrupt *)clic);
+    int num_subinterrupts = __metal_driver_sifive_clic0_num_subinterrupts((struct metal_interrupt *)clic);
+
+    if (id >= num_subinterrupts) {
         return -1;
     }
-    __METAL_ACCESS_ONCE((__metal_io_u8 *)(clic->control_base +
+    __METAL_ACCESS_ONCE((__metal_io_u8 *)(control_base +
                                        METAL_SIFIVE_CLIC0_MMODE_APERTURE +
                                        METAL_SIFIVE_CLIC0_CLICINTIE_BASE + id)) = METAL_ENABLE;
     return 0;
@@ -215,10 +232,13 @@ int __metal_clic0_interrupt_enable (struct __metal_driver_sifive_clic0 *clic, in
 
 int __metal_clic0_interrupt_disable (struct __metal_driver_sifive_clic0 *clic, int id)
 {
-    if (id >= clic->num_subinterrupts) {
+    unsigned long control_base = __metal_driver_sifive_clic0_control_base((struct metal_interrupt *)clic);
+    int num_subinterrupts = __metal_driver_sifive_clic0_num_subinterrupts((struct metal_interrupt *)clic);
+
+    if (id >= num_subinterrupts) {
         return -1;
     }
-    __METAL_ACCESS_ONCE((__metal_io_u8 *)(clic->control_base +
+    __METAL_ACCESS_ONCE((__metal_io_u8 *)(control_base +
                                        METAL_SIFIVE_CLIC0_MMODE_APERTURE +
                                        METAL_SIFIVE_CLIC0_CLICINTIE_BASE + id)) = METAL_DISABLE;
     return 0;
@@ -226,34 +246,44 @@ int __metal_clic0_interrupt_disable (struct __metal_driver_sifive_clic0 *clic, i
 
 int __metal_clic0_interrupt_is_enabled (struct __metal_driver_sifive_clic0 *clic, int id)
 {
-    if (id >= clic->num_subinterrupts) {
+    unsigned long control_base = __metal_driver_sifive_clic0_control_base((struct metal_interrupt *)clic);
+    int num_subinterrupts = __metal_driver_sifive_clic0_num_subinterrupts((struct metal_interrupt *)clic);
+
+    if (id >= num_subinterrupts) {
         return 0;
     }
-    return __METAL_ACCESS_ONCE((__metal_io_u8 *)(clic->control_base +
+    return __METAL_ACCESS_ONCE((__metal_io_u8 *)(control_base +
                                        METAL_SIFIVE_CLIC0_MMODE_APERTURE +
                                        METAL_SIFIVE_CLIC0_CLICINTIE_BASE + id));
 }
 
 int __metal_clic0_interrupt_is_pending (struct __metal_driver_sifive_clic0 *clic, int id)
 {
-    if (id >= clic->num_subinterrupts) {
+    unsigned long control_base = __metal_driver_sifive_clic0_control_base((struct metal_interrupt *)clic);
+    int num_subinterrupts = __metal_driver_sifive_clic0_num_subinterrupts((struct metal_interrupt *)clic);
+
+    if (id >= num_subinterrupts) {
         return 0;
     }
-    return __METAL_ACCESS_ONCE((__metal_io_u8 *)(clic->control_base +
+    return __METAL_ACCESS_ONCE((__metal_io_u8 *)(control_base +
                                        METAL_SIFIVE_CLIC0_MMODE_APERTURE +
                                        METAL_SIFIVE_CLIC0_CLICINTIP_BASE + id));
 }
 
 int __metal_clic0_interrupt_set (struct __metal_driver_sifive_clic0 *clic, int id)
 {       
-    if ((id >= METAL_INTERRUPT_ID_LC0) && (id < clic->num_subinterrupts)) {
+    int num_subinterrupts = __metal_driver_sifive_clic0_num_subinterrupts((struct metal_interrupt *)clic);
+
+    if ((id >= METAL_INTERRUPT_ID_LC0) && (id < num_subinterrupts)) {
     }
     return 0;
 }
 
 int __metal_clic0_interrupt_clear (struct __metal_driver_sifive_clic0 *clic, int id)
 {
-    if ((id >= METAL_INTERRUPT_ID_LC0) && (id < clic->num_subinterrupts)) {
+    int num_subinterrupts = __metal_driver_sifive_clic0_num_subinterrupts((struct metal_interrupt *)clic);
+
+    if ((id >= METAL_INTERRUPT_ID_LC0) && (id < num_subinterrupts)) {
     }
     return 0;
 }
@@ -277,27 +307,29 @@ void __metal_clic0_configure_level (struct __metal_driver_sifive_clic0 *clic, in
 unsigned long long __metal_clic0_mtime_get (struct __metal_driver_sifive_clic0 *clic)
 {
     __metal_io_u32 lo, hi;
+    unsigned long control_base = __metal_driver_sifive_clic0_control_base((struct metal_interrupt *)clic);
 
     /* Guard against rollover when reading */
     do {
-	hi = __METAL_ACCESS_ONCE((__metal_io_u32 *)(clic->control_base + METAL_SIFIVE_CLIC0_MTIME + 4));
-	lo = __METAL_ACCESS_ONCE((__metal_io_u32 *)(clic->control_base + METAL_SIFIVE_CLIC0_MTIME));
-    } while (__METAL_ACCESS_ONCE((__metal_io_u32 *)(clic->control_base + METAL_SIFIVE_CLIC0_MTIME + 4)) != hi);
+	hi = __METAL_ACCESS_ONCE((__metal_io_u32 *)(control_base + METAL_SIFIVE_CLIC0_MTIME + 4));
+	lo = __METAL_ACCESS_ONCE((__metal_io_u32 *)(control_base + METAL_SIFIVE_CLIC0_MTIME));
+    } while (__METAL_ACCESS_ONCE((__metal_io_u32 *)(control_base + METAL_SIFIVE_CLIC0_MTIME + 4)) != hi);
 
     return (((unsigned long long)hi) << 32) | lo;
 }
 
 int __metal_clic0_mtime_set (struct __metal_driver_sifive_clic0 *clic, unsigned long long time)
 {   
+    unsigned long control_base = __metal_driver_sifive_clic0_control_base((struct metal_interrupt *)clic);
     /* Per spec, the RISC-V MTIME/MTIMECMP registers are 64 bit,
      * and are NOT internally latched for multiword transfers.
      * Need to be careful about sequencing to avoid triggering
      * spurious interrupts: For that set the high word to a max
      * value first.
      */
-    __METAL_ACCESS_ONCE((__metal_io_u32 *)(clic->control_base + METAL_SIFIVE_CLIC0_MTIMECMP_BASE + 4)) = 0xFFFFFFFF;
-    __METAL_ACCESS_ONCE((__metal_io_u32 *)(clic->control_base + METAL_SIFIVE_CLIC0_MTIMECMP_BASE)) = (__metal_io_u32)time;
-    __METAL_ACCESS_ONCE((__metal_io_u32 *)(clic->control_base + METAL_SIFIVE_CLIC0_MTIMECMP_BASE + 4)) = (__metal_io_u32)(time >> 32);
+    __METAL_ACCESS_ONCE((__metal_io_u32 *)(control_base + METAL_SIFIVE_CLIC0_MTIMECMP_BASE + 4)) = 0xFFFFFFFF;
+    __METAL_ACCESS_ONCE((__metal_io_u32 *)(control_base + METAL_SIFIVE_CLIC0_MTIMECMP_BASE)) = (__metal_io_u32)time;
+    __METAL_ACCESS_ONCE((__metal_io_u32 *)(control_base + METAL_SIFIVE_CLIC0_MTIMECMP_BASE + 4)) = (__metal_io_u32)(time >> 32);
     return 0;
 }
 
@@ -306,9 +338,10 @@ void __metal_clic0_handler (int id, void *priv)
 {
     int idx;
     struct __metal_driver_sifive_clic0 *clic = priv;
+    int num_subinterrupts = __metal_driver_sifive_clic0_num_subinterrupts((struct metal_interrupt *)clic);
 
     idx = id - METAL_INTERRUPT_ID_LC0;
-    if ( (idx < clic->num_subinterrupts) && (clic->metal_mtvt_table[idx]) ) {
+    if ( (idx < num_subinterrupts) && (clic->metal_mtvt_table[idx]) ) {
         clic->metal_mtvt_table[idx](id, clic->metal_exint_table[idx].exint_data);
     }
 }
@@ -323,9 +356,10 @@ void __metal_driver_sifive_clic0_init (struct metal_interrupt *controller)
                               (struct __metal_driver_sifive_clic0 *)(controller);
 
     if ( !clic->init_done ) {
-        int level;
+        int level, max_levels, line, num_interrupts, num_subinterrupts;
         struct __metal_clic_cfg cfg = __metal_clic_defaultcfg;
-        struct metal_interrupt *intc = clic->interrupt_parent;
+        struct metal_interrupt *intc =
+	    __metal_driver_sifive_clic0_interrupt_parent(controller);
 
         /* Initialize ist parent controller, aka cpu_intc. */
         intc->vtable->interrupt_init(intc);
@@ -336,19 +370,21 @@ void __metal_driver_sifive_clic0_init (struct metal_interrupt *controller)
          * Register its interrupts with with parent controller,
          * aka sw, timer and ext to its default isr
          */
-        for (int i = 0; i < clic->num_interrupts; i++) {
-            intc->vtable->interrupt_register(intc,
-                                             clic->interrupt_lines[i],
-                                             NULL, clic);
+	num_interrupts = __metal_driver_sifive_clic0_num_interrupts(controller);
+        for (int i = 0; i < num_interrupts; i++) {
+	    line = __metal_driver_sifive_clic0_interrupt_lines(controller, i);
+            intc->vtable->interrupt_register(intc, line, NULL, clic);
         }
 
         /* Default CLIC mode to per dts */
-        cfg.nlbits = (clic->max_levels > METAL_CLIC_MAX_NLBITS) ?
-                                METAL_CLIC_MAX_NLBITS : clic->max_levels;
+	max_levels = __metal_driver_sifive_clic0_max_levels(controller);
+        cfg.nlbits = (max_levels > METAL_CLIC_MAX_NLBITS) ?
+                                METAL_CLIC_MAX_NLBITS : max_levels;
         __metal_clic0_configuration(clic, &cfg);
 
         level = (1 << cfg.nlbits) - 1;
-        for (int i = 0; i < clic->num_subinterrupts; i++) {
+	num_subinterrupts = __metal_driver_sifive_clic0_num_subinterrupts(controller);
+        for (int i = 0; i < num_subinterrupts; i++) {
             clic->metal_mtvt_table[i] = NULL;
             clic->metal_exint_table[i].sub_int = NULL;
             clic->metal_exint_table[i].exint_data = NULL;
@@ -364,9 +400,11 @@ int __metal_driver_sifive_clic0_register (struct metal_interrupt *controller,
                                         void *priv)
 {
     int rc = -1;
+    int num_subinterrupts;
     struct __metal_driver_sifive_clic0 *clic =
                               (struct __metal_driver_sifive_clic0 *)(controller);
-    struct metal_interrupt *intc = clic->interrupt_parent;
+    struct metal_interrupt *intc =
+                       __metal_driver_sifive_clic0_interrupt_parent(controller);
 
     /* Register its interrupts with parent controller */
     if ( id < METAL_INTERRUPT_ID_LC0) {
@@ -378,7 +416,8 @@ int __metal_driver_sifive_clic0_register (struct metal_interrupt *controller,
      * Reset the IDs to reflects this. 
      */
     id -= METAL_INTERRUPT_ID_LC0;
-    if (id < clic->num_subinterrupts) {
+    num_subinterrupts = __metal_driver_sifive_clic0_num_subinterrupts(controller);
+    if (id < num_subinterrupts) {
         if ( isr) {
             clic->metal_mtvt_table[id] = isr;
             clic->metal_exint_table[id].exint_data = priv;        
@@ -408,6 +447,7 @@ int __metal_driver_sifive_clic0_disable (struct metal_interrupt *controller, int
 int __metal_driver_sifive_clic0_enable_interrupt_vector(struct metal_interrupt *controller,
                                                       int id, metal_vector_mode mode)
 {
+    int num_subinterrupts;
     struct __metal_driver_sifive_clic0 *clic =
                               (struct __metal_driver_sifive_clic0 *)(controller);
 
@@ -421,7 +461,8 @@ int __metal_driver_sifive_clic0_enable_interrupt_vector(struct metal_interrupt *
             return 0;
         }
     }
-    if ((id >= METAL_INTERRUPT_ID_LC0) && (id < clic->num_subinterrupts)) {
+    num_subinterrupts = __metal_driver_sifive_clic0_num_subinterrupts(controller);
+    if ((id >= METAL_INTERRUPT_ID_LC0) && (id < num_subinterrupts)) {
         if ((mode == METAL_SELECTIVE_VECTOR_MODE) &&
              __metal_controller_interrupt_is_selective_vectored()) {
             __metal_clic0_interrupt_set_vector(clic, id, METAL_ENABLE);
@@ -434,6 +475,7 @@ int __metal_driver_sifive_clic0_enable_interrupt_vector(struct metal_interrupt *
 
 int __metal_driver_sifive_clic0_disable_interrupt_vector(struct metal_interrupt *controller, int id)
 {
+    int num_subinterrupts;
     struct __metal_driver_sifive_clic0 *clic =
                               (struct __metal_driver_sifive_clic0 *)(controller);
 
@@ -441,7 +483,8 @@ int __metal_driver_sifive_clic0_disable_interrupt_vector(struct metal_interrupt 
         __metal_controller_interrupt_vector(METAL_SELECTIVE_VECTOR_MODE, &__metal_clic0_handler);
         return 0;
     }
-    if ((id >= METAL_INTERRUPT_ID_LC0) && (id < clic->num_subinterrupts)) {
+    num_subinterrupts = __metal_driver_sifive_clic0_num_subinterrupts(controller);
+    if ((id >= METAL_INTERRUPT_ID_LC0) && (id < num_subinterrupts)) {
         if  (__metal_controller_interrupt_is_selective_vectored()) {
             __metal_clic0_interrupt_set_vector(clic, id, METAL_DISABLE);
             return 0;
@@ -457,6 +500,7 @@ int __metal_driver_sifive_clic0_command_request (struct metal_interrupt *control
     int rc = -1;
     struct __metal_driver_sifive_clic0 *clic =
                               (struct __metal_driver_sifive_clic0 *)(controller);
+    unsigned long control_base = __metal_driver_sifive_clic0_control_base(controller);
 
     switch (command) {
     case METAL_TIMER_MTIME_GET:
@@ -474,9 +518,9 @@ int __metal_driver_sifive_clic0_command_request (struct metal_interrupt *control
     case METAL_SOFTWARE_IPI_CLEAR:
 	if (data) {
 	    hartid = *(int *)data;
-            __METAL_ACCESS_ONCE((__metal_io_u32 *)(clic->control_base +
+            __METAL_ACCESS_ONCE((__metal_io_u32 *)(control_base +
 					       (hartid * 4))) = METAL_DISABLE;
-           __METAL_ACCESS_ONCE((__metal_io_u8 *)(clic->control_base +
+           __METAL_ACCESS_ONCE((__metal_io_u8 *)(control_base +
                                               METAL_SIFIVE_CLIC0_MMODE_APERTURE +
                                               METAL_SIFIVE_CLIC0_CLICINTIP_BASE)) = METAL_DISABLE;
             rc = 0;
@@ -485,9 +529,9 @@ int __metal_driver_sifive_clic0_command_request (struct metal_interrupt *control
     case METAL_SOFTWARE_IPI_SET:
 	if (data) {
 	    hartid = *(int *)data;
-            __METAL_ACCESS_ONCE((__metal_io_u32 *)(clic->control_base +
+            __METAL_ACCESS_ONCE((__metal_io_u32 *)(control_base +
 					       (hartid * 4))) = METAL_ENABLE;
-            __METAL_ACCESS_ONCE((__metal_io_u8 *)(clic->control_base +
+            __METAL_ACCESS_ONCE((__metal_io_u8 *)(control_base +
                                                METAL_SIFIVE_CLIC0_MMODE_APERTURE +
                                                METAL_SIFIVE_CLIC0_CLICINTIP_BASE)) = METAL_ENABLE;
             rc = 0;
@@ -497,7 +541,7 @@ int __metal_driver_sifive_clic0_command_request (struct metal_interrupt *control
         rc = 0;
 	if (data) {
 	    hartid = *(int *)data;
-            rc = __METAL_ACCESS_ONCE((__metal_io_u32 *)(clic->control_base +
+            rc = __METAL_ACCESS_ONCE((__metal_io_u32 *)(control_base +
 						    (hartid * 4)));
         }
         break;
@@ -507,5 +551,14 @@ int __metal_driver_sifive_clic0_command_request (struct metal_interrupt *control
 
     return rc;
 }
+__METAL_DEFINE_VTABLE(__metal_driver_vtable_sifive_clic0) = {
+    .clic_vtable.interrupt_init     = __metal_driver_sifive_clic0_init,
+    .clic_vtable.interrupt_register = __metal_driver_sifive_clic0_register,
+    .clic_vtable.interrupt_enable   = __metal_driver_sifive_clic0_enable,
+    .clic_vtable.interrupt_disable  = __metal_driver_sifive_clic0_disable,
+    .clic_vtable.interrupt_vector_enable   = __metal_driver_sifive_clic0_enable_interrupt_vector,
+    .clic_vtable.interrupt_vector_disable  = __metal_driver_sifive_clic0_disable_interrupt_vector,
+    .clic_vtable.command_request    = __metal_driver_sifive_clic0_command_request,
+};
 
 #endif /* METAL_SIFIVE_CLIC0 */

--- a/src/drivers/sifive,fe310-g000,hfrosc.c
+++ b/src/drivers/sifive,fe310-g000,hfrosc.c
@@ -1,7 +1,12 @@
 /* Copyright 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 
+#include <metal/machine/platform.h>
+
+#ifdef METAL_SIFIVE_FE310_G000_HFROSC
+
 #include <metal/drivers/sifive,fe310-g000,hfrosc.h>
+#include <metal/machine.h>
 
 #define CONFIG_DIVIDER 0x0000003FUL
 #define CONFIG_TRIM    0x001F0000UL
@@ -10,16 +15,28 @@
 
 long __metal_driver_sifive_fe310_g000_hfrosc_get_rate_hz(const struct metal_clock *clock)
 {
-    struct __metal_driver_sifive_fe310_g000_hfrosc *clk = (void *)clock;
-    long cfg = clk->config_base->vtable->get_reg(clk->config_base, clk->config_offset);
+    struct metal_clock *ref = __metal_driver_sifive_fe310_g000_hfrosc_ref(clock);
+    long config_offset = __metal_driver_sifive_fe310_g000_hfrosc_config_offset(clock);
+    struct __metal_driver_sifive_fe310_g000_prci *config_base =
+      __metal_driver_sifive_fe310_g000_hfrosc_config_base(clock);
+    struct __metal_driver_vtable_sifive_fe310_g000_prci *vtable =
+      __metal_driver_sifive_fe310_g000_prci_vtable();
+    long cfg = vtable->get_reg(config_base, config_offset);
+
     if (cfg & CONFIG_ENABLE == 0)
         return -1;
     if (cfg & CONFIG_READY == 0)
         return -1;
-    return metal_clock_get_rate_hz(clk->ref) / ((cfg & CONFIG_DIVIDER) + 1);
+    return metal_clock_get_rate_hz(ref) / ((cfg & CONFIG_DIVIDER) + 1);
 }
 
 long __metal_driver_sifive_fe310_g000_hfrosc_set_rate_hz(struct metal_clock *clock, long rate)
 {
     return __metal_driver_sifive_fe310_g000_hfrosc_get_rate_hz(clock);
 }
+
+__METAL_DEFINE_VTABLE(__metal_driver_vtable_sifive_fe310_g000_hfrosc) = {
+    .clock.get_rate_hz = &__metal_driver_sifive_fe310_g000_hfrosc_get_rate_hz,
+    .clock.set_rate_hz = &__metal_driver_sifive_fe310_g000_hfrosc_set_rate_hz,
+};
+#endif /* METAL_SIFIVE_FE310_G000_HFROSC */

--- a/src/drivers/sifive,fe310-g000,hfxosc.c
+++ b/src/drivers/sifive,fe310-g000,hfxosc.c
@@ -1,23 +1,41 @@
 /* Copyright 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 
+#include <metal/machine/platform.h>
+
+#ifdef METAL_SIFIVE_FE310_G000_HFXOSC
+
 #include <metal/drivers/sifive,fe310-g000,hfxosc.h>
+#include <metal/machine.h>
 
 #define CONFIG_ENABLE  0x40000000UL
 #define CONFIG_READY   0x80000000UL
 
 long __metal_driver_sifive_fe310_g000_hfxosc_get_rate_hz(const struct metal_clock *clock)
 {
-    struct __metal_driver_sifive_fe310_g000_hfxosc *clk = (void *)clock;
-    long cfg = clk->config_base->vtable->get_reg(clk->config_base, clk->config_offset);
+    struct metal_clock *ref = __metal_driver_sifive_fe310_g000_hfxosc_ref(clock);
+    long config_offset = __metal_driver_sifive_fe310_g000_hfxosc_config_offset(clock);
+    struct __metal_driver_sifive_fe310_g000_prci *config_base =
+      __metal_driver_sifive_fe310_g000_hfxosc_config_base(clock);
+    struct __metal_driver_vtable_sifive_fe310_g000_prci *vtable =
+      __metal_driver_sifive_fe310_g000_prci_vtable();
+    long cfg = vtable->get_reg(config_base, config_offset);
+
     if (cfg & CONFIG_ENABLE == 0)
         return -1;
     if (cfg & CONFIG_READY == 0)
         return -1;
-    return metal_clock_get_rate_hz(clk->ref);
+    return metal_clock_get_rate_hz(ref);
 }
 
 long __metal_driver_sifive_fe310_g000_hfxosc_set_rate_hz(struct metal_clock *clock, long rate)
 {
     return __metal_driver_sifive_fe310_g000_hfxosc_get_rate_hz(clock);
 }
+
+__METAL_DEFINE_VTABLE(__metal_driver_vtable_sifive_fe310_g000_hfxosc) = {
+    .clock.get_rate_hz = __metal_driver_sifive_fe310_g000_hfxosc_get_rate_hz,
+    .clock.set_rate_hz = __metal_driver_sifive_fe310_g000_hfxosc_set_rate_hz,
+};
+
+#endif /* METAL_SIFIVE_FE310_G000_HFXOSC */

--- a/src/drivers/sifive,fe310-g000,prci.c
+++ b/src/drivers/sifive,fe310-g000,prci.c
@@ -1,12 +1,26 @@
 /* Copyright 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 
+#include <metal/machine/platform.h>
+
+#ifdef METAL_SIFIVE_FE310_G000_PRCI
+
 #include <metal/drivers/sifive,fe310-g000,prci.h>
+#include <metal/machine.h>
 
 long __metal_driver_sifive_fe310_g000_prci_get_reg(const struct __metal_driver_sifive_fe310_g000_prci *prci, long offset) {
-    return __METAL_ACCESS_ONCE((__metal_io_u32 *)(prci->base + offset));
+    unsigned long base = __metal_driver_sifive_fe310_g000_prci_base();
+    return __METAL_ACCESS_ONCE((__metal_io_u32 *)(base + offset));
 }
 
 long __metal_driver_sifive_fe310_g000_prci_set_reg(const struct __metal_driver_sifive_fe310_g000_prci *prci, long offset, long value) {
-    return __METAL_ACCESS_ONCE((__metal_io_u32 *)(prci->base + offset)) = value;
+    unsigned long base = __metal_driver_sifive_fe310_g000_prci_base();
+    return __METAL_ACCESS_ONCE((__metal_io_u32 *)(base + offset)) = value;
 }
+
+__METAL_DEFINE_VTABLE(__metal_driver_vtable_sifive_fe310_g000_prci) = {
+    .get_reg = __metal_driver_sifive_fe310_g000_prci_get_reg,
+    .set_reg = __metal_driver_sifive_fe310_g000_prci_set_reg,
+};
+
+#endif /* METAL_SIFIVE_FE310_G000_PRCI */

--- a/src/drivers/sifive,fu540-c000,l2.c
+++ b/src/drivers/sifive,fu540-c000,l2.c
@@ -72,4 +72,10 @@ int __metal_driver_sifive_fu540_c000_l2_set_enabled_ways(struct metal_cache *cac
     return 0;
 }
 
+__METAL_DEFINE_VTABLE(__metal_driver_vtable_sifive_fu540_c000_l2) = {
+	.cache.init = __metal_driver_sifive_fu540_c000_l2_init,
+	.cache.get_enabled_ways = __metal_driver_sifive_fu540_c000_l2_get_enabled_ways,
+	.cache.set_enabled_ways = __metal_driver_sifive_fu540_c000_l2_set_enabled_ways,
+};
+
 #endif

--- a/src/drivers/sifive,global-external-interrupts0.c
+++ b/src/drivers/sifive,global-external-interrupts0.c
@@ -1,9 +1,14 @@
 /* Copyright 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 
+#include <metal/machine/platform.h>
+
+#ifdef METAL_SIFIVE_GLOBAL_EXTERNAL_INTERRUPTS0
+
 #include <metal/io.h>
 #include <metal/shutdown.h>
 #include <metal/drivers/sifive,global-external-interrupts0.h>
+#include <metal/machine.h>
 
 void __metal_driver_sifive_global_external_interrupt_init(struct metal_interrupt *controller)
 {
@@ -11,15 +16,18 @@ void __metal_driver_sifive_global_external_interrupt_init(struct metal_interrupt
 
     global0 = (struct __metal_driver_sifive_global_external_interrupts0 *)(controller);
     if ( !global0->init_done ) {
-        struct metal_interrupt *intc = global0->interrupt_parent;
+        struct metal_interrupt *intc =
+	    __metal_driver_sifive_global_external_interrupts0_interrupt_parent(controller);
 
 	if (intc) {
 	    intc->vtable->interrupt_init(intc);
 	    /* Register its interrupts with with parent controller */
-            for (int i = 0; i < global0->num_interrupts; i++) {
+            for (int i = 0;
+		 i < __metal_driver_sifive_global_external_interrupts0_num_interrupts(controller);
+		 i++) {
 	    	intc->vtable->interrupt_register(intc,
-						global0->interrupt_lines[i],
-						NULL, global0);
+		    __metal_driver_sifive_global_external_interrupts0_interrupt_lines(controller, i),
+						 NULL, controller);
 	    }
             global0->init_done = 1;
 	}
@@ -31,11 +39,10 @@ int __metal_driver_sifive_global_external_interrupt_register(struct metal_interr
                                                            void *priv)
 {
     int rc = -1;
-    struct __metal_driver_sifive_global_external_interrupts0 *global0 =
-                              (struct __metal_driver_sifive_global_external_interrupts0 *)(controller);
 
     if (id != 0) {
-        struct metal_interrupt *intc = global0->interrupt_parent;
+        struct metal_interrupt *intc =
+	    __metal_driver_sifive_global_external_interrupts0_interrupt_parent(controller);
 
         /* Enable its interrupts with parent controller */
         if (intc) {
@@ -48,11 +55,10 @@ int __metal_driver_sifive_global_external_interrupt_register(struct metal_interr
 int __metal_driver_sifive_global_external_interrupt_enable(struct metal_interrupt *controller, int id)
 {
     int rc = -1;
-    struct __metal_driver_sifive_global_external_interrupts0 *global0 =
-                              (struct __metal_driver_sifive_global_external_interrupts0 *)(controller);
 
     if (id != 0) {
-        struct metal_interrupt *intc = global0->interrupt_parent;
+        struct metal_interrupt *intc =
+	    __metal_driver_sifive_global_external_interrupts0_interrupt_parent(controller);
 
         /* Enable its interrupts with parent controller */
         if (intc) {
@@ -65,11 +71,10 @@ int __metal_driver_sifive_global_external_interrupt_enable(struct metal_interrup
 int __metal_driver_sifive_global_external_interrupt_disable(struct metal_interrupt *controller, int id)
 {
     int rc = -1;
-    struct __metal_driver_sifive_global_external_interrupts0 *global0 =
-                              (struct __metal_driver_sifive_global_external_interrupts0 *)(controller);
 
     if (id != 0) {
-        struct metal_interrupt *intc = global0->interrupt_parent;
+        struct metal_interrupt *intc =
+	    __metal_driver_sifive_global_external_interrupts0_interrupt_parent(controller);
 
         /* Enable its interrupts with parent controller */
         if (intc) {
@@ -82,20 +87,18 @@ int __metal_driver_sifive_global_external_interrupt_disable(struct metal_interru
 int __metal_driver_sifive_global_external_command_request (struct metal_interrupt *controller,
                                                          int command, void *data)
 {
-    int index;
+    int idx;
     int rc = -1;
-    struct __metal_driver_sifive_global_external_interrupts0 *global0 =
-                              (struct __metal_driver_sifive_global_external_interrupts0 *)(controller);
 
     switch (command) {
     case METAL_MAX_INTERRUPT_GET:
-        rc = global0->num_interrupts;
+        rc = __metal_driver_sifive_global_external_interrupts0_num_interrupts(controller);
         break;
     case METAL_INDEX_INTERRUPT_GET:
         rc = 0;
         if (data) {
-            index = *(int *)data;
-            rc = global0->interrupt_lines[index];
+            idx = *(int *)data;
+            rc = __metal_driver_sifive_global_external_interrupts0_interrupt_lines(controller, idx);
         }
         break;
     default:
@@ -104,3 +107,14 @@ int __metal_driver_sifive_global_external_command_request (struct metal_interrup
 
     return rc;
 }
+
+__METAL_DEFINE_VTABLE(__metal_driver_vtable_sifive_global_external_interrupts0) = {
+    .global0_vtable.interrupt_init     = __metal_driver_sifive_global_external_interrupt_init,
+    .global0_vtable.interrupt_register = __metal_driver_sifive_global_external_interrupt_register,
+    .global0_vtable.interrupt_enable   = __metal_driver_sifive_global_external_interrupt_enable,
+    .global0_vtable.interrupt_disable  = __metal_driver_sifive_global_external_interrupt_disable,
+    .global0_vtable.command_request    = __metal_driver_sifive_global_external_command_request,
+};
+
+#endif
+

--- a/src/drivers/sifive,gpio-leds.c
+++ b/src/drivers/sifive,gpio-leds.c
@@ -1,55 +1,83 @@
 /* Copyright 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 
+#include <metal/machine/platform.h>
+
+#ifdef METAL_SIFIVE_GPIO_LEDS
+
 #include <string.h>
 #include <metal/gpio.h>
 #include <metal/drivers/sifive,gpio-leds.h>
+#include <metal/machine.h>
 
 int  __metal_driver_led_exist (struct metal_led *led, char *label)
 {
-    struct __metal_driver_sifive_gpio_led *_led = (void *)(led);
-
-    if (strcmp(_led->label, label) == 0) {
-	return 1;
+    if (strcmp(__metal_driver_sifive_gpio_led_label(led), label) == 0) {
+        return 1;
     }
     return 0;
 }
 
 void __metal_driver_led_enable (struct metal_led *led)
 {
-    struct __metal_driver_sifive_gpio_led *_led = (void *)(led);
+    int pin;
+    struct metal_gpio *gpio;
 
-    if (_led->gpio != NULL) {
-	/* Configure LED as output */
-        metal_gpio_disable_input((struct metal_gpio *) _led->gpio, _led->pin);
-        metal_gpio_enable_output((struct metal_gpio *) _led->gpio, _led->pin);
+    pin = __metal_driver_sifive_gpio_led_pin(led);
+    gpio =  __metal_driver_sifive_gpio_led_gpio(led);
+
+    if (gpio != NULL) {
+        /* Configure LED as output */
+        metal_gpio_disable_input((struct metal_gpio *) gpio, pin);
+        metal_gpio_enable_output((struct metal_gpio *) gpio, pin);
     }
 }
 
 void __metal_driver_led_on (struct metal_led *led)
 {
-    struct __metal_driver_sifive_gpio_led *_led = (void *)(led);
+    int pin;
+    struct metal_gpio *gpio;
 
-    if (_led->gpio != NULL) {
-        metal_gpio_set_pin((struct metal_gpio *) _led->gpio, _led->pin, 1);
+    pin = __metal_driver_sifive_gpio_led_pin(led);
+    gpio =  __metal_driver_sifive_gpio_led_gpio(led);
+
+    if (gpio != NULL) {
+        metal_gpio_set_pin((struct metal_gpio *) gpio, pin, 1);
     }
 }
 
 void __metal_driver_led_off (struct metal_led *led)
 {
-    struct __metal_driver_sifive_gpio_led *_led = (void *)(led);
+    int pin;
+    struct metal_gpio *gpio;
 
-    if (_led->gpio != NULL) {
-        metal_gpio_set_pin((struct metal_gpio *) _led->gpio, _led->pin, 0);
+    pin = __metal_driver_sifive_gpio_led_pin(led);
+    gpio =  __metal_driver_sifive_gpio_led_gpio(led);
+
+    if (gpio != NULL) {
+        metal_gpio_set_pin((struct metal_gpio *) gpio, pin, 0);
     }
 }
 
 void __metal_driver_led_toggle (struct metal_led *led)
 {
-    struct __metal_driver_sifive_gpio_led *_led = (void *)(led);
+    int pin;
+    struct metal_gpio *gpio;
 
-    if (_led->gpio != NULL) {
-        metal_gpio_toggle_pin((struct metal_gpio *) _led->gpio, _led->pin);
+    pin = __metal_driver_sifive_gpio_led_pin(led);
+    gpio =  __metal_driver_sifive_gpio_led_gpio(led);
+
+    if (gpio != NULL) {
+        metal_gpio_toggle_pin((struct metal_gpio *) gpio, pin);
     }
 }
 
+__METAL_DEFINE_VTABLE(__metal_driver_vtable_sifive_led) = {
+    .led_vtable.led_exist   = __metal_driver_led_exist,
+    .led_vtable.led_enable  = __metal_driver_led_enable,
+    .led_vtable.led_on      = __metal_driver_led_on,
+    .led_vtable.led_off     = __metal_driver_led_off,
+    .led_vtable.led_toggle  = __metal_driver_led_toggle,
+};
+
+#endif

--- a/src/drivers/sifive,gpio-switches.c
+++ b/src/drivers/sifive,gpio-switches.c
@@ -1,16 +1,19 @@
 /* Copyright 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 
+#include <metal/machine/platform.h>
+
+#ifdef METAL_SIFIVE_GPIO_SWITCHES
+
 #include <string.h>
 #include <metal/drivers/riscv,cpu.h>
 #include <metal/drivers/sifive,gpio-switches.h>
+#include <metal/machine.h>
 
 int  __metal_driver_switch_exist (struct metal_switch *flip, char *label)
 {
-    struct __metal_driver_sifive_gpio_switch *swch = (void *)(flip);
-
-    if (strcmp(swch->label, label) == 0) {
-	return 1;
+    if (strcmp(__metal_driver_sifive_gpio_switch_label(flip), label) == 0) {
+        return 1;
     }
     return 0;
 }
@@ -18,25 +21,34 @@ int  __metal_driver_switch_exist (struct metal_switch *flip, char *label)
 struct metal_interrupt *
 __metal_driver_switch_interrupt_controller(struct metal_switch *flip)
 {
-    struct __metal_driver_sifive_gpio_switch *swch = (void *)(flip);
-
-    return swch->interrupt_parent;
+    return __metal_driver_sifive_gpio_switch_interrupt_controller(flip);
 }
 
 int __metal_driver_switch_get_interrupt_id(struct metal_switch *flip)
 {
-    int max_irq;
-    struct __metal_driver_sifive_gpio_switch *swch = (void *)(flip);
+    int irq, max_irq;
+    struct metal_interrupt *irc;
 
-    if (swch->interrupt_parent != NULL) {
-        max_irq = _metal_interrupt_command_request(swch->interrupt_parent,
-                                                METAL_MAX_INTERRUPT_GET, NULL);
+    irq = __metal_driver_sifive_gpio_switch_interrupt_line(flip);
+    irc =  __metal_driver_sifive_gpio_switch_interrupt_controller(flip);
+    if (irc != NULL) {
+        max_irq = _metal_interrupt_command_request(irc,
+                                                   METAL_MAX_INTERRUPT_GET,
+                                                   NULL);
 
-        if (swch->interrupt_line < max_irq) {
-            return _metal_interrupt_command_request(swch->interrupt_parent,
+        if (irq < max_irq) {
+            return _metal_interrupt_command_request(irc,
                                                  METAL_INDEX_INTERRUPT_GET,
-                                                 (void *)&swch->interrupt_line);
-	}
+                                                 (void *)&irq);
+        }
     }
     return METAL_INTERRUPT_ID_LCMX;
 }
+
+__METAL_DEFINE_VTABLE(__metal_driver_vtable_sifive_switch) = {
+    .switch_vtable.switch_exist   = __metal_driver_switch_exist,
+    .switch_vtable.interrupt_controller = __metal_driver_switch_interrupt_controller,
+    .switch_vtable.get_interrupt_id = __metal_driver_switch_get_interrupt_id,
+};
+
+#endif

--- a/src/drivers/sifive,gpio0.c
+++ b/src/drivers/sifive,gpio0.c
@@ -7,68 +7,79 @@
 
 #include <metal/drivers/sifive,gpio0.h>
 #include <metal/io.h>
+#include <metal/machine.h>
 
 int __metal_driver_sifive_gpio0_disable_input(struct metal_gpio *ggpio, long source)
 {
-    struct __metal_driver_sifive_gpio0 *gpio = (void *)ggpio;
+    long base = __metal_driver_sifive_gpio0_base(ggpio);
 
-    __METAL_ACCESS_ONCE((__metal_io_u32 *)(gpio->base + METAL_SIFIVE_GPIO0_INPUT_EN))  &= ~source;
+    __METAL_ACCESS_ONCE((__metal_io_u32 *)(base + METAL_SIFIVE_GPIO0_INPUT_EN))  &= ~source;
 
     return 0;
 }
 
 long __metal_driver_sifive_gpio0_output(struct metal_gpio *ggpio)
 {
-    struct __metal_driver_sifive_gpio0 *gpio = (void *)ggpio;
+    long base = __metal_driver_sifive_gpio0_base(ggpio);
 
-    return __METAL_ACCESS_ONCE((__metal_io_u32 *)(gpio->base + METAL_SIFIVE_GPIO0_PORT));
+    return __METAL_ACCESS_ONCE((__metal_io_u32 *)(base + METAL_SIFIVE_GPIO0_PORT));
 }
 
 int __metal_driver_sifive_gpio0_enable_output(struct metal_gpio *ggpio, long source)
 {
-    struct __metal_driver_sifive_gpio0 *gpio = (void *)ggpio;
+    long base = __metal_driver_sifive_gpio0_base(ggpio);
 
-    __METAL_ACCESS_ONCE((__metal_io_u32 *)(gpio->base + METAL_SIFIVE_GPIO0_OUTPUT_EN))  |= source;
+    __METAL_ACCESS_ONCE((__metal_io_u32 *)(base + METAL_SIFIVE_GPIO0_OUTPUT_EN))  |= source;
 
     return 0;
 }
 
 int __metal_driver_sifive_gpio0_output_set(struct metal_gpio *ggpio, long value)
 {
-    struct __metal_driver_sifive_gpio0 *gpio = (void *)ggpio;
+    long base = __metal_driver_sifive_gpio0_base(ggpio);
 
-    __METAL_ACCESS_ONCE((__metal_io_u32 *)(gpio->base + METAL_SIFIVE_GPIO0_PORT)) |= value;
+    __METAL_ACCESS_ONCE((__metal_io_u32 *)(base + METAL_SIFIVE_GPIO0_PORT)) |= value;
 
     return 0;
 }
 
 int __metal_driver_sifive_gpio0_output_clear(struct metal_gpio *ggpio, long value)
 {
-    struct __metal_driver_sifive_gpio0 *gpio = (void *)ggpio;
+    long base = __metal_driver_sifive_gpio0_base(ggpio);
 
-    __METAL_ACCESS_ONCE((__metal_io_u32 *)(gpio->base + METAL_SIFIVE_GPIO0_PORT)) &= ~value;
+    __METAL_ACCESS_ONCE((__metal_io_u32 *)(base + METAL_SIFIVE_GPIO0_PORT)) &= ~value;
 
     return 0;
 }
 
 int __metal_driver_sifive_gpio0_output_toggle(struct metal_gpio *ggpio, long value)
 {
-    struct __metal_driver_sifive_gpio0 *gpio = (void *)ggpio;
+    long base = __metal_driver_sifive_gpio0_base(ggpio);
 
-    __METAL_ACCESS_ONCE((__metal_io_u32 *)(gpio->base + METAL_SIFIVE_GPIO0_PORT)) =
-	__METAL_ACCESS_ONCE((__metal_io_u32 *)(gpio->base + METAL_SIFIVE_GPIO0_PORT)) ^ value;
+    __METAL_ACCESS_ONCE((__metal_io_u32 *)(base + METAL_SIFIVE_GPIO0_PORT)) =
+	__METAL_ACCESS_ONCE((__metal_io_u32 *)(base + METAL_SIFIVE_GPIO0_PORT)) ^ value;
 
     return 0;
 }
 
 int __metal_driver_sifive_gpio0_enable_io(struct metal_gpio *ggpio, long source, long dest)
 {
-    struct __metal_driver_sifive_gpio0 *gpio = (void *)ggpio;
+    long base = __metal_driver_sifive_gpio0_base(ggpio);
 
-    __METAL_ACCESS_ONCE((__metal_io_u32 *)(gpio->base + METAL_SIFIVE_GPIO0_IOF_SEL)) &= ~source;
-    __METAL_ACCESS_ONCE((__metal_io_u32 *)(gpio->base + METAL_SIFIVE_GPIO0_IOF_EN))  |= dest;
+    __METAL_ACCESS_ONCE((__metal_io_u32 *)(base + METAL_SIFIVE_GPIO0_IOF_SEL)) &= ~source;
+    __METAL_ACCESS_ONCE((__metal_io_u32 *)(base + METAL_SIFIVE_GPIO0_IOF_EN))  |= dest;
 
     return 0;
 }
+
+__METAL_DEFINE_VTABLE(__metal_driver_vtable_sifive_gpio0) = {
+    .gpio.disable_input = __metal_driver_sifive_gpio0_disable_input,
+    .gpio.output        = __metal_driver_sifive_gpio0_output,
+    .gpio.enable_output = __metal_driver_sifive_gpio0_enable_output,
+    .gpio.output_set    = __metal_driver_sifive_gpio0_output_set,
+    .gpio.output_clear  = __metal_driver_sifive_gpio0_output_clear,
+    .gpio.output_toggle = __metal_driver_sifive_gpio0_output_toggle,
+    .gpio.enable_io = __metal_driver_sifive_gpio0_enable_io,
+};
 
 #endif /* METAL_SIFIVE_GPIO0 */

--- a/src/drivers/sifive,spi0.c
+++ b/src/drivers/sifive,spi0.c
@@ -36,12 +36,13 @@
 #define METAL_SPI_TXMARK_MASK         0x3
 #define METAL_SPI_TXWM                (1 << 0)
 
-#define METAL_SPI_REG(offset)   (((unsigned long)(((struct __metal_driver_sifive_spi0 *)(spi))->control_base) + offset))
+#define METAL_SPI_REG(offset)   (((unsigned long)control_base + offset))
 #define METAL_SPI_REGB(offset)  (__METAL_ACCESS_ONCE((__metal_io_u8  *)METAL_SPI_REG(offset)))
 #define METAL_SPI_REGW(offset)  (__METAL_ACCESS_ONCE((__metal_io_u32 *)METAL_SPI_REG(offset)))
 
 static int configure_spi(struct __metal_driver_sifive_spi0 *spi, struct metal_spi_config *config)
 {
+    long control_base = __metal_driver_sifive_spio0_control_base((struct metal_spi *)spi);
     /* Set protocol */
     METAL_SPI_REGW(METAL_SIFIVE_SPI0_FMT) &= ~(METAL_SPI_PROTO_MASK);
     switch(config->protocol) {
@@ -109,6 +110,7 @@ int __metal_driver_sifive_spi0_transfer(struct metal_spi *gspi,
                                       char *rx_buf)
 {
     struct __metal_driver_sifive_spi0 *spi = (void *)gspi;
+    long control_base = __metal_driver_sifive_spio0_control_base(gspi);
     int rc = 0;
     int rxdata = 0;
 
@@ -156,12 +158,13 @@ int __metal_driver_sifive_spi0_get_baud_rate(struct metal_spi *gspi)
 
 int __metal_driver_sifive_spi0_set_baud_rate(struct metal_spi *gspi, int baud_rate)
 {
-    struct __metal_driver_sifive_spi0 *spi = (void *)gspi;
+    long control_base = __metal_driver_sifive_spio0_control_base(gspi);
+    struct metal_clock *clock = __metal_driver_sifive_spio0_clock(gspi);
 
     spi->baud_rate = baud_rate;
 
-    if (spi->clock != NULL) {
-        long clock_rate = spi->clock->vtable->get_rate_hz(spi->clock);
+    if (clock != NULL) {
+        long clock_rate = clock->get_rate_hz(clock);
 
         /* Calculate divider */
         long div = (clock_rate / (2 * baud_rate)) - 1;
@@ -181,7 +184,7 @@ int __metal_driver_sifive_spi0_set_baud_rate(struct metal_spi *gspi, int baud_ra
 
 static void pre_rate_change_callback(void *priv)
 {
-    struct __metal_driver_sifive_spi0 *spi = priv;
+    long control_base = __metal_driver_sifive_spio0_control_base((struct metal_spi *)priv);
 
     /* Detect when the TXDATA is empty by setting the transmit watermark count
      * to zero and waiting until an interrupt is pending */
@@ -199,22 +202,32 @@ static void post_rate_change_callback(void *priv)
 
 void __metal_driver_sifive_spi0_init(struct metal_spi *gspi, int baud_rate)
 {
+    struct metal_clock *clock = __metal_driver_sifive_spio0_clock(gspi);
+    struct __metal_driver_sifive_gpio0 *pinmux = __metal_driver_sifive_spio0_pinmux(gspi);
     struct __metal_driver_sifive_spi0 *spi = (void *)(gspi);
 
-    if(spi->clock != NULL) {
-        metal_clock_register_pre_rate_change_callback(spi->clock, &pre_rate_change_callback, spi);
-        metal_clock_register_post_rate_change_callback(spi->clock, &post_rate_change_callback, spi);
+    if(clock != NULL) {
+        metal_clock_register_pre_rate_change_callback(clock, &pre_rate_change_callback, spi);
+        metal_clock_register_post_rate_change_callback(clock, &post_rate_change_callback, spi);
     }
 
     metal_spi_set_baud_rate(&(spi->spi), baud_rate);
 
-    if (spi->pinmux != NULL) {
-        spi->pinmux->vtable->gpio.enable_io(
-            (struct metal_gpio *) spi->pinmux,
-            spi->pinmux_output_selector,
-            spi->pinmux_source_selector
+    if (pinmux != NULL) {
+        long pinmux_output_selector = __metal_driver_sifive_spio0_pinmux_output_selector(gspi);
+        long pinmux_source_selector = __metal_driver_sifive_spio0_pinmux_source_selector(gspi);
+        pinmux->gpio.enable_io(
+            (struct metal_gpio *) pinmux,
+            pinmux_output_selector,
+            pinmux_source_selector
         );
     }
 }
 
+__METAL_DEFINE_VTABLE(__metal_driver_vtable_sifive_spi0) = {
+    .spi.init          = __metal_driver_sifive_spi0_init,
+    .spi.transfer      = __metal_driver_sifive_spi0_transfer,
+    .spi.get_baud_rate = __metal_driver_sifive_spi0_get_baud_rate,
+    .spi.set_baud_rate = __metal_driver_sifive_spi0_set_baud_rate,
+};
 #endif /* METAL_SIFIVE_SPI0 */

--- a/src/drivers/sifive,test0.c
+++ b/src/drivers/sifive,test0.c
@@ -8,14 +8,18 @@
 #include <metal/drivers/sifive,test0.h>
 #include <metal/io.h>
 #include <stdint.h>
+#include <metal/machine.h>
 
 void __metal_driver_sifive_test0_exit(const struct __metal_shutdown *sd, int code)
 {
-    const struct __metal_driver_sifive_test0 *test = (void *)sd;
+    long base = __metal_driver_sifive_test0_base();
     uint32_t out = (code << 16) + (code == 0 ? 0x5555 : 0x3333);
     while (1) {
-        __METAL_ACCESS_ONCE((__metal_io_u32 *)(test->base + METAL_SIFIVE_TEST0_FINISHER_OFFSET)) = out;
+        __METAL_ACCESS_ONCE((__metal_io_u32 *)(base + METAL_SIFIVE_TEST0_FINISHER_OFFSET)) = out;
     }
 }
 
+__METAL_DEFINE_VTABLE(__metal_driver_vtable_sifive_test0) = {
+    .shutdown.exit       = &__metal_driver_sifive_test0_exit,
+};
 #endif /* METAL_SIFIVE_TEST0 */

--- a/src/drivers/sifive,uart0.c
+++ b/src/drivers/sifive,uart0.c
@@ -138,8 +138,7 @@ void __metal_driver_sifive_uart0_init(struct metal_uart *guart, int baud_rate)
     }
 }
 
-//__METAL_DEFINE_VTABLE(__metal_driver_vtable_sifive_uart0) = {
-const struct __metal_driver_vtable_sifive_uart0 __metal_driver_vtable_sifive_uart0 = {
+__METAL_DEFINE_VTABLE(__metal_driver_vtable_sifive_uart0) = {
     .uart.init          = __metal_driver_sifive_uart0_init,
     .uart.putc          = __metal_driver_sifive_uart0_putc,
     .uart.getc          = __metal_driver_sifive_uart0_getc,

--- a/src/drivers/sifive,uart0.c
+++ b/src/drivers/sifive,uart0.c
@@ -6,6 +6,7 @@
 #ifdef METAL_SIFIVE_UART0
 
 #include <metal/drivers/sifive,uart0.h>
+#include <metal/machine.h>
 
 /* TXDATA Fields */
 #define UART_TXEN               (1 <<  0)
@@ -22,25 +23,25 @@
 /* IP Fields */
 #define UART_TXWM               (1 <<  0)
 
-#define UART_REG(offset)   (((unsigned long)(((struct __metal_driver_sifive_uart0 *)(uart))->control_base) + offset))
+#define UART_REG(offset)   (((unsigned long)control_base + offset))
 #define UART_REGB(offset)  (__METAL_ACCESS_ONCE((__metal_io_u8  *)UART_REG(offset)))
 #define UART_REGW(offset)  (__METAL_ACCESS_ONCE((__metal_io_u32 *)UART_REG(offset)))
 
 struct metal_interrupt *
 __metal_driver_sifive_uart0_interrupt_controller(struct metal_uart *uart)
 {
-    struct __metal_driver_sifive_uart0 *uart0 = (void *)uart;
-    return (struct metal_interrupt *)uart0->interrupt_parent;
+    return __metal_driver_sifive_uart0_interrupt_parent(uart);
 }
 
 int __metal_driver_sifive_uart0_get_interrupt_id(struct metal_uart *uart)
 {
-    struct __metal_driver_sifive_uart0 *uart0 = (void *)uart;
-    return (uart0->interrupt_line + METAL_INTERRUPT_ID_GL0);
+    return (__metal_driver_sifive_uart0_interrupt_line(uart) + METAL_INTERRUPT_ID_GL0);
 }
 
 int __metal_driver_sifive_uart0_putc(struct metal_uart *uart, unsigned char c)
 {
+    long control_base = __metal_driver_sifive_uart0_control_base(uart);
+
     while ((UART_REGW(METAL_SIFIVE_UART0_TXDATA) & UART_TXFULL) != 0) { }
     UART_REGW(METAL_SIFIVE_UART0_TXDATA) = c;
     return 0;
@@ -49,6 +50,8 @@ int __metal_driver_sifive_uart0_putc(struct metal_uart *uart, unsigned char c)
 int __metal_driver_sifive_uart0_getc(struct metal_uart *uart, unsigned char *c)
 {
     uint32_t ch = UART_RXEMPTY;
+    long control_base = __metal_driver_sifive_uart0_control_base(uart);
+
     while (ch & UART_RXEMPTY) {
         ch = UART_REGW(METAL_SIFIVE_UART0_RXDATA);
     }
@@ -65,11 +68,13 @@ int __metal_driver_sifive_uart0_get_baud_rate(struct metal_uart *guart)
 int __metal_driver_sifive_uart0_set_baud_rate(struct metal_uart *guart, int baud_rate)
 {
     struct __metal_driver_sifive_uart0 *uart = (void *)guart;
+    long control_base = __metal_driver_sifive_uart0_control_base(guart);
+    struct metal_clock *clock = __metal_driver_sifive_uart0_clock(guart);
 
     uart->baud_rate = baud_rate;
 
-    if (uart->clock != NULL) {
-        long clock_rate = uart->clock->vtable->get_rate_hz(uart->clock);
+    if (clock != NULL) {
+        long clock_rate = clock->vtable->get_rate_hz(clock);
         UART_REGW(METAL_SIFIVE_UART0_DIV) = clock_rate / baud_rate - 1;
         UART_REGW(METAL_SIFIVE_UART0_TXCTRL) |= UART_TXEN;
         UART_REGW(METAL_SIFIVE_UART0_RXCTRL) |= UART_RXEN;
@@ -80,6 +85,8 @@ int __metal_driver_sifive_uart0_set_baud_rate(struct metal_uart *guart, int baud
 static void pre_rate_change_callback(void *priv)
 {
     struct __metal_driver_sifive_uart0 *uart = priv;
+    long control_base = __metal_driver_sifive_uart0_control_base((struct metal_uart *)priv);
+    struct metal_clock *clock = __metal_driver_sifive_uart0_clock((struct metal_uart *)priv);
 
     /* Detect when the TXDATA is empty by setting the transmit watermark count
      * to one and waiting until an interrupt is pending */
@@ -94,7 +101,7 @@ static void pre_rate_change_callback(void *priv)
      * that long. */
 
     long bits_per_symbol = (UART_REGW(METAL_SIFIVE_UART0_TXCTRL) & (1 << 1)) ? 9 : 10;
-    long clk_freq = uart->clock->vtable->get_rate_hz(uart->clock);
+    long clk_freq = clock->vtable->get_rate_hz(clock);
     long cycles_to_wait = bits_per_symbol * clk_freq / uart->baud_rate;
 
     for(volatile long x = 0; x < cycles_to_wait; x++)
@@ -110,21 +117,36 @@ static void post_rate_change_callback(void *priv)
 void __metal_driver_sifive_uart0_init(struct metal_uart *guart, int baud_rate)
 {
     struct __metal_driver_sifive_uart0 *uart = (void *)(guart);
+    struct metal_clock *clock = __metal_driver_sifive_uart0_clock(guart);
+    struct __metal_driver_sifive_gpio0 *pinmux = __metal_driver_sifive_uart0_pinmux(guart);
 
-    if(uart->clock != NULL) {
-        metal_clock_register_pre_rate_change_callback(uart->clock, &pre_rate_change_callback, uart);
-        metal_clock_register_post_rate_change_callback(uart->clock, &post_rate_change_callback, uart);
+    if(clock != NULL) {
+        metal_clock_register_pre_rate_change_callback(clock, &pre_rate_change_callback, guart);
+        metal_clock_register_post_rate_change_callback(clock, &post_rate_change_callback, guart);
     }
 
     metal_uart_set_baud_rate(&(uart->uart), baud_rate);
 
-    if (uart->pinmux != NULL) {
-        uart->pinmux->vtable->gpio.enable_io(
-            (struct metal_gpio *) uart->pinmux,
-            uart->pinmux_output_selector,
-            uart->pinmux_source_selector
+    if (pinmux != NULL) {
+        long pinmux_output_selector = __metal_driver_sifive_uart0_pinmux_output_selector(guart);
+        long pinmux_source_selector = __metal_driver_sifive_uart0_pinmux_source_selector(guart);
+        pinmux->gpio.vtable->enable_io(
+            (struct metal_gpio *) pinmux,
+            pinmux_output_selector,
+            pinmux_source_selector
         );
     }
 }
+
+//__METAL_DEFINE_VTABLE(__metal_driver_vtable_sifive_uart0) = {
+const struct __metal_driver_vtable_sifive_uart0 __metal_driver_vtable_sifive_uart0 = {
+    .uart.init          = __metal_driver_sifive_uart0_init,
+    .uart.putc          = __metal_driver_sifive_uart0_putc,
+    .uart.getc          = __metal_driver_sifive_uart0_getc,
+    .uart.get_baud_rate = __metal_driver_sifive_uart0_get_baud_rate,
+    .uart.set_baud_rate = __metal_driver_sifive_uart0_set_baud_rate,
+    .uart.controller_interrupt = __metal_driver_sifive_uart0_interrupt_controller,
+    .uart.get_interrupt_id     = __metal_driver_sifive_uart0_get_interrupt_id,
+};
 
 #endif /* METAL_SIFIVE_UART0 */


### PR DESCRIPTION
Metal Headers generated by the Freedom-devicetree-tools will no longer produce fields in its structures to capture the const value described by the design dts file. Instead it will generate inline functions to retrieve to those values. This also allow us to avoid using ".weak" attributes for its structure declaring.

This PR capture the changes for this migration.