### PR TITLE
Use __asm__ instead of asm keyword

### DIFF
--- a/metal/drivers/riscv_cpu.h
+++ b/metal/drivers/riscv_cpu.h
@@ -175,7 +175,7 @@ inline int __metal_controller_interrupt_is_selective_vectored (void)
 {
     uintptr_t val;
 
-    asm volatile ("csrr %0, mtvec" : "=r"(val));
+    __asm__ volatile ("csrr %0, mtvec" : "=r"(val));
     return ((val & METAL_MTVEC_CLIC_VECTORED) == METAL_MTVEC_CLIC);
 }
 

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -16,7 +16,7 @@ int metal_cpu_get_current_hartid()
 {
 #ifdef __riscv
     int mhartid;
-    asm volatile("csrr %0, mhartid" : "=r" (mhartid));
+    __asm__ volatile("csrr %0, mhartid" : "=r" (mhartid));
     return mhartid;
 #endif
 }

--- a/src/drivers/riscv_cpu.c
+++ b/src/drivers/riscv_cpu.c
@@ -20,7 +20,7 @@ struct metal_cpu *__metal_driver_cpu_get(int hartid)
 uintptr_t __metal_myhart_id (void)
 {
     uintptr_t myhart;
-    asm volatile ("csrr %0, mhartid" : "=r"(myhart));
+    __asm__ volatile ("csrr %0, mhartid" : "=r"(myhart));
     return myhart;
 }
 
@@ -34,54 +34,54 @@ void __metal_zero_memory (unsigned char *base, unsigned int size)
 
 void __metal_interrupt_global_enable (void) {
     uintptr_t m;
-    asm volatile ("csrrs %0, mstatus, %1" : "=r"(m) : "r"(METAL_MIE_INTERRUPT));
+    __asm__ volatile ("csrrs %0, mstatus, %1" : "=r"(m) : "r"(METAL_MIE_INTERRUPT));
 }
 
 void __metal_interrupt_global_disable (void) {
     uintptr_t m;
-    asm volatile ("csrrc %0, mstatus, %1" : "=r"(m) : "r"(METAL_MIE_INTERRUPT));
+    __asm__ volatile ("csrrc %0, mstatus, %1" : "=r"(m) : "r"(METAL_MIE_INTERRUPT));
 }
 
 void __metal_interrupt_software_enable (void) {
     uintptr_t m;
-    asm volatile ("csrrs %0, mie, %1" : "=r"(m) : "r"(METAL_LOCAL_INTERRUPT_SW));
+    __asm__ volatile ("csrrs %0, mie, %1" : "=r"(m) : "r"(METAL_LOCAL_INTERRUPT_SW));
 }
 
 void __metal_interrupt_software_disable (void) {
     uintptr_t m;
-    asm volatile ("csrrc %0, mie, %1" : "=r"(m) : "r"(METAL_LOCAL_INTERRUPT_SW));
+    __asm__ volatile ("csrrc %0, mie, %1" : "=r"(m) : "r"(METAL_LOCAL_INTERRUPT_SW));
 }
 
 void __metal_interrupt_timer_enable (void) {
     uintptr_t m;
-    asm volatile ("csrrs %0, mie, %1" : "=r"(m) : "r"(METAL_LOCAL_INTERRUPT_TMR));
+    __asm__ volatile ("csrrs %0, mie, %1" : "=r"(m) : "r"(METAL_LOCAL_INTERRUPT_TMR));
 }
 
 void __metal_interrupt_timer_disable (void) {
     uintptr_t m;
-    asm volatile ("csrrc %0, mie, %1" : "=r"(m) : "r"(METAL_LOCAL_INTERRUPT_TMR));
+    __asm__ volatile ("csrrc %0, mie, %1" : "=r"(m) : "r"(METAL_LOCAL_INTERRUPT_TMR));
 }
 
 void __metal_interrupt_external_enable (void) {
     uintptr_t m;
-    asm volatile ("csrrs %0, mie, %1" : "=r"(m) : "r"(METAL_LOCAL_INTERRUPT_EXT));
+    __asm__ volatile ("csrrs %0, mie, %1" : "=r"(m) : "r"(METAL_LOCAL_INTERRUPT_EXT));
 }
 
 void __metal_interrupt_external_disable (void) {
     unsigned long m;
-    asm volatile ("csrrc %0, mie, %1" : "=r"(m) : "r"(METAL_LOCAL_INTERRUPT_EXT));
+    __asm__ volatile ("csrrc %0, mie, %1" : "=r"(m) : "r"(METAL_LOCAL_INTERRUPT_EXT));
 }
 
 void __metal_interrupt_local_enable (int id) {
     uintptr_t b = 1 << id;
     uintptr_t m;
-    asm volatile ("csrrs %0, mie, %1" : "=r"(m) : "r"(b));
+    __asm__ volatile ("csrrs %0, mie, %1" : "=r"(m) : "r"(b));
 }
 
 void __metal_interrupt_local_disable (int id) {
     uintptr_t b = 1 << id;
     uintptr_t m;
-    asm volatile ("csrrc %0, mie, %1" : "=r"(m) : "r"(b));
+    __asm__ volatile ("csrrc %0, mie, %1" : "=r"(m) : "r"(b));
 }
 
 void __metal_default_exception_handler (struct metal_cpu *cpu, int ecode) {
@@ -97,7 +97,7 @@ void __metal_default_sw_handler (int id, void *priv) {
     struct __metal_driver_riscv_cpu_intc *intc;
     struct __metal_driver_cpu *cpu = __metal_cpu_table[__metal_myhart_id()];
 
-    asm volatile ("csrr %0, mcause" : "=r"(mcause));
+    __asm__ volatile ("csrr %0, mcause" : "=r"(mcause));
     if ( cpu ) {
         intc = (struct __metal_driver_riscv_cpu_intc *)
 	  __metal_driver_cpu_interrupt_controller((struct metal_cpu *)cpu);
@@ -121,10 +121,10 @@ void __metal_exception_handler (void) {
     struct __metal_driver_riscv_cpu_intc *intc;
     struct __metal_driver_cpu *cpu = __metal_cpu_table[__metal_myhart_id()];
 
-    asm volatile ("csrr %0, mcause" : "=r"(mcause));
-    asm volatile ("csrr %0, mepc" : "=r"(mepc));
-    asm volatile ("csrr %0, mtval" : "=r"(mtval));
-    asm volatile ("csrr %0, mtvec" : "=r"(mtvec));
+    __asm__ volatile ("csrr %0, mcause" : "=r"(mcause));
+    __asm__ volatile ("csrr %0, mepc" : "=r"(mepc));
+    __asm__ volatile ("csrr %0, mtval" : "=r"(mtval));
+    __asm__ volatile ("csrr %0, mtvec" : "=r"(mtvec));
 
     if ( cpu ) {
         intc = (struct __metal_driver_riscv_cpu_intc *)
@@ -141,7 +141,7 @@ void __metal_exception_handler (void) {
     		uintptr_t mtvt;
     		metal_interrupt_handler_t mtvt_handler;
 
-                asm volatile ("csrr %0, mtvt" : "=r"(mtvt));
+                __asm__ volatile ("csrr %0, mtvt" : "=r"(mtvt));
                	priv = intc->metal_int_table[METAL_INTERRUPT_ID_SW].sub_int;
                	mtvt_handler = (metal_interrupt_handler_t)mtvt;
                	mtvt_handler(id, priv);
@@ -157,24 +157,24 @@ void __metal_controller_interrupt_vector (metal_vector_mode mode, void *vec_tabl
 {  
     uintptr_t trap_entry, val;
 
-    asm volatile ("csrr %0, mtvec" : "=r"(val));
+    __asm__ volatile ("csrr %0, mtvec" : "=r"(val));
     val &= ~(METAL_MTVEC_CLIC_VECTORED | METAL_MTVEC_CLIC_RESERVED);
     trap_entry = (uintptr_t)vec_table;
 
     switch (mode) {
     case METAL_SELECTIVE_VECTOR_MODE:
-        asm volatile ("csrw mtvt, %0" :: "r"(trap_entry | METAL_MTVEC_CLIC));
-        asm volatile ("csrw mtvec, %0" :: "r"(val | METAL_MTVEC_CLIC));
+        __asm__ volatile ("csrw mtvt, %0" :: "r"(trap_entry | METAL_MTVEC_CLIC));
+        __asm__ volatile ("csrw mtvec, %0" :: "r"(val | METAL_MTVEC_CLIC));
         break;
     case METAL_HARDWARE_VECTOR_MODE:
-        asm volatile ("csrw mtvt, %0" :: "r"(trap_entry | METAL_MTVEC_CLIC_VECTORED));
-        asm volatile ("csrw mtvec, %0" :: "r"(val | METAL_MTVEC_CLIC_VECTORED));
+        __asm__ volatile ("csrw mtvt, %0" :: "r"(trap_entry | METAL_MTVEC_CLIC_VECTORED));
+        __asm__ volatile ("csrw mtvec, %0" :: "r"(val | METAL_MTVEC_CLIC_VECTORED));
         break;
     case METAL_VECTOR_MODE:
-        asm volatile ("csrw mtvec, %0" :: "r"(trap_entry | METAL_MTVEC_VECTORED));
+        __asm__ volatile ("csrw mtvec, %0" :: "r"(trap_entry | METAL_MTVEC_VECTORED));
         break;
     case METAL_DIRECT_MODE:
-        asm volatile ("csrw mtvec, %0" :: "r"(trap_entry & ~METAL_MTVEC_CLIC_VECTORED));
+        __asm__ volatile ("csrw mtvec, %0" :: "r"(trap_entry & ~METAL_MTVEC_CLIC_VECTORED));
         break;
     }
 }
@@ -295,25 +295,25 @@ void __metal_driver_riscv_cpu_controller_interrupt_init (struct metal_interrupt 
 
     if ( !intc->init_done ) {
         /* Disable and clear all interrupt sources */
-        asm volatile ("csrc mie, %0" :: "r"(-1));
-        asm volatile ("csrc mip, %0" :: "r"(-1));
+        __asm__ volatile ("csrc mie, %0" :: "r"(-1));
+        __asm__ volatile ("csrc mip, %0" :: "r"(-1));
 
         /* Read the misa CSR to determine if the delegation registers exist */
         uintptr_t misa;
-        asm volatile ("csrr %0, misa" : "=r" (misa));
+        __asm__ volatile ("csrr %0, misa" : "=r" (misa));
 
         /* The delegation CSRs exist if user mode interrupts (N extension) or
          * supervisor mode (S extension) are supported */
         if((misa & METAL_ISA_N_EXTENSIONS) || (misa & METAL_ISA_S_EXTENSIONS)) {
             /* Disable interrupt and exception delegation */
-            asm volatile ("csrc mideleg, %0" :: "r"(-1));
-            asm volatile ("csrc medeleg, %0" :: "r"(-1));
+            __asm__ volatile ("csrc mideleg, %0" :: "r"(-1));
+            __asm__ volatile ("csrc medeleg, %0" :: "r"(-1));
         }
 
         /* The satp CSR exists if supervisor mode (S extension) is supported */
         if(misa & METAL_ISA_S_EXTENSIONS) {
             /* Clear the entire CSR to make sure that satp.MODE = 0 */
-            asm volatile ("csrc satp, %0" :: "r"(-1));
+            __asm__ volatile ("csrc satp, %0" :: "r"(-1));
         }
 
         /* Default to use direct interrupt, setup sw cb table*/
@@ -326,11 +326,11 @@ void __metal_driver_riscv_cpu_controller_interrupt_init (struct metal_interrupt 
 	    intc->metal_exception_table[i] = __metal_default_exception_handler;
 	}
         __metal_controller_interrupt_vector(METAL_DIRECT_MODE, &__metal_exception_handler);
-	asm volatile ("csrr %0, misa" : "=r"(val));
+	__asm__ volatile ("csrr %0, misa" : "=r"(val));
 	if (val & (METAL_ISA_D_EXTENSIONS | METAL_ISA_F_EXTENSIONS | METAL_ISA_Q_EXTENSIONS)) {
 	    /* Floating point architecture, so turn on FP register saving*/
-	    asm volatile ("csrr %0, mstatus" : "=r"(val));
-	    asm volatile ("csrw mstatus, %0" :: "r"(val | METAL_MSTATUS_FS_INIT));
+	    __asm__ volatile ("csrr %0, mstatus" : "=r"(val));
+	    __asm__ volatile ("csrw mstatus, %0" :: "r"(val | METAL_MSTATUS_FS_INIT));
 	}
 	intc->init_done = 1;
     }
@@ -447,14 +447,14 @@ unsigned long long __metal_driver_cpu_mcycle_get(struct metal_cpu *cpu)
 #if __riscv_xlen == 32
     unsigned long hi, hi1, lo;
 
-    asm volatile ("csrr %0, mcycleh" : "=r"(hi));
-    asm volatile ("csrr %0, mcycle" : "=r"(lo));
-    asm volatile ("csrr %0, mcycleh" : "=r"(hi1));
+    __asm__ volatile ("csrr %0, mcycleh" : "=r"(hi));
+    __asm__ volatile ("csrr %0, mcycle" : "=r"(lo));
+    __asm__ volatile ("csrr %0, mcycleh" : "=r"(hi1));
     if (hi == hi1) {
         val = ((unsigned long long)hi << 32) | lo;
     }
 #else
-    asm volatile ("csrr %0, mcycle" : "=r"(val));
+    __asm__ volatile ("csrr %0, mcycle" : "=r"(val));
 #endif
 
     return val;
@@ -649,13 +649,13 @@ int  __metal_driver_cpu_get_instruction_length(struct metal_cpu *cpu, uintptr_t 
 uintptr_t  __metal_driver_cpu_get_exception_pc(struct metal_cpu *cpu)
 {
     uintptr_t mepc;
-    asm volatile ("csrr %0, mepc" : "=r"(mepc));
+    __asm__ volatile ("csrr %0, mepc" : "=r"(mepc));
     return mepc;
 }
 
 int  __metal_driver_cpu_set_exception_pc(struct metal_cpu *cpu, uintptr_t mepc)
 {
-    asm volatile ("csrw mepc, %0" :: "r"(mepc));
+    __asm__ volatile ("csrw mepc, %0" :: "r"(mepc));
     return 0;
 }
 

--- a/src/drivers/sifive_uart0.c
+++ b/src/drivers/sifive_uart0.c
@@ -120,7 +120,7 @@ static void pre_rate_change_callback_func(void *priv)
     long cycles_to_wait = bits_per_symbol * clk_freq / uart->baud_rate;
 
     for(volatile long x = 0; x < cycles_to_wait; x++)
-        asm("nop");
+        __asm__("nop");
 }
 
 static void post_rate_change_callback_func(void *priv)

--- a/src/pmp.c
+++ b/src/pmp.c
@@ -151,67 +151,67 @@ int metal_pmp_set_region(struct metal_pmp *pmp,
     if(old_address != address) {
         switch(region) {
         case 0:
-            asm("csrw pmpaddr0, %[addr]"
+            __asm__("csrw pmpaddr0, %[addr]"
                     :: [addr] "r" (address) :);
             break;
         case 1:
-            asm("csrw pmpaddr1, %[addr]"
+            __asm__("csrw pmpaddr1, %[addr]"
                     :: [addr] "r" (address) :);
             break;
         case 2:
-            asm("csrw pmpaddr2, %[addr]"
+            __asm__("csrw pmpaddr2, %[addr]"
                     :: [addr] "r" (address) :);
             break;
         case 3:
-            asm("csrw pmpaddr3, %[addr]"
+            __asm__("csrw pmpaddr3, %[addr]"
                     :: [addr] "r" (address) :);
             break;
         case 4:
-            asm("csrw pmpaddr4, %[addr]"
+            __asm__("csrw pmpaddr4, %[addr]"
                     :: [addr] "r" (address) :);
             break;
         case 5:
-            asm("csrw pmpaddr5, %[addr]"
+            __asm__("csrw pmpaddr5, %[addr]"
                     :: [addr] "r" (address) :);
             break;
         case 6:
-            asm("csrw pmpaddr6, %[addr]"
+            __asm__("csrw pmpaddr6, %[addr]"
                     :: [addr] "r" (address) :);
             break;
         case 7:
-            asm("csrw pmpaddr7, %[addr]"
+            __asm__("csrw pmpaddr7, %[addr]"
                     :: [addr] "r" (address) :);
             break;
         case 8:
-            asm("csrw pmpaddr8, %[addr]"
+            __asm__("csrw pmpaddr8, %[addr]"
                     :: [addr] "r" (address) :);
             break;
         case 9:
-            asm("csrw pmpaddr9, %[addr]"
+            __asm__("csrw pmpaddr9, %[addr]"
                     :: [addr] "r" (address) :);
             break;
         case 10:
-            asm("csrw pmpaddr10, %[addr]"
+            __asm__("csrw pmpaddr10, %[addr]"
                     :: [addr] "r" (address) :);
             break;
         case 11:
-            asm("csrw pmpaddr11, %[addr]"
+            __asm__("csrw pmpaddr11, %[addr]"
                     :: [addr] "r" (address) :);
             break;
         case 12:
-            asm("csrw pmpaddr12, %[addr]"
+            __asm__("csrw pmpaddr12, %[addr]"
                     :: [addr] "r" (address) :);
             break;
         case 13:
-            asm("csrw pmpaddr13, %[addr]"
+            __asm__("csrw pmpaddr13, %[addr]"
                     :: [addr] "r" (address) :);
             break;
         case 14:
-            asm("csrw pmpaddr14, %[addr]"
+            __asm__("csrw pmpaddr14, %[addr]"
                     :: [addr] "r" (address) :);
             break;
         case 15:
-            asm("csrw pmpaddr15, %[addr]"
+            __asm__("csrw pmpaddr15, %[addr]"
                     :: [addr] "r" (address) :);
             break;
         }
@@ -225,31 +225,31 @@ int metal_pmp_set_region(struct metal_pmp *pmp,
         
         switch(region / 4) {
         case 0:
-            asm("csrc pmpcfg0, %[mask]"
+            __asm__("csrc pmpcfg0, %[mask]"
                     :: [mask] "r" (cfgmask) :);
 
-            asm("csrs pmpcfg0, %[cfg]"
+            __asm__("csrs pmpcfg0, %[cfg]"
                     :: [cfg] "r" (pmpcfg) :);
             break;
         case 1:
-            asm("csrc pmpcfg1, %[mask]"
+            __asm__("csrc pmpcfg1, %[mask]"
                     :: [mask] "r" (cfgmask) :);
 
-            asm("csrs pmpcfg1, %[cfg]"
+            __asm__("csrs pmpcfg1, %[cfg]"
                     :: [cfg] "r" (pmpcfg) :);
             break;
         case 2:
-            asm("csrc pmpcfg2, %[mask]"
+            __asm__("csrc pmpcfg2, %[mask]"
                     :: [mask] "r" (cfgmask) :);
 
-            asm("csrs pmpcfg2, %[cfg]"
+            __asm__("csrs pmpcfg2, %[cfg]"
                     :: [cfg] "r" (pmpcfg) :);
             break;
         case 3:
-            asm("csrc pmpcfg3, %[mask]"
+            __asm__("csrc pmpcfg3, %[mask]"
                     :: [mask] "r" (cfgmask) :);
 
-            asm("csrs pmpcfg3, %[cfg]"
+            __asm__("csrs pmpcfg3, %[cfg]"
                     :: [cfg] "r" (pmpcfg) :);
             break;
         }
@@ -262,17 +262,17 @@ int metal_pmp_set_region(struct metal_pmp *pmp,
         
         switch(region / 8) {
         case 0:
-            asm("csrc pmpcfg0, %[mask]"
+            __asm__("csrc pmpcfg0, %[mask]"
                     :: [mask] "r" (cfgmask) :);
 
-            asm("csrs pmpcfg0, %[cfg]"
+            __asm__("csrs pmpcfg0, %[cfg]"
                     :: [cfg] "r" (pmpcfg) :);
             break;
         case 1:
-            asm("csrc pmpcfg2, %[mask]"
+            __asm__("csrc pmpcfg2, %[mask]"
                     :: [mask] "r" (cfgmask) :);
 
-            asm("csrs pmpcfg2, %[cfg]"
+            __asm__("csrs pmpcfg2, %[cfg]"
                     :: [cfg] "r" (pmpcfg) :);
             break;
         }
@@ -304,19 +304,19 @@ int metal_pmp_get_region(struct metal_pmp *pmp,
 #if __riscv_xlen==32
     switch(region / 4) {
     case 0:
-        asm("csrr %[cfg], pmpcfg0"
+        __asm__("csrr %[cfg], pmpcfg0"
                 : [cfg] "=r" (pmpcfg) ::);
         break;
     case 1:
-        asm("csrr %[cfg], pmpcfg1"
+        __asm__("csrr %[cfg], pmpcfg1"
                 : [cfg] "=r" (pmpcfg) ::);
         break;
     case 2:
-        asm("csrr %[cfg], pmpcfg2"
+        __asm__("csrr %[cfg], pmpcfg2"
                 : [cfg] "=r" (pmpcfg) ::);
         break;
     case 3:
-        asm("csrr %[cfg], pmpcfg3"
+        __asm__("csrr %[cfg], pmpcfg3"
                 : [cfg] "=r" (pmpcfg) ::);
         break;
     }
@@ -326,11 +326,11 @@ int metal_pmp_get_region(struct metal_pmp *pmp,
 #elif __riscv_xlen==64
     switch(region / 8) {
     case 0:
-        asm("csrr %[cfg], pmpcfg0"
+        __asm__("csrr %[cfg], pmpcfg0"
                 : [cfg] "=r" (pmpcfg) ::);
         break;
     case 1:
-        asm("csrr %[cfg], pmpcfg2"
+        __asm__("csrr %[cfg], pmpcfg2"
                 : [cfg] "=r" (pmpcfg) ::);
         break;
     }
@@ -345,67 +345,67 @@ int metal_pmp_get_region(struct metal_pmp *pmp,
 
     switch(region) {
     case 0:
-        asm("csrr %[addr], pmpaddr0"
+        __asm__("csrr %[addr], pmpaddr0"
                 : [addr] "=r" (*address) ::);
         break;
     case 1:
-        asm("csrr %[addr], pmpaddr1"
+        __asm__("csrr %[addr], pmpaddr1"
                 : [addr] "=r" (*address) ::);
         break;
     case 2:
-        asm("csrr %[addr], pmpaddr2"
+        __asm__("csrr %[addr], pmpaddr2"
                 : [addr] "=r" (*address) ::);
         break;
     case 3:
-        asm("csrr %[addr], pmpaddr3"
+        __asm__("csrr %[addr], pmpaddr3"
                 : [addr] "=r" (*address) ::);
         break;
     case 4:
-        asm("csrr %[addr], pmpaddr4"
+        __asm__("csrr %[addr], pmpaddr4"
                 : [addr] "=r" (*address) ::);
         break;
     case 5:
-        asm("csrr %[addr], pmpaddr5"
+        __asm__("csrr %[addr], pmpaddr5"
                 : [addr] "=r" (*address) ::);
         break;
     case 6:
-        asm("csrr %[addr], pmpaddr6"
+        __asm__("csrr %[addr], pmpaddr6"
                 : [addr] "=r" (*address) ::);
         break;
     case 7:
-        asm("csrr %[addr], pmpaddr7"
+        __asm__("csrr %[addr], pmpaddr7"
                 : [addr] "=r" (*address) ::);
         break;
     case 8:
-        asm("csrr %[addr], pmpaddr8"
+        __asm__("csrr %[addr], pmpaddr8"
                 : [addr] "=r" (*address) ::);
         break;
     case 9:
-        asm("csrr %[addr], pmpaddr9"
+        __asm__("csrr %[addr], pmpaddr9"
                 : [addr] "=r" (*address) ::);
         break;
     case 10:
-        asm("csrr %[addr], pmpaddr10"
+        __asm__("csrr %[addr], pmpaddr10"
                 : [addr] "=r" (*address) ::);
         break;
     case 11:
-        asm("csrr %[addr], pmpaddr11"
+        __asm__("csrr %[addr], pmpaddr11"
                 : [addr] "=r" (*address) ::);
         break;
     case 12:
-        asm("csrr %[addr], pmpaddr12"
+        __asm__("csrr %[addr], pmpaddr12"
                 : [addr] "=r" (*address) ::);
         break;
     case 13:
-        asm("csrr %[addr], pmpaddr13"
+        __asm__("csrr %[addr], pmpaddr13"
                 : [addr] "=r" (*address) ::);
         break;
     case 14:
-        asm("csrr %[addr], pmpaddr14"
+        __asm__("csrr %[addr], pmpaddr14"
                 : [addr] "=r" (*address) ::);
         break;
     case 15:
-        asm("csrr %[addr], pmpaddr15"
+        __asm__("csrr %[addr], pmpaddr15"
                 : [addr] "=r" (*address) ::);
         break;
     }

--- a/src/privilege.c
+++ b/src/privilege.c
@@ -20,7 +20,7 @@ void metal_privilege_drop_to_mode(enum metal_privilege_mode mode,
 				  metal_privilege_entry_point_t entry_point)
 {
 	uintptr_t mstatus;
-	asm volatile("csrr %0, mstatus" : "=r" (mstatus));
+	__asm__ volatile("csrr %0, mstatus" : "=r" (mstatus));
 
 	/* Set xPIE bits based on current xIE bits */
 	if(mstatus && (1 << METAL_MSTATUS_MIE_OFFSET)) {
@@ -43,15 +43,15 @@ void metal_privilege_drop_to_mode(enum metal_privilege_mode mode,
 	mstatus &= ~(METAL_MSTATUS_MPP_MASK << METAL_MSTATUS_MPP_OFFSET);
 	mstatus |= (mode << METAL_MSTATUS_MPP_OFFSET);
 
-	asm volatile("csrw mstatus, %0" :: "r" (mstatus));
+	__asm__ volatile("csrw mstatus, %0" :: "r" (mstatus));
 
 	/* Set the entry point in MEPC */
-	asm volatile("csrw mepc, %0" :: "r" (entry_point));
+	__asm__ volatile("csrw mepc, %0" :: "r" (entry_point));
 
 	/* Set the register file */
-	asm volatile("mv ra, %0" :: "r" (regfile.ra));
-	asm volatile("mv sp, %0" :: "r" (regfile.sp));
+	__asm__ volatile("mv ra, %0" :: "r" (regfile.ra));
+	__asm__ volatile("mv sp, %0" :: "r" (regfile.sp));
 
-	asm volatile("mret");
+	__asm__ volatile("mret");
 }
 


### PR DESCRIPTION
The `asm` keyword is a GCC extension, so remove it for the more portable `__asm__`.