### PR TITLE
Rename CPU internal method from timer_get to mcycle_get

### DIFF
--- a/metal/cpu.h
+++ b/metal/cpu.h
@@ -20,7 +20,7 @@ struct metal_cpu;
 typedef void (*metal_exception_handler_t) (struct metal_cpu *cpu, int ecode);
 
 struct metal_cpu_vtable {
-    unsigned long long (*timer_get)(struct metal_cpu *cpu);
+    unsigned long long (*mcycle_get)(struct metal_cpu *cpu);
     unsigned long long (*timebase_get)(struct metal_cpu *cpu);
     unsigned long long (*mtime_get)(struct metal_cpu *cpu);
     int (*mtimecmp_set)(struct metal_cpu *cpu, unsigned long long time);
@@ -69,7 +69,7 @@ int metal_cpu_get_num_harts();
  * @return The value of the CPU cycle count timer
  */
 inline unsigned long long metal_cpu_get_timer(struct metal_cpu *cpu)
-{ return cpu->vtable->timer_get(cpu); }
+{ return cpu->vtable->mcycle_get(cpu); }
 
 /*! @brief Get the timebase of the CPU
  *

--- a/src/drivers/riscv_cpu.c
+++ b/src/drivers/riscv_cpu.c
@@ -440,7 +440,7 @@ extern inline int __metal_controller_interrupt_is_selective_vectored(void);
 
 /* CPU driver !!! */
 
-unsigned long long __metal_driver_cpu_timer_get(struct metal_cpu *cpu)
+unsigned long long __metal_driver_cpu_mcycle_get(struct metal_cpu *cpu)
 {
     unsigned long long val = 0;
 
@@ -670,7 +670,7 @@ __METAL_DEFINE_VTABLE(__metal_driver_vtable_riscv_cpu_intc) = {
 };
 
 __METAL_DEFINE_VTABLE(__metal_driver_vtable_cpu) = {
-    .cpu_vtable.timer_get     = __metal_driver_cpu_timer_get,
+    .cpu_vtable.mcycle_get     = __metal_driver_cpu_mcycle_get,
     .cpu_vtable.timebase_get  = __metal_driver_cpu_timebase_get,
     .cpu_vtable.mtime_get = __metal_driver_cpu_mtime_get,
     .cpu_vtable.mtimecmp_set = __metal_driver_cpu_mtimecmp_set,


### PR DESCRIPTION
Only changes the internal method name in the CPU vtable