### PR TITLE
Fix sifive,test0 inline

### DIFF
--- a/src/drivers/sifive_test0.c
+++ b/src/drivers/sifive_test0.c
@@ -5,15 +5,17 @@
 
 #ifdef METAL_SIFIVE_TEST0
 
+#include <metal/machine.h>
+
+#include <stdint.h>
+
 #include <metal/drivers/sifive_test0.h>
 #include <metal/io.h>
-#include <stdint.h>
-#include <metal/machine.h>
 
 void __metal_driver_sifive_test0_exit(const struct __metal_shutdown *sd, int code) __attribute__((noreturn));
 void __metal_driver_sifive_test0_exit(const struct __metal_shutdown *sd, int code)
 {
-    long base = __metal_driver_sifive_test0_base();
+    long base = __metal_driver_sifive_test0_base(sd);
     uint32_t out = (code << 16) + (code == 0 ? 0x5555 : 0x3333);
     while (1) {
         __METAL_ACCESS_ONCE((__metal_io_u32 *)(base + METAL_SIFIVE_TEST0_FINISHER_OFFSET)) = out;

--- a/src/tty.c
+++ b/src/tty.c
@@ -44,8 +44,8 @@ static void metal_tty_init(void)
 /* This implementation of putc doesn't actually do anything, it's just there to
  * provide a shim that eats all the characters so we can ensure that everything
  * can link to metal_tty_putc. */
-int nop_putc(unsigned char c) __attribute__((section(".text.metal.nop.putc")));
-int nop_putc(unsigned char c) { return -1; }
-int metal_tty_putc(unsigned char c) __attribute__((weak, alias("nop_putc")));
+int nop_putc(int c) __attribute__((section(".text.metal.nop.putc")));
+int nop_putc(int c) { return -1; }
+int metal_tty_putc(int c) __attribute__((weak, alias("nop_putc")));
 #warning "There is no default output device, metal_tty_putc() will throw away all input."
 #endif


### PR DESCRIPTION
Pass device handle to __metal_driver_sifive_test0_base().

Also fix type signature of nop_putc() and friends.