### PR TITLE
Qspi debug

### DIFF
--- a/src/drivers/sifive_spi0.c
+++ b/src/drivers/sifive_spi0.c
@@ -53,16 +53,16 @@ static int configure_spi(struct __metal_driver_sifive_spi0 *spi, struct metal_sp
 {
     long control_base = __metal_driver_sifive_spi0_control_base((struct metal_spi *)spi);
     /* Set protocol */
-    METAL_SPI_REGB(METAL_SIFIVE_SPI0_FMT) &= ~(METAL_SPI_PROTO_MASK);
+    METAL_SPI_REGW(METAL_SIFIVE_SPI0_FMT) &= ~(METAL_SPI_PROTO_MASK);
     switch(config->protocol) {
         case METAL_SPI_SINGLE:
-            METAL_SPI_REGB(METAL_SIFIVE_SPI0_FMT) |= METAL_SPI_PROTO_SINGLE;
+            METAL_SPI_REGW(METAL_SIFIVE_SPI0_FMT) |= METAL_SPI_PROTO_SINGLE;
             break;
         case METAL_SPI_DUAL:
-            METAL_SPI_REGB(METAL_SIFIVE_SPI0_FMT) |= METAL_SPI_PROTO_DUAL;
+            METAL_SPI_REGW(METAL_SIFIVE_SPI0_FMT) |= METAL_SPI_PROTO_DUAL;
             break;
         case METAL_SPI_QUAD:
-            METAL_SPI_REGB(METAL_SIFIVE_SPI0_FMT) |= METAL_SPI_PROTO_QUAD;
+            METAL_SPI_REGW(METAL_SIFIVE_SPI0_FMT) |= METAL_SPI_PROTO_QUAD;
             break;
         default:
             /* Unsupported value */
@@ -71,33 +71,33 @@ static int configure_spi(struct __metal_driver_sifive_spi0 *spi, struct metal_sp
 
     /* Set Polarity */
     if(config->polarity) {
-        METAL_SPI_REGB(METAL_SIFIVE_SPI0_SCKMODE) |= (1 << METAL_SPI_SCKMODE_PHA_SHIFT);
+        METAL_SPI_REGW(METAL_SIFIVE_SPI0_SCKMODE) |= (1 << METAL_SPI_SCKMODE_PHA_SHIFT);
     } else {
-        METAL_SPI_REGB(METAL_SIFIVE_SPI0_SCKMODE) &= ~(1 << METAL_SPI_SCKMODE_PHA_SHIFT);
+        METAL_SPI_REGW(METAL_SIFIVE_SPI0_SCKMODE) &= ~(1 << METAL_SPI_SCKMODE_PHA_SHIFT);
     }
 
     /* Set Phase */
     if(config->phase) {
-        METAL_SPI_REGB(METAL_SIFIVE_SPI0_SCKMODE) |= (1 << METAL_SPI_SCKMODE_POL_SHIFT);
+        METAL_SPI_REGW(METAL_SIFIVE_SPI0_SCKMODE) |= (1 << METAL_SPI_SCKMODE_POL_SHIFT);
     } else {
-        METAL_SPI_REGB(METAL_SIFIVE_SPI0_SCKMODE) &= ~(1 << METAL_SPI_SCKMODE_POL_SHIFT);
+        METAL_SPI_REGW(METAL_SIFIVE_SPI0_SCKMODE) &= ~(1 << METAL_SPI_SCKMODE_POL_SHIFT);
     }
 
     /* Set Endianness */
     if(config->little_endian) {
-        METAL_SPI_REGB(METAL_SIFIVE_SPI0_FMT) |= METAL_SPI_ENDIAN_LSB;
+        METAL_SPI_REGW(METAL_SIFIVE_SPI0_FMT) |= METAL_SPI_ENDIAN_LSB;
     } else {
-        METAL_SPI_REGB(METAL_SIFIVE_SPI0_FMT) &= ~(METAL_SPI_ENDIAN_LSB);
+        METAL_SPI_REGW(METAL_SIFIVE_SPI0_FMT) &= ~(METAL_SPI_ENDIAN_LSB);
     }
 
     /* Always populate receive FIFO */
-    METAL_SPI_REGB(METAL_SIFIVE_SPI0_FMT) &= ~(METAL_SPI_DISABLE_RX);
+    METAL_SPI_REGW(METAL_SIFIVE_SPI0_FMT) &= ~(METAL_SPI_DISABLE_RX);
 
     /* Set CS Active */
     if(config->cs_active_high) {
-        METAL_SPI_REGB(METAL_SIFIVE_SPI0_CSDEF) = 0;
+        METAL_SPI_REGW(METAL_SIFIVE_SPI0_CSDEF) = 0;
     } else {
-        METAL_SPI_REGB(METAL_SIFIVE_SPI0_CSDEF) = 1;
+        METAL_SPI_REGW(METAL_SIFIVE_SPI0_CSDEF) = 1;
     }
 
     /* Set frame length */
@@ -107,7 +107,7 @@ static int configure_spi(struct __metal_driver_sifive_spi0 *spi, struct metal_sp
     }
 
     /* Set CS line */
-    METAL_SPI_REGB(METAL_SIFIVE_SPI0_CSID) = config->csid;
+    METAL_SPI_REGW(METAL_SIFIVE_SPI0_CSID) = config->csid;
 
     /* Toggle off memory-mapped SPI flash mode, toggle on programmable IO mode
      * It seems that with this line uncommented, the debugger cannot have access 
@@ -116,7 +116,7 @@ static int configure_spi(struct __metal_driver_sifive_spi0 *spi, struct metal_sp
      * reset cores, reset $pc, set *((int *) 0x20004060) = 0, (set the flash
      * interface control register to programmable I/O mode) and then continue
      * Alternative, comment out the "flash" line in openocd.cfg */
-    METAL_SPI_REGB(METAL_SIFIVE_SPI0_FCTRL) = METAL_SPI_CONTROL_IO;
+    METAL_SPI_REGW(METAL_SIFIVE_SPI0_FCTRL) = METAL_SPI_CONTROL_IO;
 
     return 0;
 }
@@ -137,8 +137,8 @@ int __metal_driver_sifive_spi0_transfer(struct metal_spi *gspi,
     }
 
     /* Hold the chip select line for all len transferred */
-    METAL_SPI_REGB(METAL_SIFIVE_SPI0_CSMODE) &= ~(METAL_SPI_CSMODE_MASK);
-    METAL_SPI_REGB(METAL_SIFIVE_SPI0_CSMODE) |= METAL_SPI_CSMODE_HOLD;
+    METAL_SPI_REGW(METAL_SIFIVE_SPI0_CSMODE) &= ~(METAL_SPI_CSMODE_MASK);
+    METAL_SPI_REGW(METAL_SIFIVE_SPI0_CSMODE) |= METAL_SPI_CSMODE_HOLD;
 
     /* Master send bytes to the slave */
     for(int i = 0; i < len; i++) {
@@ -167,7 +167,7 @@ int __metal_driver_sifive_spi0_transfer(struct metal_spi *gspi,
         while((rxdata = METAL_SPI_REGW(METAL_SIFIVE_SPI0_RXDATA)) & METAL_SPI_RXDATA_EMPTY) {
             if (time(NULL) > endwait) {
                 /* if timeout, deassert the CS */
-                METAL_SPI_REGB(METAL_SIFIVE_SPI0_CSMODE) &= ~(METAL_SPI_CSMODE_MASK);
+                METAL_SPI_REGW(METAL_SIFIVE_SPI0_CSMODE) &= ~(METAL_SPI_CSMODE_MASK);
                 
                 /* if timeout, immediately stop receiving more bytes */
                 return 1;
@@ -186,7 +186,7 @@ int __metal_driver_sifive_spi0_transfer(struct metal_spi *gspi,
      * After the host iterates through the array, fifo is likely not cleared yet. If host deasserts
      * the CS pin immediately, the following bytes in the output FIFO will not be sent consecutively. 
      * There needs to be a better way to handle this. */
-    METAL_SPI_REGB(METAL_SIFIVE_SPI0_CSMODE) &= ~(METAL_SPI_CSMODE_MASK);
+    METAL_SPI_REGW(METAL_SIFIVE_SPI0_CSMODE) &= ~(METAL_SPI_CSMODE_MASK);
 
     return 0;
 }

--- a/src/drivers/sifive_spi0.c
+++ b/src/drivers/sifive_spi0.c
@@ -15,27 +15,33 @@
 #define METAL_SPI_SCKMODE_PHA_SHIFT   0
 #define METAL_SPI_SCKMODE_POL_SHIFT   1
 
-#define METAL_SPI_CSMODE_MASK         0x3
+#define METAL_SPI_CSMODE_MASK         3
 #define METAL_SPI_CSMODE_AUTO         0
 #define METAL_SPI_CSMODE_HOLD         2
 #define METAL_SPI_CSMODE_OFF          3
 
-#define METAL_SPI_PROTO_MASK          0x3
+#define METAL_SPI_PROTO_MASK          3
 #define METAL_SPI_PROTO_SINGLE        0
 #define METAL_SPI_PROTO_DUAL          1
 #define METAL_SPI_PROTO_QUAD          2
 
-#define METAL_SPI_ENDIAN_LSB          (1 << 2)
+#define METAL_SPI_ENDIAN_LSB          4
 
-#define METAL_SPI_DISABLE_RX          (1 << 3)
+#define METAL_SPI_DISABLE_RX          8
 
 #define METAL_SPI_FRAME_LEN_SHIFT     16
 #define METAL_SPI_FRAME_LEN_MASK      (0xF << METAL_SPI_FRAME_LEN_SHIFT)
 
 #define METAL_SPI_TXDATA_FULL         (1 << 31)
 #define METAL_SPI_RXDATA_EMPTY        (1 << 31)
-#define METAL_SPI_TXMARK_MASK         0x3
-#define METAL_SPI_TXWM                (1 << 0)
+#define METAL_SPI_TXMARK_MASK         3
+#define METAL_SPI_TXWM                1
+#define METAL_SPI_TXRXDATA_MASK	      (0xFF)
+
+#define METAL_SPI_WATERMARK_MASK	  7
+
+#define METAL_SPI_CONTROL_IO          0
+#define METAL_SPI_CONTROL_MAPPED      1
 
 #define METAL_SPI_REG(offset)   (((unsigned long)control_base + offset))
 #define METAL_SPI_REGB(offset)  (__METAL_ACCESS_ONCE((__metal_io_u8  *)METAL_SPI_REG(offset)))
@@ -101,6 +107,15 @@ static int configure_spi(struct __metal_driver_sifive_spi0 *spi, struct metal_sp
     /* Set CS line */
     METAL_SPI_REGW(METAL_SIFIVE_SPI0_CSID) = config->csid;
 
+    /* Toggle off memory-mapped SPI flash mode, toggle on programmable IO mode
+     * It seems that with this line uncommented, the debugger cannot have access 
+     * to the chip at all because it assumes the chip is in memory-mapped mode. 
+     * I have to compile the code with this line commented and launch gdb,
+     * reset cores, reset $pc, set *((int *) 0x20004060) = 0, (set the flash
+     * interface control register to programmable I/O mode) and then continue
+     * Alternative, comment out the "flash" line in openocd.cfg */
+	METAL_SPI_REGW(METAL_SPI_REG_FCTRL) = METAL_SPI_CONTROL_IO;
+
     return 0;
 }
 
@@ -110,6 +125,11 @@ int __metal_driver_sifive_spi0_transfer(struct metal_spi *gspi,
                                       char *tx_buf,
                                       char *rx_buf)
 {
+	/* Transmit and receive buffer must not be empty */
+	if (tx_buf == NULL || rx_buf == NULL) {
+		return 1;
+	}
+
     struct __metal_driver_sifive_spi0 *spi = (void *)gspi;
     long control_base = __metal_driver_sifive_spi0_control_base(gspi);
     int rc = 0;
@@ -121,32 +141,48 @@ int __metal_driver_sifive_spi0_transfer(struct metal_spi *gspi,
     }
 
     /* Hold the chip select line for all len transferred */
-    METAL_SPI_REGW(METAL_SIFIVE_SPI0_CSMODE) = METAL_SPI_CSMODE_HOLD;
+    METAL_SPI_REGW(METAL_SPI_REG_CSMODE) &= ~(METAL_SPI_CSMODE_MASK);
+	METAL_SPI_REGW(METAL_SPI_REG_CSMODE) |= METAL_SPI_CSMODE_HOLD;
+
+	/* Increase the maximum delay between two consecutive frames, in units of clock cycles 
+	 * The purpose is to prevent the spi controller from deasserting the cs pin in between
+	 * consecutive frames. By default 0 frame interval is allowed between frames. The delay
+	 * between each iteration in the for loop is more than one clock cycle. 0xA means the
+	 * maximum allowed inter-frame interval is 10 clock cycles.*/
+	/** METAL_SPI_REGW(METAL_SPI_REG_DELAY1) &= ~(0xFF << 16); */
+	/** METAL_SPI_REGW(METAL_SPI_REG_DELAY1) |= (0xA << 16); */
+
+    /* Master send bytes to the slave */
+
+	/* Set the transmit watermark register to enqueue the bytes before sending out */
+	METAL_SPI_REGW(METAL_SPI_REG_TXMARK) &= ~(METAL_SPI_WATERMARK_MASK);
+	METAL_SPI_REGW(METAL_SPI_REG_TXMARK) |= len;
+	int temp = METAL_SPI_REGW(METAL_SPI_REG_TXMARK);
 
     for(int i = 0; i < len; i++) {
-        /* Wait for TXFIFO to not be full */
-        while(METAL_SPI_REGW(METAL_SIFIVE_SPI0_TXDATA) & METAL_SPI_TXDATA_FULL) ;
 
-        /* Transfer byte */
-        if(tx_buf) {
-            METAL_SPI_REGW(METAL_SIFIVE_SPI0_TXDATA) = tx_buf[i];
-        } else {
-            METAL_SPI_REGW(METAL_SIFIVE_SPI0_TXDATA) = 0;
-        }
-
-        if(i == (len - 1)) {
-            /* On the last byte, set CSMODE to auto so that the chip select
-             * transitions back to high */
-            METAL_SPI_REGW(METAL_SIFIVE_SPI0_CSMODE) = METAL_SPI_CSMODE_AUTO;
-        }
-
-        /* Wait for RXFIFO to not be empty */
-        while((rxdata = METAL_SPI_REGW(METAL_SIFIVE_SPI0_RXDATA)) & METAL_SPI_RXDATA_EMPTY) ;
-
-        if(rx_buf) {
-            rx_buf[i] = (char) (rxdata & 0xFF);
-        }
+		/* Wait for TXFIFO to not be full */
+		while(METAL_SPI_REGW(METAL_SPI_REG_TXDATA) & METAL_SPI_TXDATA_FULL);
+	
+		/* Transfer byte */
+		METAL_SPI_REGW(METAL_SPI_REG_TXDATA) &= ~(METAL_SPI_TXRXDATA_MASK);
+	    METAL_SPI_REGW(METAL_SPI_REG_TXDATA) |= tx_buf[i];
     }
+
+	/* On the last byte, set CSMODE to auto so that the chip select transitions back to high */
+	METAL_SPI_REGW(METAL_SPI_REG_CSMODE) &= ~(METAL_SPI_CSMODE_MASK);
+
+	/* Reset the maximum interframe delay to 0 clock cycle */
+	/** METAL_SPI_REGW(METAL_SPI_REG_DELAY1) &= ~(0xFF << 16); */
+
+    /* Master receive bytes from the slave */
+    for (int i = 0; i < len; i++) {
+
+		/* Wait for RXFIFO to not be empty */
+		while((rxdata = METAL_SPI_REGW(METAL_SPI_REG_RXDATA)) & METAL_SPI_RXDATA_EMPTY);
+
+		rx_buf[i] = (char) (rxdata & METAL_SPI_TXRXDATA_MASK);
+	}
 
     return 0;
 }
@@ -190,8 +226,12 @@ static void pre_rate_change_callback(void *priv)
 
     /* Detect when the TXDATA is empty by setting the transmit watermark count
      * to zero and waiting until an interrupt is pending */
+<<<<<<< HEAD:src/drivers/sifive_spi0.c
 
     METAL_SPI_REGW(METAL_SIFIVE_SPI0_TXMARK) &= ~(METAL_SPI_TXMARK_MASK);
+=======
+    METAL_SPI_REGW(METAL_SPI_REG_TXMARK) &= ~(METAL_SPI_TXMARK_MASK);
+>>>>>>> Dequeue the receive FIFO after sending all data:src/drivers/sifive,spi0.c
 
     while((METAL_SPI_REGW(METAL_SIFIVE_SPI0_IP) & METAL_SPI_TXWM) == 0) ;
 }

--- a/src/drivers/sifive_spi0.c
+++ b/src/drivers/sifive_spi0.c
@@ -30,7 +30,7 @@
 #define METAL_SPI_DISABLE_RX          (1 << 3)
 
 #define METAL_SPI_FRAME_LEN_SHIFT     16
-#define METAL_SPI_FRAME_LEN_MASK      (0x1F << METAL_SPI_FRAME_LEN_SHIFT)
+#define METAL_SPI_FRAME_LEN_MASK      (0xF << METAL_SPI_FRAME_LEN_SHIFT)
 
 #define METAL_SPI_TXDATA_FULL         (1 << 31)
 #define METAL_SPI_RXDATA_EMPTY        (1 << 31)
@@ -77,13 +77,13 @@ static int configure_spi(struct __metal_driver_sifive_spi0 *spi, struct metal_sp
 
     /* Set Endianness */
     if(config->little_endian) {
-        METAL_SPI_REGW(METAL_SIFIVE_SPI0_FMT) |= (1 << METAL_SPI_ENDIAN_LSB);
+        METAL_SPI_REGW(METAL_SPI_REG_FMT) |= METAL_SPI_ENDIAN_LSB;
     } else {
-        METAL_SPI_REGW(METAL_SIFIVE_SPI0_FMT) &= ~(1 << METAL_SPI_ENDIAN_LSB);
+        METAL_SPI_REGW(METAL_SPI_REG_FMT) &= ~(METAL_SPI_ENDIAN_LSB);
     }
 
     /* Always populate receive FIFO */
-    METAL_SPI_REGW(METAL_SIFIVE_SPI0_FMT) &= ~(1 << METAL_SPI_DISABLE_RX);
+    METAL_SPI_REGW(METAL_SPI_REG_FMT) &= ~(METAL_SPI_DISABLE_RX);
 
     /* Set CS Active */
     if(config->cs_active_high) {


### PR DESCRIPTION
Modified `src/drivers/sifive,spi0.c` only. Changed some of the preprocessor directives to match those specified in [SiFive FE310-G002 Manual v19p05](https://sifive.cdn.prismic.io/sifive%2F59a1f74e-d918-41c5-b837-3fe01ba7eaa1_fe310-g002-manual-v19p05.pdf).
 
Another thing to note is that I moved the CS deassert line to only after the RXDADA FIFO has been dequeued. There are some timing issues (according to Logic analyzer) if the CS# was immediately deasserted after the last byte in TXDATA was enqueued in the sending FIFO. Placing the deassert line so late in the process probably hurt performance a bit. I need to be able to get the SCK frequency in order to calculate a better latency, and this relates to the next point.

Any `set_baud_rate` doesn't seem to modify SPI clock rates at all. The analyzer showed the clock rate stayed approximately at 4MHz whether I set `baud_rate` to 10 or 100,000.

`METAL_SPI_REGW(METAL_SPI_REG_FCTRL) = METAL_SPI_CONTROL_IO` switches the SPI from memory-mapped to programmable I/O mode. I have to either comment this line to start gdb normally and then manually edit the register value through gdb before I start the program, or I have to comment out the `flash bank my_first_flash fespi 0x40000000 0 0 0 $_TARGETNAME 0x20004000` line in `openocd.cfg`. I'm not familiar with openocd to give a better fix.