### PR TITLE
Improve uart

### DIFF
--- a/doc/sphinx/devguide/tty.rst
+++ b/doc/sphinx/devguide/tty.rst
@@ -1,10 +1,11 @@
 Standard I/O
 ============
 
-Freedom Metal integrates with libc ``STDOUT`` to provide virtual terminal support.
-The default ``STDOUT`` device is the first UART serial peripheral on the target.
-If no UART serial peripheral is present, such as in the case of SiFive CoreIP
-test harnesses, then the bytes sent to ``STDOUT`` are dropped.
+Freedom Metal integrates with libc ``STDOUT`` and ``STDIN`` to provide virtual
+terminal support. The default ``STDIO`` device is the first UART serial peripheral
+on the target. If no UART serial peripheral is present, such as in the case of
+SiFive CoreIP test harnesses, then the bytes sent to ``STDOUT`` are dropped and
+reads of ``STDIN`` fail with error ``ENOSYS``.
 
 Hello World
 -----------

--- a/gloss/sys_read.c
+++ b/gloss/sys_read.c
@@ -1,9 +1,25 @@
+#include <metal/tty.h>
 #include <sys/types.h>
 #include <errno.h>
+#include <unistd.h>
 
 ssize_t
 _read(int file, void *ptr, size_t len)
 {
-  errno = ENOSYS;
-  return -1;
+  if (file != STDIN_FILENO) {
+    errno = ENOSYS;
+    return -1;
+  }
+
+  char c = metal_tty_getc();
+
+  /* If we got back -1, no default input device is available */
+  if(c == -1) {
+    errno = EBADF;
+    return -1;
+  }
+
+  *((char *) ptr) = c;
+
+  return 1;
 }

--- a/gloss/sys_read.c
+++ b/gloss/sys_read.c
@@ -3,54 +3,104 @@
 #include <errno.h>
 #include <unistd.h>
 
+/* Known Bugs:
+ * ======
+ * The content of tty_buffer has to be filled before calling
+ * metal_tty_putc(). This is because metal_tty_putc() always
+ * modifies the content of the tty_buffer array, though this
+ * array is declared static in this file scope. 
+ *
+ * This happens after
+ * inline int metal_uart_putc(struct metal_uart *uart, int c) { 
+ *     return uart->vtable->putc(uart, c);
+ * }
+ * is called in metal/uart.h.
+ * ======
+ * When TTY_BUFFER_LEN is set to a small number (such as 10),
+ * metal_tty_putc() will again modify the values of start_index
+ * and end_index. 
+ *
+ * This happens after 
+ * __metal_driver_sifive_uart0_txready(uart)
+ * is called in src/drivers/sifive_uart0.c. */
+
 /* Parameters for the circular input buffer */
-#define TTY_BUFFER_LEN 127
-static char tty_buffer[TTY_BUFFER_LEN];
+#define TTY_BUFFER_LEN (127)
+#define WRAP_LEN (TTY_BUFFER_LEN + 1)
+
+static char tty_buffer[WRAP_LEN];
 static uint8_t start_index;
 static uint8_t end_index;
-#define increase_index(n) (n = (n + 1) % TTY_BUFFER_LEN)
-#define decrease_index(n) (n = (n + TTY_BUFFER_LEN - 1) % TTY_BUFFER_LEN)
-#define buffer_len (end_index > start_index ? \
-                                        end_index - start_index : \
-                                        end_index + TTY_BUFFER_LEN - start_index \
-                                        )
+#define INCREASE_INDEX(n) (n = (n + 1) % WRAP_LEN)
+#define DECREASE_INDEX(n) (n = (n + TTY_BUFFER_LEN) % WRAP_LEN)
+#define BUFFER_LEN (end_index > start_index ? \
+                    end_index - start_index : \
+                    end_index + WRAP_LEN - start_index)
+/* This macro backs up start_index and end_index
+ * on the stack. This is only a temporary solution to the 
+ * bugs described above */
+#define BACKUP_INDICES(statement) \
+    start_backup = start_index; \
+    end_backup = end_index; \
+    statement \
+    start_index = start_backup; \
+    end_index = end_backup;
 
 static void present_buffer(void) {
-  signed char c;
+  char c;
   int int_buffer;
+  uint8_t start_backup;
+  uint8_t end_backup;
   while (1) {
     metal_tty_getc(&int_buffer);
     /* If input is nothing, do nothing */
     if (int_buffer == -1) {
       continue;
     }
-    switch((c = int_buffer)) {
+    c = int_buffer;
+    /* Prevent overflowing the buffer */
+    if (BUFFER_LEN == TTY_BUFFER_LEN) {
+        if (c == 010 || c == 0177) {
+            DECREASE_INDEX(end_index);
+            BACKUP_INDICES(metal_tty_putc(010);
+                           metal_tty_putc(' ');
+                           metal_tty_putc(010);)
+            continue;
+        } else if (c != '\r' && c != '\n') {
+            continue;
+        } else {
+            BACKUP_INDICES(metal_tty_putc(c);
+                           metal_tty_putc_raw('\n');)
+            tty_buffer[end_index] = '\n';
+            return;
+        }
+    }
+    switch(c) {
       /* Entered newline character, end the buffer presentation */
       case '\r':
       case '\n':
-        metal_tty_putc(c);
-        metal_tty_putc_raw('\n');
+        BACKUP_INDICES(metal_tty_putc(c);
+                       metal_tty_putc_raw('\n');)
         tty_buffer[end_index] = '\n';
-        increase_index(end_index);
         return;
 
       /* Backspace */
       case 010:
       /* Del */
       case 0177:
-        if (buffer_len) {
-          decrease_index(end_index);
-          metal_tty_putc(010);
-          metal_tty_putc(' ');
-          metal_tty_putc(010);
+        if (BUFFER_LEN) {
+          DECREASE_INDEX(end_index);
+          BACKUP_INDICES(metal_tty_putc(010);
+                         metal_tty_putc(' ');
+                         metal_tty_putc(010);)
         }
         break;
         
       /* Other "normal" input */  
       default:
+        BACKUP_INDICES(metal_tty_putc(c);)
         tty_buffer[end_index] = c;
-        metal_tty_putc(c);
-        increase_index(end_index);
+        INCREASE_INDEX(end_index);
         break;
     }
   }
@@ -69,14 +119,15 @@ _read(int file, void *ptr, size_t len)
  
   /* Present an editable buffer */
   present_buffer();
-  int ret_len = buffer_len;
+  int ret_len = BUFFER_LEN + 1;
 
   /* Store the value in the buffer into ptr */
   while (start_index != end_index) {
     *cptr = tty_buffer[start_index];
     cptr++;
-    increase_index(start_index);
+    INCREASE_INDEX(start_index);
   }
+  *cptr = tty_buffer[end_index];
 
   return ret_len;
 }

--- a/gloss/sys_read.c
+++ b/gloss/sys_read.c
@@ -3,23 +3,80 @@
 #include <errno.h>
 #include <unistd.h>
 
+/* Parameters for the circular input buffer */
+#define TTY_BUFFER_LEN 127
+static char tty_buffer[TTY_BUFFER_LEN];
+static uint8_t start_index;
+static uint8_t end_index;
+#define increase_index(n) (n = (n + 1) % TTY_BUFFER_LEN)
+#define decrease_index(n) (n = (n + TTY_BUFFER_LEN - 1) % TTY_BUFFER_LEN)
+#define buffer_len (end_index > start_index ? \
+                                        end_index - start_index : \
+                                        end_index + TTY_BUFFER_LEN - start_index \
+                                        )
+
+static void present_buffer(void) {
+  signed char c;
+  int int_buffer;
+  while (1) {
+    metal_tty_getc(&int_buffer);
+    /* If input is nothing, do nothing */
+    if (int_buffer == -1) {
+      continue;
+    }
+    switch((c = int_buffer)) {
+      /* Entered newline character, end the buffer presentation */
+      case '\r':
+      case '\n':
+        metal_tty_putc(c);
+        metal_tty_putc_raw('\n');
+        tty_buffer[end_index] = '\n';
+        increase_index(end_index);
+        return;
+
+      /* Backspace */
+      case 010:
+      /* Del */
+      case 0177:
+        if (buffer_len) {
+          decrease_index(end_index);
+          metal_tty_putc(010);
+          metal_tty_putc(' ');
+          metal_tty_putc(010);
+        }
+        break;
+        
+      /* Other "normal" input */  
+      default:
+        tty_buffer[end_index] = c;
+        metal_tty_putc(c);
+        increase_index(end_index);
+        break;
+    }
+  }
+}
+
 ssize_t
 _read(int file, void *ptr, size_t len)
 {
-  if (file != STDIN_FILENO) {
-    errno = ENOSYS;
-    return -1;
-  }
-
-  char c = metal_tty_getc();
+  char *cptr = ptr;
 
   /* If we got back -1, no default input device is available */
-  if(c == -1) {
+  if (file != STDIN_FILENO) {
     errno = EBADF;
     return -1;
   }
+ 
+  /* Present an editable buffer */
+  present_buffer();
+  int ret_len = buffer_len;
 
-  *((char *) ptr) = c;
+  /* Store the value in the buffer into ptr */
+  while (start_index != end_index) {
+    *cptr = tty_buffer[start_index];
+    cptr++;
+    increase_index(start_index);
+  }
 
-  return 1;
+  return ret_len;
 }

--- a/gloss/sys_write.c
+++ b/gloss/sys_write.c
@@ -8,12 +8,18 @@ ssize_t
 _write(int file, const void *ptr, size_t len)
 {
   if (file != STDOUT_FILENO) {
-    errno = ENOSYS;
+    errno = EBADF;
     return -1;
   }
 
   const char *bptr = ptr;
-  for (size_t i = 0; i < len; ++i)
+  for (size_t i = 0; i < len; ++i) {
     metal_tty_putc(bptr[i]);
-  return 0;
+  }
+
+  /* Should return the number of bytes actually written,
+   * but methods tty.h and uart0.h do not indicate whether
+   * bytes are actually written, return the whole write length
+   * instead */
+  return len;
 }

--- a/metal/tty.h
+++ b/metal/tty.h
@@ -15,9 +15,38 @@
  * Write a character to the default output device, which for most
  * targets is the UART serial port.
  * 
+ * putc() does CR/LF mapping.
+ * putc_raw() does not.
+ *
  * @param c The character to write to the terminal
  * @return 0 on success, or -1 on failure.
  */
-int metal_tty_putc(unsigned char c);
+int metal_tty_putc(int c);
+
+/*!
+ * @brief Write a raw character to the default output device
+ *
+ * Write a character to the default output device, which for most
+ * targets is the UART serial port.
+ *
+ * putc() does CR/LF mapping.
+ * putc_raw() does not.
+ *
+ * @param c The character to write to the terminal
+ * @return 0 on success, or -1 on failure.
+ */
+int metal_tty_putc_raw(int c);
+
+/*!
+ * @brief Get a byte from the default output device
+ *
+ * The default output device, is typically the UART serial port.
+ *
+ * This call is non-blocking, if nothing is ready c==-1
+ * if something is ready, then c=[0x00 to 0xff] byte value.
+ *
+ * @return 0 on success, or -1 on failure.
+ */
+int metal_tty_getc(int *c);
 
 #endif

--- a/metal/tty.h
+++ b/metal/tty.h
@@ -5,6 +5,15 @@
 #define METAL__TTY_H
 
 /*!
+ * @brief Define a few special characters
+ */
+#define __METAL_BS_CHAR (010)
+#define __METAL_LF_CHAR (012)
+#define __METAL_CR_CHAR (015)
+#define __METAL_SP_CHAR (040)
+#define __METAL_DEL_CHAR (0177)
+
+/*!
  * @file tty.h
  * @brief API for emulated serial teriminals
  */

--- a/src/tty.c
+++ b/src/tty.c
@@ -10,8 +10,8 @@
  * UART on a system. */
 int metal_tty_putc(int c)
 {
-    if (c == '\n') {
-    metal_tty_putc_raw( '\r' );
+    if (c == __METAL_LF_CHAR) {
+    metal_tty_putc_raw(__METAL_CR_CHAR);
     }
   return metal_tty_putc_raw( c );
 }

--- a/src/tty.c
+++ b/src/tty.c
@@ -2,19 +2,28 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 #include <metal/uart.h>
+#include <metal/tty.h>
 #include <metal/machine.h>
 
 #if defined(__METAL_DT_STDOUT_UART_HANDLE)
 /* This implementation serves as a small shim that interfaces with the first
  * UART on a system. */
-int metal_tty_putc(unsigned char c)
+int metal_tty_putc(int c)
 {
     if (c == '\n') {
-        int out = metal_uart_putc(__METAL_DT_STDOUT_UART_HANDLE, '\r');
-        if (out != 0)
-            return out;
+    metal_tty_putc_raw( '\r' );
     }
+  return metal_tty_putc_raw( c );
+}
+int metal_tty_putc_raw(int c)
+{
     return metal_uart_putc(__METAL_DT_STDOUT_UART_HANDLE, c);
+}
+
+int metal_tty_getc(int *c)
+{
+    metal_uart_getc( __METAL_DT_STDOUT_UART_HANDLE, c );
+    return 0;
 }
 
 #ifndef __METAL_DT_STDOUT_UART_BAUD

--- a/src/uart.c
+++ b/src/uart.c
@@ -4,7 +4,8 @@
 #include <metal/uart.h>
 
 extern inline void metal_uart_init(struct metal_uart *uart, int baud_rate);
-extern inline int metal_uart_putc(struct metal_uart *uart, unsigned char c);
-extern inline int metal_uart_getc(struct metal_uart *uart, unsigned char *c);
+extern inline int metal_uart_putc(struct metal_uart *uart, int c);
+extern inline int metal_uart_txready(struct metal_uart *uart);
+extern inline int metal_uart_getc(struct metal_uart *uart, int *c);
 extern inline int metal_uart_get_baud_rate(struct metal_uart *uart);
 extern inline int metal_uart_set_baud_rate(struct metal_uart *uart, int baud_rate);


### PR DESCRIPTION
sys_read implements a circular buffer that blocks actual storing of data to memory. Each time the user types a string in the GNU screen, that string will be buffered until the user hits enter. Then that string will be appended with a '\n'. After that, the result string enters the stdin stream.

This behavior is actually closer to scanf, fgets, getc etc. on a standard pc. I did not implement non-blocking reads as of now. It seems that without ncurses, making non-block read calls on stdin does not have a clear use case. But if indeed that feature is desired, much more needs to be added. For example, the api will need to support fnctl, select, poll etc.