### PR TITLE
Remove indirection from metal/machine.h

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -54,8 +54,6 @@ endif # PRECONFIGURED
 # Install some METAL-specific headers, one of which is automatically generated.
 # The files that aren't automatically generated are the same for all machines.
 nobase_include_HEADERS = \
-	metal/machine/@MACHINE_NAME@.h \
-	metal/machine/platform.h \
 	metal/drivers/fixed-clock.h \
 	metal/drivers/fixed-factor-clock.h \
 	metal/drivers/riscv,clint0.h \
@@ -75,6 +73,7 @@ nobase_include_HEADERS = \
 	metal/drivers/sifive,spi0.h \
 	metal/drivers/sifive,test0.h \
 	metal/drivers/sifive,uart0.h \
+	metal/machine/platform.h \
 	metal/button.h \
 	metal/clock.h \
 	metal/compiler.h \
@@ -97,7 +96,7 @@ nobase_include_HEADERS = \
 	metal/uart.h
 
 if PRECONFIGURED
-metal/machine/@MACHINE_NAME@.h: @MACHINE_HEADER@
+metal/machine.h: @MACHINE_HEADER@
 	@mkdir -p $(dir $@)
 	cp $< $@
 
@@ -114,7 +113,7 @@ else # !PRECONFIGURED
 @MACHINE_NAME@.dtb: @DTC@ @MACHINE_DTS@
 	$< $(filter %.dts,$^) -o $@ -O dtb -I dts
 
-metal/machine/@MACHINE_NAME@.h: @METAL_HEADER_GENERATOR@ @MACHINE_NAME@.dtb
+metal/machine.h: @METAL_HEADER_GENERATOR@ @MACHINE_NAME@.dtb
 	@mkdir -p $(dir $@)
 	$< --dtb $(filter %.dtb,$^) --output $@
 
@@ -137,7 +136,7 @@ libriscv__mmachine__@MACHINE_NAME@_a_CCASFLAGS = @MENV_METAL@ @MMACHINE_MACHINE_
 
 # This will generate these sources before the compilation step
 BUILT_SOURCES = \
-	metal/machine/@MACHINE_NAME@.h \
+	metal/machine.h \
 	metal/machine/platform.h \
 	riscv__menv__metal.specs \
 	riscv__mmachine__@MACHINE_NAME@.specs
@@ -248,6 +247,6 @@ hello_LDFLAGS         = -L. -Wl,--gc-sections -Wl,-Map=hello.map
 # Extra clean targets
 clean-local:
 	-rm -rf @MACHINE_NAME@.mk
-	-rm -rf metal/machine/@MACHINE_NAME@.h metal/machine/platform.h
+	-rm -rf metal/machine.h metal/machine/platform.h
 	-rm -rf @MACHINE_NAME@.dtb metal-@MACHINE_NAME@.lds
 	-rm -rf *.map *.specs

--- a/Makefile.in
+++ b/Makefile.in
@@ -464,8 +464,6 @@ spec_DATA = riscv__mmachine__@MACHINE_NAME@.specs \
 # Install some METAL-specific headers, one of which is automatically generated.
 # The files that aren't automatically generated are the same for all machines.
 nobase_include_HEADERS = \
-	metal/machine/@MACHINE_NAME@.h \
-	metal/machine/platform.h \
 	metal/drivers/fixed-clock.h \
 	metal/drivers/fixed-factor-clock.h \
 	metal/drivers/riscv,clint0.h \
@@ -485,6 +483,7 @@ nobase_include_HEADERS = \
 	metal/drivers/sifive,spi0.h \
 	metal/drivers/sifive,test0.h \
 	metal/drivers/sifive,uart0.h \
+	metal/machine/platform.h \
 	metal/button.h \
 	metal/clock.h \
 	metal/compiler.h \
@@ -518,7 +517,7 @@ libriscv__mmachine__@MACHINE_NAME@_a_CCASFLAGS = @MENV_METAL@ @MMACHINE_MACHINE_
 
 # This will generate these sources before the compilation step
 BUILT_SOURCES = \
-	metal/machine/@MACHINE_NAME@.h \
+	metal/machine.h \
 	metal/machine/platform.h \
 	riscv__menv__metal.specs \
 	riscv__mmachine__@MACHINE_NAME@.specs
@@ -2030,7 +2029,7 @@ riscv__menv__metal.specs: riscv__menv__metal.specs.in
 @PRECONFIGURED_FALSE@@MACHINE_NAME@.mk: @MAKEATTRIBUTES_GENERATOR@ @MACHINE_NAME@.dtb
 @PRECONFIGURED_FALSE@	$< --dtb $(filter %.dtb,$^) --output $@
 
-@PRECONFIGURED_TRUE@metal/machine/@MACHINE_NAME@.h: @MACHINE_HEADER@
+@PRECONFIGURED_TRUE@metal/machine.h: @MACHINE_HEADER@
 @PRECONFIGURED_TRUE@	@mkdir -p $(dir $@)
 @PRECONFIGURED_TRUE@	cp $< $@
 
@@ -2046,7 +2045,7 @@ riscv__menv__metal.specs: riscv__menv__metal.specs.in
 @PRECONFIGURED_FALSE@@MACHINE_NAME@.dtb: @DTC@ @MACHINE_DTS@
 @PRECONFIGURED_FALSE@	$< $(filter %.dts,$^) -o $@ -O dtb -I dts
 
-@PRECONFIGURED_FALSE@metal/machine/@MACHINE_NAME@.h: @METAL_HEADER_GENERATOR@ @MACHINE_NAME@.dtb
+@PRECONFIGURED_FALSE@metal/machine.h: @METAL_HEADER_GENERATOR@ @MACHINE_NAME@.dtb
 @PRECONFIGURED_FALSE@	@mkdir -p $(dir $@)
 @PRECONFIGURED_FALSE@	$< --dtb $(filter %.dtb,$^) --output $@
 
@@ -2057,7 +2056,7 @@ riscv__menv__metal.specs: riscv__menv__metal.specs.in
 # Extra clean targets
 clean-local:
 	-rm -rf @MACHINE_NAME@.mk
-	-rm -rf metal/machine/@MACHINE_NAME@.h metal/machine/platform.h
+	-rm -rf metal/machine.h metal/machine/platform.h
 	-rm -rf @MACHINE_NAME@.dtb metal-@MACHINE_NAME@.lds
 	-rm -rf *.map *.specs
 

--- a/configure
+++ b/configure
@@ -4579,9 +4579,7 @@ $as_echo "$ac_res" >&6; }
 if eval test \"x\$"$as_CACHEVAR"\" = x"yes"; then :
   mmachine_machine_name="-mmachine=$machine_name"
 else
-  mmachine_machine_name="-D__METAL_MACHINE_HEADER=\\\"$with_machine_header\\\""
-#    [mmachine_machine_name="-mmachine=$with_machine_name"]
-
+  :
 fi
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -250,8 +250,6 @@ AS_IF([test "x$with_preconfigured" = "xyes"],
 # directly substituting in the relevant 
 AX_CHECK_COMPILE_FLAG([mmachine=$machine_name],
     [mmachine_machine_name="-mmachine=$machine_name"],
-    [mmachine_machine_name="-D__METAL_MACHINE_HEADER=\\\"$with_machine_header\\\""]
-#    [mmachine_machine_name="-mmachine=$with_machine_name"]
 )
 
 AC_SUBST([MMACHINE_MACHINE_NAME], "$mmachine_machine_name")

--- a/metal/machine.h
+++ b/metal/machine.h
@@ -1,8 +1,0 @@
-/* SPDX-License-Identifier: Apache-2.0 */
-/* Copyright 2018 SiFive, Inc */
-
-#ifndef __METAL_MACHINE_HEADER
-#error "The toolchain must define __METAL_MACHINE_HEADER"
-#endif
-
-#include __METAL_MACHINE_HEADER


### PR DESCRIPTION
Copy the machine header directly into `metal/machine.h` instead of `metal/machine/@MACHINE_NAME@.h`.