### PR TITLE
Explicitly include interrupt.h in gpio.h

### DIFF
--- a/metal/gpio.h
+++ b/metal/gpio.h
@@ -5,6 +5,7 @@
 #define METAL__GPIO_H
 
 #include <metal/compiler.h>
+#include <metal/interrupt.h>
 
 /*!
  * @file gpio.h


### PR DESCRIPTION
It uses `metal_interrupt` but doesn't include `interrupt.h`.