### PR TITLE
crt0 copies double-words on 64-bit targets

### DIFF
--- a/gloss/crt0.S
+++ b/gloss/crt0.S
@@ -80,11 +80,19 @@ _start:
   bge t1, t2, 2f
 
 1:
+#if __riscv_xlen == 32
   lw   a0, 0(t0)
   addi t0, t0, 4
   sw   a0, 0(t1)
   addi t1, t1, 4
   blt  t1, t2, 1b
+#else
+  ld   a0, 0(t0)
+  addi t0, t0, 8
+  sd   a0, 0(t1)
+  addi t1, t1, 8
+  blt  t1, t2, 1b
+#endif
 2:
 
   /* Copy the ITIM section */
@@ -96,11 +104,19 @@ _start:
   bge t1, t2, 2f
 
 1:
+#if __riscv_xlen == 32
   lw   a0, 0(t0)
   addi t0, t0, 4
   sw   a0, 0(t1)
   addi t1, t1, 4
   blt  t1, t2, 1b
+#else
+  ld   a0, 0(t0)
+  addi t0, t0, 8
+  sd   a0, 0(t1)
+  addi t1, t1, 8
+  blt  t1, t2, 1b
+#endif
 2:
 
   /* Zero the BSS segment. */
@@ -110,9 +126,15 @@ _start:
   bge t1, t2, 2f
 
 1:
+#if __riscv_xlen == 32
   sw   x0, 0(t1)
   addi t1, t1, 4
   blt  t1, t2, 1b
+#else
+  sd   x0, 0(t1)
+  addi t1, t1, 8
+  blt  t1, t2, 1b
+#endif
 2:
 
   /* At this point we're in an environment that can execute C code.  The first


### PR DESCRIPTION
crt0.S initializes the data, itim, and bss segments in memory on 64-bit targets using store/load double-words.

This is one of the changes necessary to remedy errors related to software failures on targets with ECC.