### PR TITLE
Fix some build-time warnings

### DIFF
--- a/src/drivers/sifive_clic0.c
+++ b/src/drivers/sifive_clic0.c
@@ -318,7 +318,7 @@ unsigned long long __metal_clic0_mtime_get (struct __metal_driver_sifive_clic0 *
     return (((unsigned long long)hi) << 32) | lo;
 }
 
-int __metal_driver_sifive_clic0_mtimecmp_set(struct interrupt_controller *controller,
+int __metal_driver_sifive_clic0_mtimecmp_set(struct metal_interrupt *controller,
                                              int hartid,
                                              unsigned long long time)
 {   

--- a/src/drivers/sifive_test0.c
+++ b/src/drivers/sifive_test0.c
@@ -10,6 +10,7 @@
 #include <stdint.h>
 #include <metal/machine.h>
 
+void __metal_driver_sifive_test0_exit(const struct __metal_shutdown *sd, int code) __attribute__((noreturn));
 void __metal_driver_sifive_test0_exit(const struct __metal_shutdown *sd, int code)
 {
     long base = __metal_driver_sifive_test0_base();


### PR DESCRIPTION
These two changes got overlooked earlier and were causing build-time warnings.