### PR TITLE
Synchronize harts before calling secondary_main

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -197,6 +197,7 @@ lib_LIBRARIES += libriscv__menv__metal.a
 
 libriscv__menv__metal_a_SOURCES = \
 	gloss/crt0.S \
+	gloss/synchronize_harts.c \
 	gloss/nanosleep.c \
 	gloss/sys_access.c \
 	gloss/sys_chdir.c \

--- a/Makefile.in
+++ b/Makefile.in
@@ -149,20 +149,21 @@ am__v_AR_1 =
 libriscv__menv__metal_a_AR = $(AR) $(ARFLAGS)
 libriscv__menv__metal_a_LIBADD =
 am__libriscv__menv__metal_a_SOURCES_DIST = gloss/crt0.S \
-	gloss/nanosleep.c gloss/sys_access.c gloss/sys_chdir.c \
-	gloss/sys_chmod.c gloss/sys_chown.c gloss/sys_close.c \
-	gloss/sys_execve.c gloss/sys_exit.c gloss/sys_faccessat.c \
-	gloss/sys_fork.c gloss/sys_fstat.c gloss/sys_fstatat.c \
-	gloss/sys_ftime.c gloss/sys_getcwd.c gloss/sys_getpid.c \
-	gloss/sys_gettimeofday.c gloss/sys_isatty.c gloss/sys_kill.c \
-	gloss/sys_link.c gloss/sys_lseek.c gloss/sys_lstat.c \
-	gloss/sys_open.c gloss/sys_openat.c gloss/sys_read.c \
-	gloss/sys_sbrk.c gloss/sys_stat.c gloss/sys_sysconf.c \
-	gloss/sys_times.c gloss/sys_unlink.c gloss/sys_utime.c \
-	gloss/sys_wait.c gloss/sys_write.c
+	gloss/synchronize_harts.c gloss/nanosleep.c gloss/sys_access.c \
+	gloss/sys_chdir.c gloss/sys_chmod.c gloss/sys_chown.c \
+	gloss/sys_close.c gloss/sys_execve.c gloss/sys_exit.c \
+	gloss/sys_faccessat.c gloss/sys_fork.c gloss/sys_fstat.c \
+	gloss/sys_fstatat.c gloss/sys_ftime.c gloss/sys_getcwd.c \
+	gloss/sys_getpid.c gloss/sys_gettimeofday.c gloss/sys_isatty.c \
+	gloss/sys_kill.c gloss/sys_link.c gloss/sys_lseek.c \
+	gloss/sys_lstat.c gloss/sys_open.c gloss/sys_openat.c \
+	gloss/sys_read.c gloss/sys_sbrk.c gloss/sys_stat.c \
+	gloss/sys_sysconf.c gloss/sys_times.c gloss/sys_unlink.c \
+	gloss/sys_utime.c gloss/sys_wait.c gloss/sys_write.c
 am__dirstamp = $(am__leading_dot)dirstamp
 @WITH_BUILTIN_LIBGLOSS_TRUE@am_libriscv__menv__metal_a_OBJECTS =  \
 @WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/crt0.$(OBJEXT) \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/synchronize_harts.$(OBJEXT) \
 @WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/nanosleep.$(OBJEXT) \
 @WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_access.$(OBJEXT) \
 @WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_chdir.$(OBJEXT) \
@@ -570,6 +571,7 @@ libriscv__mmachine__@MACHINE_NAME@_a_SOURCES = \
 
 @WITH_BUILTIN_LIBGLOSS_TRUE@libriscv__menv__metal_a_SOURCES = \
 @WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/crt0.S \
+@WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/synchronize_harts.c \
 @WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/nanosleep.c \
 @WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_access.c \
 @WITH_BUILTIN_LIBGLOSS_TRUE@	gloss/sys_chdir.c \
@@ -688,6 +690,8 @@ gloss/$(DEPDIR)/$(am__dirstamp):
 	@$(MKDIR_P) gloss/$(DEPDIR)
 	@: > gloss/$(DEPDIR)/$(am__dirstamp)
 gloss/crt0.$(OBJEXT): gloss/$(am__dirstamp) \
+	gloss/$(DEPDIR)/$(am__dirstamp)
+gloss/synchronize_harts.$(OBJEXT): gloss/$(am__dirstamp) \
 	gloss/$(DEPDIR)/$(am__dirstamp)
 gloss/nanosleep.$(OBJEXT): gloss/$(am__dirstamp) \
 	gloss/$(DEPDIR)/$(am__dirstamp)
@@ -911,6 +915,7 @@ distclean-compile:
 
 @AMDEP_TRUE@@am__include@ @am__quote@gloss/$(DEPDIR)/crt0.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@gloss/$(DEPDIR)/nanosleep.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@gloss/$(DEPDIR)/synchronize_harts.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@gloss/$(DEPDIR)/sys_access.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@gloss/$(DEPDIR)/sys_chdir.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@gloss/$(DEPDIR)/sys_chmod.Po@am__quote@

--- a/gloss/crt0.S
+++ b/gloss/crt0.S
@@ -129,6 +129,10 @@ _start:
 
 _skip_init:
 
+  /* Synchronize harts so that secondary harts wait until hart 0 finishes
+     initializing */
+  call _synchronize_harts
+
   /* Check RISC-V isa and enable FS bits if Floating Point architecture. */
   csrr a5, misa
   li   a4, 0x10028

--- a/gloss/synchronize_harts.c
+++ b/gloss/synchronize_harts.c
@@ -1,0 +1,59 @@
+/* Copyright 2019 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include <metal/machine.h>
+#include <metal/machine/platform.h>
+#include <metal/io.h>
+#include <metal/cpu.h>
+
+#define METAL_REG(base, offset)   (((unsigned long)(base) + (offset)))
+#define METAL_REGW(base, offset)  (__METAL_ACCESS_ONCE((__metal_io_u32 *)METAL_REG((base), (offset))))
+#define METAL_MSIP(base, hart)    (METAL_REGW((base),4*(hart)))
+
+/*
+ * _synchronize_harts() is called by crt0.S to cause harts > 0 to wait for
+ * hart 0 to finish copying the datat section, zeroing the BSS, and running
+ * the libc contstructors.
+ */
+void _synchronize_harts() {
+#if __METAL_DT_MAX_HARTS > 1
+
+    int hart = metal_cpu_get_current_hartid();
+    uintptr_t msip_base = 0;
+
+    /* Get the base address of the MSIP registers */
+#ifdef __METAL_DT_RISCV_CLINT0_HANDLE
+    msip_base = __metal_driver_sifive_clint0_control_base(__METAL_DT_RISCV_CLINT0_HANDLE);
+    msip_base += METAL_RISCV_CLINT0_MSIP_BASE;
+#elif __METAL_DT_RISCV_CLIC0_HANDLE
+    msip_base = __metal_driver_sifive_clic0_control_base(__METAL_DT_RISCV_CLIC0_HANDLE);
+    msip_base += METAL_RISCV_CLIC0_MSIP_BASE;
+#else
+#warning No handle for CLINT or CLIC found, harts may be unsynchronized after init!
+#endif
+
+    /* Disable machine interrupts as a precaution */
+    __asm__ volatile("csrc mstatus, %0" :: "r" (METAL_MSTATUS_MIE));
+
+    if (hart == 0) {
+        /* Hart 0 waits for all harts to set their MSIP bit */
+        for (int i = 1 ; i < __METAL_DT_MAX_HARTS; i++) {
+            while (METAL_MSIP(msip_base, i) == 0) ;
+        }
+
+        /* Hart 0 clears everyone's MSIP bit */
+        for (int i = 1 ; i < __METAL_DT_MAX_HARTS; i++) {
+            METAL_MSIP(msip_base, i) = 0;
+        }
+    } else {
+        /* Other harts set their MSIP bit to indicate they're ready */
+        METAL_MSIP(msip_base, hart) = 1;
+        __asm__ volatile ("fence w,rw");
+
+        /* Wait for hart 0 to clear the MSIP bit */
+        while (METAL_MSIP(msip_base, hart) == 1) ;
+    }
+
+#endif /* __METAL_DT_MAX_HARTS > 1 */
+}
+


### PR DESCRIPTION
Use the MSIP registers in the CLINT or CLIC to make all harts wait for hart 0 to finish initializing the data section, BSS, and constructors.