### PR TITLE
Fix warnings and errors for C99

### DIFF
--- a/gloss/synchronize_harts.c
+++ b/gloss/synchronize_harts.c
@@ -29,7 +29,7 @@ void _synchronize_harts() {
     msip_base = __metal_driver_sifive_clic0_control_base(__METAL_DT_RISCV_CLIC0_HANDLE);
     msip_base += METAL_RISCV_CLIC0_MSIP_BASE;
 #else
-#warning No handle for CLINT or CLIC found, harts may be unsynchronized after init!
+#pragma message(No handle for CLINT or CLIC found, harts may be unsynchronized after init!)
 #endif
 
     /* Disable machine interrupts as a precaution */

--- a/gloss/sys_gettimeofday.c
+++ b/gloss/sys_gettimeofday.c
@@ -7,10 +7,12 @@ _gettimeofday(struct timeval *tp, void *tzp)
 {
     int rv;
     unsigned long long mcc, timebase;
-    if (rv = metal_timer_get_cyclecount(0, &mcc)) {
+    rv = metal_timer_get_cyclecount(0, &mcc);
+    if (rv != 0) {
         return -1;
     }
-    if (rv = metal_timer_get_timebase_frequency(0, &timebase)) {
+    rv = metal_timer_get_timebase_frequency(0, &timebase);
+    if (rv != 0) {
         return -1;
     }
     tp->tv_sec = mcc / timebase;

--- a/gloss/sys_times.c
+++ b/gloss/sys_times.c
@@ -30,7 +30,8 @@ _times(struct tms *buf)
     _gettimeofday (&t, 0);
 
     unsigned long long timebase;
-    if (rv = metal_timer_get_timebase_frequency(0, &timebase)) {
+    rv = metal_timer_get_timebase_frequency(0, &timebase);
+    if (rv != 0) {
         return -1;
     }
 

--- a/metal/button.h
+++ b/metal/button.h
@@ -45,7 +45,7 @@ struct metal_button* metal_button_get(char *label);
  * @return A pointer to the interrupt controller responsible for handling
  * button interrupts.
  */
-inline struct metal_interrupt*
+__inline__ struct metal_interrupt*
     metal_button_interrupt_controller(struct metal_button *button) { return button->vtable->interrupt_controller(button); }
 
 /*!
@@ -54,6 +54,6 @@ inline struct metal_interrupt*
  * @param button The handle for the button
  * @return The interrupt id corresponding to a button.
  */
-inline int metal_button_get_interrupt_id(struct metal_button *button) { return button->vtable->get_interrupt_id(button); }
+__inline__ int metal_button_get_interrupt_id(struct metal_button *button) { return button->vtable->get_interrupt_id(button); }
 
 #endif

--- a/metal/cache.h
+++ b/metal/cache.h
@@ -33,7 +33,7 @@ struct metal_cache {
  * Initializes a cache with the requested number of ways enabled.
  */
 __inline__ void metal_cache_init(struct metal_cache *cache, int ways) {
-	return cache->vtable->init(cache, ways);
+	cache->vtable->init(cache, ways);
 }
 
 /*!

--- a/metal/cache.h
+++ b/metal/cache.h
@@ -32,7 +32,7 @@ struct metal_cache {
  *
  * Initializes a cache with the requested number of ways enabled.
  */
-inline void metal_cache_init(struct metal_cache *cache, int ways) {
+__inline__ void metal_cache_init(struct metal_cache *cache, int ways) {
 	return cache->vtable->init(cache, ways);
 }
 
@@ -41,7 +41,7 @@ inline void metal_cache_init(struct metal_cache *cache, int ways) {
  * @param cache The handle for the cache
  * @return The current number of enabled cache ways
  */
-inline int metal_cache_get_enabled_ways(struct metal_cache *cache) {
+__inline__ int metal_cache_get_enabled_ways(struct metal_cache *cache) {
 	return cache->vtable->get_enabled_ways(cache);
 }
 
@@ -51,7 +51,7 @@ inline int metal_cache_get_enabled_ways(struct metal_cache *cache) {
  * @param ways The number of ways to enabled
  * @return 0 if the ways are successfully enabled
  */
-inline int metal_cache_set_enabled_ways(struct metal_cache *cache, int ways) {
+__inline__ int metal_cache_set_enabled_ways(struct metal_cache *cache, int ways) {
 	return cache->vtable->set_enabled_ways(cache, ways);
 }
 

--- a/metal/clock.h
+++ b/metal/clock.h
@@ -45,7 +45,7 @@ typedef struct _metal_clock_callback_t metal_clock_callback;
 /*!
  * @brief Call all callbacks in the linked list, if any are registered
  */
-inline void _metal_clock_call_all_callbacks(const metal_clock_callback *const list) {
+__inline__ void _metal_clock_call_all_callbacks(const metal_clock_callback *const list) {
     const metal_clock_callback *current = list;
     while (current) {
         current->callback(current->priv);
@@ -56,7 +56,7 @@ inline void _metal_clock_call_all_callbacks(const metal_clock_callback *const li
 /*!
  * @brief Append a callback to the linked list and return the head of the list
  */
-inline metal_clock_callback *_metal_clock_append_to_callbacks(metal_clock_callback *list, metal_clock_callback *const cb) {
+__inline__ metal_clock_callback *_metal_clock_append_to_callbacks(metal_clock_callback *list, metal_clock_callback *const cb) {
     cb->_next = NULL;
 
     if (!list) {
@@ -102,7 +102,7 @@ struct metal_clock {
  * @param clk The handle for the clock
  * @return The current rate of the clock in Hz
  */
-inline long metal_clock_get_rate_hz(const struct metal_clock *clk) { return clk->vtable->get_rate_hz(clk); }
+__inline__ long metal_clock_get_rate_hz(const struct metal_clock *clk) { return clk->vtable->get_rate_hz(clk); }
 
 /*!
  * @brief Set the current rate of a clock
@@ -118,7 +118,7 @@ inline long metal_clock_get_rate_hz(const struct metal_clock *clk) { return clk-
  * Prior to and after the rate change of the clock, this will call the registered
  * pre- and post-rate change callbacks.
  */
-inline long metal_clock_set_rate_hz(struct metal_clock *clk, long hz)
+__inline__ long metal_clock_set_rate_hz(struct metal_clock *clk, long hz)
 {
     _metal_clock_call_all_callbacks(clk->_pre_rate_change_callback);
 
@@ -135,7 +135,7 @@ inline long metal_clock_set_rate_hz(struct metal_clock *clk, long hz)
  * @param clk The handle for the clock
  * @param cb The callback to be registered
  */
-inline void metal_clock_register_pre_rate_change_callback(struct metal_clock *clk, metal_clock_callback *cb)
+__inline__ void metal_clock_register_pre_rate_change_callback(struct metal_clock *clk, metal_clock_callback *cb)
 {
     clk->_pre_rate_change_callback = _metal_clock_append_to_callbacks(clk->_pre_rate_change_callback, cb);
 }
@@ -146,7 +146,7 @@ inline void metal_clock_register_pre_rate_change_callback(struct metal_clock *cl
  * @param clk The handle for the clock
  * @param cb The callback to be registered
  */
-inline void metal_clock_register_post_rate_change_callback(struct metal_clock *clk, metal_clock_callback *cb)
+__inline__ void metal_clock_register_post_rate_change_callback(struct metal_clock *clk, metal_clock_callback *cb)
 {
     clk->_post_rate_change_callback = _metal_clock_append_to_callbacks(clk->_post_rate_change_callback, cb);
 }

--- a/metal/cpu.h
+++ b/metal/cpu.h
@@ -49,7 +49,7 @@ struct metal_cpu {
  * @param hartid The ID of the desired CPU hart
  * @return A pointer to the CPU device handle
  */
-struct metal_cpu* metal_cpu_get(int hartid);
+struct metal_cpu* metal_cpu_get(unsigned int hartid);
 
 /*! @brief Get the hartid of the CPU hart executing this function
  *

--- a/metal/cpu.h
+++ b/metal/cpu.h
@@ -68,7 +68,7 @@ int metal_cpu_get_num_harts(void);
  * @param cpu The CPU device handle
  * @return The value of the CPU cycle count timer
  */
-inline unsigned long long metal_cpu_get_timer(struct metal_cpu *cpu)
+__inline__ unsigned long long metal_cpu_get_timer(struct metal_cpu *cpu)
 { return cpu->vtable->mcycle_get(cpu); }
 
 /*! @brief Get the timebase of the CPU
@@ -78,7 +78,7 @@ inline unsigned long long metal_cpu_get_timer(struct metal_cpu *cpu)
  * @param cpu The CPU device handle
  * @return The value of the cycle count timer timebase
  */
-inline unsigned long long metal_cpu_get_timebase(struct metal_cpu *cpu)
+__inline__ unsigned long long metal_cpu_get_timebase(struct metal_cpu *cpu)
 { return cpu->vtable->timebase_get(cpu); }
 
 /*! @brief Get the value of the mtime RTC
@@ -90,7 +90,7 @@ inline unsigned long long metal_cpu_get_timebase(struct metal_cpu *cpu)
  * @param cpu The CPU device handle
  * @return The value of mtime, or 0 if failure
  */
-inline unsigned long long metal_cpu_get_mtime(struct metal_cpu *cpu)
+__inline__ unsigned long long metal_cpu_get_mtime(struct metal_cpu *cpu)
 { return cpu->vtable->mtime_get(cpu); }
 
 /*! @brief Set the value of the RTC mtimecmp RTC
@@ -103,7 +103,7 @@ inline unsigned long long metal_cpu_get_mtime(struct metal_cpu *cpu)
  * @param time The value to set the compare register to
  * @return The value of mtimecmp or -1 if error
  */
-inline int metal_cpu_set_mtimecmp(struct metal_cpu *cpu, unsigned long long time)
+__inline__ int metal_cpu_set_mtimecmp(struct metal_cpu *cpu, unsigned long long time)
 { return cpu->vtable->mtimecmp_set(cpu, time); }
 
 /*! @brief Get a reference to RTC timer interrupt controller
@@ -115,7 +115,7 @@ inline int metal_cpu_set_mtimecmp(struct metal_cpu *cpu, unsigned long long time
  * @param cpu The CPU device handle
  * @return A pointer to the timer interrupt handle
  */
-inline struct metal_interrupt* metal_cpu_timer_interrupt_controller(struct metal_cpu *cpu)
+__inline__ struct metal_interrupt* metal_cpu_timer_interrupt_controller(struct metal_cpu *cpu)
 { return cpu->vtable->tmr_controller_interrupt(cpu); }
 
 /*! @brief Get the RTC timer interrupt id
@@ -125,7 +125,7 @@ inline struct metal_interrupt* metal_cpu_timer_interrupt_controller(struct metal
  * @param cpu The CPU device handle
  * @return The timer interrupt ID
  */
-inline int metal_cpu_timer_get_interrupt_id(struct metal_cpu *cpu)
+__inline__ int metal_cpu_timer_get_interrupt_id(struct metal_cpu *cpu)
 { return cpu->vtable->get_tmr_interrupt_id(cpu); }
 
 /*! @brief Get a reference to the software interrupt controller
@@ -137,7 +137,7 @@ inline int metal_cpu_timer_get_interrupt_id(struct metal_cpu *cpu)
  * @param cpu The CPU device handle
  * @return A pointer to the software interrupt handle
  */
-inline struct metal_interrupt* metal_cpu_software_interrupt_controller(struct metal_cpu *cpu)
+__inline__ struct metal_interrupt* metal_cpu_software_interrupt_controller(struct metal_cpu *cpu)
 { return cpu->vtable->sw_controller_interrupt(cpu); }
 
 /*! @brief Get the software interrupt id
@@ -147,7 +147,7 @@ inline struct metal_interrupt* metal_cpu_software_interrupt_controller(struct me
  * @param cpu The CPU device handle
  * @return the software interrupt ID
  */
-inline int metal_cpu_software_get_interrupt_id(struct metal_cpu *cpu)
+__inline__ int metal_cpu_software_get_interrupt_id(struct metal_cpu *cpu)
 { return cpu->vtable->get_sw_interrupt_id(cpu); }
 
 /*!
@@ -161,7 +161,7 @@ inline int metal_cpu_software_get_interrupt_id(struct metal_cpu *cpu)
  * @param hartid The CPU hart ID to be interrupted
  * @return 0 upon success
  */
-inline int metal_cpu_software_set_ipi(struct metal_cpu *cpu, int hartid)
+__inline__ int metal_cpu_software_set_ipi(struct metal_cpu *cpu, int hartid)
 { return cpu->vtable->set_sw_ipi(cpu, hartid); }
 
 /*!
@@ -175,7 +175,7 @@ inline int metal_cpu_software_set_ipi(struct metal_cpu *cpu, int hartid)
  * @param hartid The CPU hart ID to clear
  * @return 0 upon success
  */
-inline int metal_cpu_software_clear_ipi(struct metal_cpu *cpu, int hartid)
+__inline__ int metal_cpu_software_clear_ipi(struct metal_cpu *cpu, int hartid)
 { return cpu->vtable->clear_sw_ipi(cpu, hartid); }
 
 /*!
@@ -190,7 +190,7 @@ inline int metal_cpu_software_clear_ipi(struct metal_cpu *cpu, int hartid)
  * @param hartid The CPU hart to read
  * @return 0 upon success
  */
-inline int metal_cpu_get_msip(struct metal_cpu *cpu, int hartid)
+__inline__ int metal_cpu_get_msip(struct metal_cpu *cpu, int hartid)
 { return cpu->vtable->get_msip(cpu, hartid); }
 
 /*!
@@ -204,7 +204,7 @@ inline int metal_cpu_get_msip(struct metal_cpu *cpu, int hartid)
  * @param cpu The CPU device handle
  * @return The handle for the CPU interrupt controller
  */
-inline struct metal_interrupt* metal_cpu_interrupt_controller(struct metal_cpu *cpu)
+__inline__ struct metal_interrupt* metal_cpu_interrupt_controller(struct metal_cpu *cpu)
 { return cpu->vtable->controller_interrupt(cpu); }
 
 /*!
@@ -218,7 +218,7 @@ inline struct metal_interrupt* metal_cpu_interrupt_controller(struct metal_cpu *
  * @param handler Callback function for the exception handler
  * @return 0 upon success
  */
-inline int metal_cpu_exception_register(struct metal_cpu *cpu, int ecode, metal_exception_handler_t handler)
+__inline__ int metal_cpu_exception_register(struct metal_cpu *cpu, int ecode, metal_exception_handler_t handler)
 { return cpu->vtable->exception_register(cpu, ecode, handler); }
 
 /*!
@@ -237,7 +237,7 @@ inline int metal_cpu_exception_register(struct metal_cpu *cpu, int ecode, metal_
  * @param epc The address of the instruction to measure
  * @return the length of the instruction in bytes
  */
-inline int metal_cpu_get_instruction_length(struct metal_cpu *cpu, uintptr_t epc)
+__inline__ int metal_cpu_get_instruction_length(struct metal_cpu *cpu, uintptr_t epc)
 { return cpu->vtable->get_ilen(cpu, epc); }
 
 /*!
@@ -249,7 +249,7 @@ inline int metal_cpu_get_instruction_length(struct metal_cpu *cpu, uintptr_t epc
  * @param cpu The CPU device handle
  * @return The value of the program counter at the time of the exception
  */
-inline uintptr_t metal_cpu_get_exception_pc(struct metal_cpu *cpu)
+__inline__ uintptr_t metal_cpu_get_exception_pc(struct metal_cpu *cpu)
 { return cpu->vtable->get_epc(cpu); }
 
 /*!
@@ -265,7 +265,7 @@ inline uintptr_t metal_cpu_get_exception_pc(struct metal_cpu *cpu)
  * @param epc The address to set the exception program counter to
  * @return 0 upon success
  */
-inline int metal_cpu_set_exception_pc(struct metal_cpu *cpu, uintptr_t epc)
+__inline__ int metal_cpu_set_exception_pc(struct metal_cpu *cpu, uintptr_t epc)
 { return cpu->vtable->set_epc(cpu, epc); }
 
 #endif

--- a/metal/drivers/riscv_cpu.h
+++ b/metal/drivers/riscv_cpu.h
@@ -171,7 +171,7 @@ struct __metal_driver_vtable_riscv_cpu_intc {
 void __metal_interrupt_global_enable(void);
 void __metal_interrupt_global_disable(void);
 void __metal_controller_interrupt_vector(metal_vector_mode mode, void *vec_table);
-inline int __metal_controller_interrupt_is_selective_vectored (void)
+__inline__ int __metal_controller_interrupt_is_selective_vectored (void)
 {
     uintptr_t val;
 

--- a/metal/drivers/riscv_cpu.h
+++ b/metal/drivers/riscv_cpu.h
@@ -175,7 +175,7 @@ inline int __metal_controller_interrupt_is_selective_vectored (void)
 {
     uintptr_t val;
 
-    asm volatile ("csrr %0, mtvec" : "=r"(val));
+    __asm__ volatile ("csrr %0, mtvec" : "=r"(val));
     return ((val & METAL_MTVEC_CLIC_VECTORED) == METAL_MTVEC_CLIC);
 }
 

--- a/metal/drivers/sifive_fe310-g000_prci.h
+++ b/metal/drivers/sifive_fe310-g000_prci.h
@@ -17,6 +17,7 @@ struct __metal_driver_vtable_sifive_fe310_g000_prci {
 __METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_fe310_g000_prci)
 
 struct __metal_driver_sifive_fe310_g000_prci {
+    const struct __metal_driver_vtable_sifive_fe310_g000_prci *vtable;
 };
 
 #endif

--- a/metal/gpio.h
+++ b/metal/gpio.h
@@ -54,7 +54,7 @@ struct metal_gpio {
  * @param device_num The GPIO device index
  * @return The GPIO device handle, or NULL if there is no device at that index
  */
-struct metal_gpio *metal_gpio_get_device(int device_num);
+struct metal_gpio *metal_gpio_get_device(unsigned int device_num);
 
 /*!
  * @brief enable input on a pin

--- a/metal/gpio.h
+++ b/metal/gpio.h
@@ -29,7 +29,7 @@ struct __metal_gpio_vtable {
     int (*config_int)(struct metal_gpio *, long pins, int intr_type);
     int (*clear_int)(struct metal_gpio *, long pins, int intr_type);
     struct metal_interrupt* (*interrupt_controller)(struct metal_gpio *gpio);
-    int (*get_interrupt_id)(struct metal_gpio *gpio, long pins);
+    int (*get_interrupt_id)(struct metal_gpio *gpio, int pin);
 };
 
 #define METAL_GPIO_INT_DISABLE       0

--- a/metal/gpio.h
+++ b/metal/gpio.h
@@ -62,7 +62,7 @@ struct metal_gpio *metal_gpio_get_device(int device_num);
  * @param pin The pin number indexed from 0
  * @return 0 if the input is successfully enabled
  */
-inline int metal_gpio_enable_input(struct metal_gpio *gpio, int pin) {
+__inline__ int metal_gpio_enable_input(struct metal_gpio *gpio, int pin) {
     if(!gpio) {
 	return 1;
     }
@@ -76,7 +76,7 @@ inline int metal_gpio_enable_input(struct metal_gpio *gpio, int pin) {
  * @param pin The pin number indexed from 0
  * @return 0 if the input is successfully disabled
  */
-inline int metal_gpio_disable_input(struct metal_gpio *gpio, int pin) {
+__inline__ int metal_gpio_disable_input(struct metal_gpio *gpio, int pin) {
     if(!gpio) {
 	return 1;
     }
@@ -90,7 +90,7 @@ inline int metal_gpio_disable_input(struct metal_gpio *gpio, int pin) {
  * @param pin The pin number indexed from 0
  * @return 0 if the output is successfully enabled
  */
-inline int metal_gpio_enable_output(struct metal_gpio *gpio, int pin) {
+__inline__ int metal_gpio_enable_output(struct metal_gpio *gpio, int pin) {
     if(!gpio) {
 	return 1;
     }
@@ -104,7 +104,7 @@ inline int metal_gpio_enable_output(struct metal_gpio *gpio, int pin) {
  * @param pin The pin number indexed from 0
  * @return 0 if the output is successfully disabled
  */
-inline int metal_gpio_disable_output(struct metal_gpio *gpio, int pin) {
+__inline__ int metal_gpio_disable_output(struct metal_gpio *gpio, int pin) {
     if(!gpio) {
 	return 1;
     }
@@ -119,7 +119,7 @@ inline int metal_gpio_disable_output(struct metal_gpio *gpio, int pin) {
  * @param value The value to set the pin to
  * @return 0 if the output is successfully set
  */
-inline int metal_gpio_set_pin(struct metal_gpio *gpio, int pin, int value) {
+__inline__ int metal_gpio_set_pin(struct metal_gpio *gpio, int pin, int value) {
     if(!gpio) {
 	return 1;
     }
@@ -137,7 +137,7 @@ inline int metal_gpio_set_pin(struct metal_gpio *gpio, int pin, int value) {
  * @param pin The pin number indexed from 0
  * @return The value of the GPIO pin
  */
-inline int metal_gpio_get_input_pin(struct metal_gpio *gpio, int pin) {
+__inline__ int metal_gpio_get_input_pin(struct metal_gpio *gpio, int pin) {
     if(!gpio) {
 	return 0;
     }
@@ -157,7 +157,7 @@ inline int metal_gpio_get_input_pin(struct metal_gpio *gpio, int pin) {
  * @param pin The pin number indexed from 0
  * @return The value of the GPIO pin
  */
-inline int metal_gpio_get_output_pin(struct metal_gpio *gpio, int pin) {
+__inline__ int metal_gpio_get_output_pin(struct metal_gpio *gpio, int pin) {
     if(!gpio) {
 	return 0;
     }
@@ -177,7 +177,7 @@ inline int metal_gpio_get_output_pin(struct metal_gpio *gpio, int pin) {
  * @param pin The pin number indexed from 0
  * @return 0 if the pin is successfully cleared
  */
-inline int metal_gpio_clear_pin(struct metal_gpio *gpio, int pin) {
+__inline__ int metal_gpio_clear_pin(struct metal_gpio *gpio, int pin) {
     if(!gpio) {
 	return 1;
     }
@@ -191,7 +191,7 @@ inline int metal_gpio_clear_pin(struct metal_gpio *gpio, int pin) {
  * @param pin The pin number indexed from 0
  * @return 0 if the pin is successfully toggled
  */
-inline int metal_gpio_toggle_pin(struct metal_gpio *gpio, int pin) {
+__inline__ int metal_gpio_toggle_pin(struct metal_gpio *gpio, int pin) {
     if(!gpio) {
 	return 1;
     }
@@ -206,7 +206,7 @@ inline int metal_gpio_toggle_pin(struct metal_gpio *gpio, int pin) {
  * @param io_function The IO function to set
  * @return 0 if the pinmux is successfully set
  */
-inline int metal_gpio_enable_pinmux(struct metal_gpio *gpio, int pin, int io_function) {
+__inline__ int metal_gpio_enable_pinmux(struct metal_gpio *gpio, int pin, int io_function) {
     if(!gpio) {
 	return 1;
     }
@@ -220,7 +220,7 @@ inline int metal_gpio_enable_pinmux(struct metal_gpio *gpio, int pin, int io_fun
  * @param pin The bitmask for the pin to disable pinmux on
  * @return 0 if the pinmux is successfully set
  */
-inline int metal_gpio_disable_pinmux(struct metal_gpio *gpio, int pin) {
+__inline__ int metal_gpio_disable_pinmux(struct metal_gpio *gpio, int pin) {
     if(!gpio) {
 	return 1;
     }
@@ -235,7 +235,7 @@ inline int metal_gpio_disable_pinmux(struct metal_gpio *gpio, int pin) {
  * @param intr_type The interrupt type
  * @return 0 if the interrupt mode is setup properly
  */
-inline int metal_gpio_config_interrupt(struct metal_gpio *gpio, int pin, int intr_type) {
+__inline__ int metal_gpio_config_interrupt(struct metal_gpio *gpio, int pin, int intr_type) {
     if(!gpio) {
 	return 1;
     }
@@ -250,7 +250,7 @@ inline int metal_gpio_config_interrupt(struct metal_gpio *gpio, int pin, int int
  * @param intr_type The interrupt type to be clear
  * @return 0 if the interrupt is cleared
  */
-inline int metal_gpio_clear_interrupt(struct metal_gpio *gpio, int pin, int intr_type) {
+__inline__ int metal_gpio_clear_interrupt(struct metal_gpio *gpio, int pin, int intr_type) {
     if(!gpio) {
 	return 1;
     }
@@ -265,7 +265,7 @@ inline int metal_gpio_clear_interrupt(struct metal_gpio *gpio, int pin, int intr
  * @return A pointer to the interrupt controller responsible for handling
  * gpio interrupts.
  */
-inline struct metal_interrupt*
+__inline__ struct metal_interrupt*
     metal_gpio_interrupt_controller(struct metal_gpio *gpio) {
     return gpio->vtable->interrupt_controller(gpio);
 }
@@ -277,7 +277,7 @@ inline struct metal_interrupt*
  * @param pin The bitmask for the pin to get gpio interrupt id
  * @return The interrupt id corresponding to a gpio.
  */
-inline int metal_gpio_get_interrupt_id(struct metal_gpio *gpio, int pin) {
+__inline__ int metal_gpio_get_interrupt_id(struct metal_gpio *gpio, int pin) {
     return gpio->vtable->get_interrupt_id(gpio, pin);
 }
 

--- a/metal/interrupt.h
+++ b/metal/interrupt.h
@@ -56,7 +56,7 @@ struct metal_interrupt {
  *
  * @param controller The handle for the interrupt controller
  */
-inline void metal_interrupt_init(struct metal_interrupt *controller)
+__inline__ void metal_interrupt_init(struct metal_interrupt *controller)
 {
     return controller->vtable->interrupt_init(controller);
 }
@@ -70,7 +70,7 @@ inline void metal_interrupt_init(struct metal_interrupt *controller)
  * @param priv_data Private data for the interrupt handler
  * @return 0 upon success
  */
-inline int metal_interrupt_register_handler(struct metal_interrupt *controller,
+__inline__ int metal_interrupt_register_handler(struct metal_interrupt *controller,
                                           int id,
                                           metal_interrupt_handler_t handler,
                                           void *priv_data)
@@ -84,7 +84,7 @@ inline int metal_interrupt_register_handler(struct metal_interrupt *controller,
  * @param id The interrupt ID to enable
  * @return 0 upon success
  */
-inline int metal_interrupt_enable(struct metal_interrupt *controller, int id)
+__inline__ int metal_interrupt_enable(struct metal_interrupt *controller, int id)
 {
     return controller->vtable->interrupt_enable(controller, id);
 }
@@ -95,7 +95,7 @@ inline int metal_interrupt_enable(struct metal_interrupt *controller, int id)
  * @param id The interrupt ID to disable
  * @return 0 upon success
  */
-inline int metal_interrupt_disable(struct metal_interrupt *controller, int id)
+__inline__ int metal_interrupt_disable(struct metal_interrupt *controller, int id)
 {
     return controller->vtable->interrupt_disable(controller, id);
 }
@@ -107,7 +107,7 @@ inline int metal_interrupt_disable(struct metal_interrupt *controller, int id)
  * @param mode The interrupt mode type to enable
  * @return 0 upon success
  */
-inline int metal_interrupt_vector_enable(struct metal_interrupt *controller,
+__inline__ int metal_interrupt_vector_enable(struct metal_interrupt *controller,
                                        int id, metal_vector_mode mode)
 {
     return controller->vtable->interrupt_vector_enable(controller, id, mode);
@@ -119,13 +119,13 @@ inline int metal_interrupt_vector_enable(struct metal_interrupt *controller,
  * @param id The interrupt ID to disable
  * @return 0 upon success
  */
-inline int metal_interrupt_vector_disable(struct metal_interrupt *controller, int id)
+__inline__ int metal_interrupt_vector_disable(struct metal_interrupt *controller, int id)
 {
     return controller->vtable->interrupt_vector_disable(controller, id);
 }
 
 /* Utilities function to controll, manages devices via a given interrupt controller */
-inline int _metal_interrupt_command_request(struct metal_interrupt *controller,
+__inline__ int _metal_interrupt_command_request(struct metal_interrupt *controller,
 					 int cmd, void *data)
 {
     return controller->vtable->command_request(controller, cmd, data);

--- a/metal/interrupt.h
+++ b/metal/interrupt.h
@@ -58,7 +58,7 @@ struct metal_interrupt {
  */
 __inline__ void metal_interrupt_init(struct metal_interrupt *controller)
 {
-    return controller->vtable->interrupt_init(controller);
+    controller->vtable->interrupt_init(controller);
 }
 
 

--- a/metal/io.h
+++ b/metal/io.h
@@ -5,7 +5,7 @@
 #define METAL__IO_H
 
 /* This macro enforces that the compiler will not elide the given access. */
-#define __METAL_ACCESS_ONCE(x) (*(typeof(*x) volatile *)(x))
+#define __METAL_ACCESS_ONCE(x) (*(__typeof__(*x) volatile *)(x))
 
 /* Allows users to specify arbitrary fences. */
 #define __METAL_IO_FENCE(pred, succ) __asm__ volatile ("fence " #pred "," #succ ::: "memory");

--- a/metal/led.h
+++ b/metal/led.h
@@ -45,24 +45,24 @@ struct metal_led* metal_led_get_rgb(char *label, char *color);
  * @brief Enable an LED
  * @param led The handle for the LED
  */
-inline void metal_led_enable(struct metal_led *led) { led->vtable->led_enable(led); }
+__inline__ void metal_led_enable(struct metal_led *led) { led->vtable->led_enable(led); }
 
 /*!
  * @brief Turn an LED on
  * @param led The handle for the LED
  */
-inline void metal_led_on(struct metal_led *led) { led->vtable->led_on(led); }
+__inline__ void metal_led_on(struct metal_led *led) { led->vtable->led_on(led); }
 
 /*!
  * @brief Turn an LED off
  * @param led The handle for the LED
  */
-inline void metal_led_off(struct metal_led *led) { led->vtable->led_off(led); }
+__inline__ void metal_led_off(struct metal_led *led) { led->vtable->led_off(led); }
 
 /*!
  * @brief Toggle the on/off state of an LED
  * @param led The handle for the LED
  */
-inline void metal_led_toggle(struct metal_led *led) { led->vtable->led_toggle(led); }
+__inline__ void metal_led_toggle(struct metal_led *led) { led->vtable->led_toggle(led); }
 
 #endif

--- a/metal/lock.h
+++ b/metal/lock.h
@@ -41,7 +41,7 @@ struct metal_lock {
  * If the lock cannot be initialized, attempts to take or give the lock
  * will result in a Store/AMO access fault.
  */
-inline int metal_lock_init(struct metal_lock *lock) {
+__inline__ int metal_lock_init(struct metal_lock *lock) {
 #ifdef __riscv_atomic
     /* Get a handle for the memory which holds the lock state */
     struct metal_memory *lock_mem = metal_get_memory_from_address((uintptr_t) &(lock->_state));
@@ -70,7 +70,7 @@ inline int metal_lock_init(struct metal_lock *lock) {
  * If the lock initialization failed, attempts to take a lock will result in
  * a Store/AMO access fault.
  */
-inline int metal_lock_take(struct metal_lock *lock) {
+__inline__ int metal_lock_take(struct metal_lock *lock) {
 #ifdef __riscv_atomic
     int old = 1;
     int new = 1;
@@ -104,7 +104,7 @@ inline int metal_lock_take(struct metal_lock *lock) {
  * If the lock initialization failed, attempts to give a lock will result in
  * a Store/AMO access fault.
  */
-inline int metal_lock_give(struct metal_lock *lock) {
+__inline__ int metal_lock_give(struct metal_lock *lock) {
 #ifdef __riscv_atomic
     __asm__ volatile("amoswap.w.rl x0, x0, (%[state])"
                      :: [state] "r" (&(lock->_state))

--- a/metal/memory.h
+++ b/metal/memory.h
@@ -14,11 +14,11 @@
  */
 
 struct _metal_memory_attributes {
-	int R : 1;
-	int W : 1;
-	int X : 1;
-	int C : 1;
-	int A : 1;
+	unsigned int R : 1;
+	unsigned int W : 1;
+	unsigned int X : 1;
+	unsigned int C : 1;
+	unsigned int A : 1;
 };
 
 /*!

--- a/metal/memory.h
+++ b/metal/memory.h
@@ -46,7 +46,7 @@ struct metal_memory *metal_get_memory_from_address(const uintptr_t address);
  * @param memory The handle for the memory block
  * @return The base address of the memory block
  */
-inline uintptr_t metal_memory_get_base_address(const struct metal_memory *memory) {
+__inline__ uintptr_t metal_memory_get_base_address(const struct metal_memory *memory) {
 	return memory->_base_address;
 }
 
@@ -55,7 +55,7 @@ inline uintptr_t metal_memory_get_base_address(const struct metal_memory *memory
  * @param memory The handle for the memory block
  * @return The size of the memory block
  */
-inline size_t metal_memory_get_size(const struct metal_memory *memory) {
+__inline__ size_t metal_memory_get_size(const struct metal_memory *memory) {
 	return memory->_size;
 }
 
@@ -64,7 +64,7 @@ inline size_t metal_memory_get_size(const struct metal_memory *memory) {
  * @param memory The handle for the memory block
  * @return nonzero if the memory block supports atomic operations
  */
-inline int metal_memory_supports_atomics(const struct metal_memory *memory) {
+__inline__ int metal_memory_supports_atomics(const struct metal_memory *memory) {
 	return memory->_attrs.A;
 }
 
@@ -73,7 +73,7 @@ inline int metal_memory_supports_atomics(const struct metal_memory *memory) {
  * @param memory The handle for the memory block
  * @return nonzero if the memory block is cachable
  */
-inline int metal_memory_is_cachable(const struct metal_memory *memory) {
+__inline__ int metal_memory_is_cachable(const struct metal_memory *memory) {
 	return memory->_attrs.C;
 }
 

--- a/metal/pmp.h
+++ b/metal/pmp.h
@@ -42,11 +42,11 @@ enum metal_pmp_address_mode {
  */
 struct metal_pmp_config {
     /*! @brief Sets whether reads to the PMP region succeed */
-    int R : 1;
+    unsigned int R : 1;
     /*! @brief Sets whether writes to the PMP region succeed */
-    int W : 1;
+    unsigned int W : 1;
     /*! @brief Sets whether the PMP region is executable */
-    int X : 1;
+    unsigned int X : 1;
 
     /*! @brief Sets the addressing mode of the PMP region */
     enum metal_pmp_address_mode A : 2;

--- a/metal/shutdown.h
+++ b/metal/shutdown.h
@@ -19,8 +19,8 @@ struct __metal_shutdown {
     const struct __metal_shutdown_vtable *vtable;
 };
 
-inline void __metal_shutdown_exit(const struct __metal_shutdown *sd, int code) __attribute__((noreturn));
-inline void __metal_shutdown_exit(const struct __metal_shutdown *sd, int code) { sd->vtable->exit(sd, code); }
+__inline__ void __metal_shutdown_exit(const struct __metal_shutdown *sd, int code) __attribute__((noreturn));
+__inline__ void __metal_shutdown_exit(const struct __metal_shutdown *sd, int code) { sd->vtable->exit(sd, code); }
 
 /*!
  * @brief The public METAL shutdown interface

--- a/metal/spi.h
+++ b/metal/spi.h
@@ -48,7 +48,7 @@ struct metal_spi *metal_spi_get_device(int device_num);
  * @param spi The handle for the SPI device to initialize
  * @param baud_rate The baud rate to set the SPI device to
  */
-inline void metal_spi_init(struct metal_spi *spi, int baud_rate) { spi->vtable->init(spi, baud_rate); }
+__inline__ void metal_spi_init(struct metal_spi *spi, int baud_rate) { spi->vtable->init(spi, baud_rate); }
 
 /*! @brief Perform a SPI transfer
  * @param spi The handle for the SPI device to perform the transfer
@@ -58,7 +58,7 @@ inline void metal_spi_init(struct metal_spi *spi, int baud_rate) { spi->vtable->
  * @param rx_buf The buffer to receive data into. Must be len bytes long. If NULL, the SPI will ignore received bytes.
  * @return 0 if the transfer succeeds
  */
-inline int metal_spi_transfer(struct metal_spi *spi, struct metal_spi_config *config, size_t len, char *tx_buf, char *rx_buf) {
+__inline__ int metal_spi_transfer(struct metal_spi *spi, struct metal_spi_config *config, size_t len, char *tx_buf, char *rx_buf) {
     return spi->vtable->transfer(spi, config, len, tx_buf, rx_buf);
 }
 
@@ -66,13 +66,13 @@ inline int metal_spi_transfer(struct metal_spi *spi, struct metal_spi_config *co
  * @param spi The handle for the SPI device
  * @return The baud rate in Hz
  */
-inline int metal_spi_get_baud_rate(struct metal_spi *spi) { return spi->vtable->get_baud_rate(spi); }
+__inline__ int metal_spi_get_baud_rate(struct metal_spi *spi) { return spi->vtable->get_baud_rate(spi); }
 
 /*! @brief Set the current baud rate of the SPI device
  * @param spi The handle for the SPI device
  * @param baud_rate The desired baud rate of the SPI device
  * @return 0 if the baud rate is successfully changed
  */
-inline int metal_spi_set_baud_rate(struct metal_spi *spi, int baud_rate) { return spi->vtable->set_baud_rate(spi, baud_rate); }
+__inline__ int metal_spi_set_baud_rate(struct metal_spi *spi, int baud_rate) { return spi->vtable->set_baud_rate(spi, baud_rate); }
 
 #endif

--- a/metal/spi.h
+++ b/metal/spi.h
@@ -42,7 +42,7 @@ struct metal_spi {
 /*! @brief Get a handle for a SPI device
  * @param device_num The index of the desired SPI device
  * @return A handle to the SPI device, or NULL if the device does not exist*/
-struct metal_spi *metal_spi_get_device(int device_num);
+struct metal_spi *metal_spi_get_device(unsigned int device_num);
 
 /*! @brief Initialize a SPI device with a certain baud rate
  * @param spi The handle for the SPI device to initialize

--- a/metal/switch.h
+++ b/metal/switch.h
@@ -38,7 +38,7 @@ struct metal_switch* metal_switch_get(char *label);
  * @param sw The handle for the switch
  * @return The interrupt controller handle
  */
-inline struct metal_interrupt*
+__inline__ struct metal_interrupt*
     metal_switch_interrupt_controller(struct metal_switch *sw) { return sw->vtable->interrupt_controller(sw); }
 
 /*!
@@ -46,6 +46,6 @@ inline struct metal_interrupt*
  * @param sw The handle for the switch
  * @return The interrupt ID for the switch
  */
-inline int metal_switch_get_interrupt_id(struct metal_switch *sw) { return sw->vtable->get_interrupt_id(sw); }
+__inline__ int metal_switch_get_interrupt_id(struct metal_switch *sw) { return sw->vtable->get_interrupt_id(sw); }
 
 #endif

--- a/metal/uart.h
+++ b/metal/uart.h
@@ -41,7 +41,7 @@ struct metal_uart {
  * @param uart The UART device handle
  * @param baud_rate the baud rate to set the UART to
  */
-inline void metal_uart_init(struct metal_uart *uart, int baud_rate) { return uart->vtable->init(uart, baud_rate); }
+__inline__ void metal_uart_init(struct metal_uart *uart, int baud_rate) { return uart->vtable->init(uart, baud_rate); }
 
 /*!
  * @brief Output a character over the UART
@@ -49,14 +49,14 @@ inline void metal_uart_init(struct metal_uart *uart, int baud_rate) { return uar
  * @param c The character to send over the UART
  * @return 0 upon success
  */
-inline int metal_uart_putc(struct metal_uart *uart, int c) { return uart->vtable->putc(uart, c); }
+__inline__ int metal_uart_putc(struct metal_uart *uart, int c) { return uart->vtable->putc(uart, c); }
 
 /*!
  * @brief Test, determine if tx output is blocked(full/busy)
  * @param uart The UART device handle
  * @return 0 not blocked
  */
-inline int metal_uart_txready(struct metal_uart *uart) { return uart->vtable->txready(uart); }
+__inline__ int metal_uart_txready(struct metal_uart *uart) { return uart->vtable->txready(uart); }
 
 /*!
  * @brief Read a character sent over the UART
@@ -67,14 +67,14 @@ inline int metal_uart_txready(struct metal_uart *uart) { return uart->vtable->tx
  * If "c == -1" no char was ready.
  * If "c != -1" then C == byte value (0x00 to 0xff)
  */
-inline int metal_uart_getc(struct metal_uart *uart, int *c) { return uart->vtable->getc(uart, c); }
+__inline__ int metal_uart_getc(struct metal_uart *uart, int *c) { return uart->vtable->getc(uart, c); }
 
 /*!
  * @brief Get the baud rate of the UART peripheral
  * @param uart The UART device handle
  * @return The current baud rate of the UART
  */
-inline int metal_uart_get_baud_rate(struct metal_uart *uart) { return uart->vtable->get_baud_rate(uart); }
+__inline__ int metal_uart_get_baud_rate(struct metal_uart *uart) { return uart->vtable->get_baud_rate(uart); }
 
 /*!
  * @brief Set the baud rate of the UART peripheral
@@ -82,7 +82,7 @@ inline int metal_uart_get_baud_rate(struct metal_uart *uart) { return uart->vtab
  * @param baud_rate The baud rate to configure
  * @return the new baud rate of the UART
  */
-inline int metal_uart_set_baud_rate(struct metal_uart *uart, int baud_rate) { return uart->vtable->set_baud_rate(uart, baud_rate); }
+__inline__ int metal_uart_set_baud_rate(struct metal_uart *uart, int baud_rate) { return uart->vtable->set_baud_rate(uart, baud_rate); }
 
 /*!
  * @brief Get the interrupt controller of the UART peripheral
@@ -94,13 +94,13 @@ inline int metal_uart_set_baud_rate(struct metal_uart *uart, int baud_rate) { re
  * @param uart The UART device handle
  * @return The handle for the UART interrupt controller
  */
-inline struct metal_interrupt* metal_uart_interrupt_controller(struct metal_uart *uart) { return uart->vtable->controller_interrupt(uart); }
+__inline__ struct metal_interrupt* metal_uart_interrupt_controller(struct metal_uart *uart) { return uart->vtable->controller_interrupt(uart); }
 
 /*!
  * @brief Get the interrupt ID of the UART controller
  * @param uart The UART device handle
  * @return The UART interrupt id
  */
-inline int metal_uart_get_interrupt_id(struct metal_uart *uart) { return uart->vtable->get_interrupt_id(uart); }
+__inline__ int metal_uart_get_interrupt_id(struct metal_uart *uart) { return uart->vtable->get_interrupt_id(uart); }
 
 #endif

--- a/metal/uart.h
+++ b/metal/uart.h
@@ -41,7 +41,7 @@ struct metal_uart {
  * @param uart The UART device handle
  * @param baud_rate the baud rate to set the UART to
  */
-__inline__ void metal_uart_init(struct metal_uart *uart, int baud_rate) { return uart->vtable->init(uart, baud_rate); }
+__inline__ void metal_uart_init(struct metal_uart *uart, int baud_rate) { uart->vtable->init(uart, baud_rate); }
 
 /*!
  * @brief Output a character over the UART

--- a/src/button.c
+++ b/src/button.c
@@ -22,6 +22,6 @@ struct metal_button* metal_button_get (char *label)
     return NULL;
 }
 
-extern inline struct metal_interrupt*
+extern __inline__ struct metal_interrupt*
     metal_button_interrupt_controller(struct metal_button *button);
-extern inline int metal_button_get_interrupt_id(struct metal_button *button);
+extern __inline__ int metal_button_get_interrupt_id(struct metal_button *button);

--- a/src/cache.c
+++ b/src/cache.c
@@ -4,9 +4,9 @@
 #include <metal/cache.h>
 #include <metal/machine.h>
 
-extern inline void metal_cache_init(struct metal_cache *cache, int ways);
-extern inline int metal_cache_get_enabled_ways(struct metal_cache *cache);
-extern inline int metal_cache_set_enabled_ways(struct metal_cache *cache, int ways);
+extern __inline__ void metal_cache_init(struct metal_cache *cache, int ways);
+extern __inline__ int metal_cache_get_enabled_ways(struct metal_cache *cache);
+extern __inline__ int metal_cache_set_enabled_ways(struct metal_cache *cache, int ways);
 
 int metal_dcache_l1_available(int hartid) {
     switch (hartid) {

--- a/src/clock.c
+++ b/src/clock.c
@@ -3,10 +3,10 @@
 
 #include <metal/clock.h>
 
-extern inline void _metal_clock_call_all_callbacks(const metal_clock_callback *const list);
-extern inline metal_clock_callback *_metal_clock_append_to_callbacks(metal_clock_callback *list, metal_clock_callback *const cb);
+extern __inline__ void _metal_clock_call_all_callbacks(const metal_clock_callback *const list);
+extern __inline__ metal_clock_callback *_metal_clock_append_to_callbacks(metal_clock_callback *list, metal_clock_callback *const cb);
 
-extern inline long metal_clock_get_rate_hz(const struct metal_clock *clk);
-extern inline long metal_clock_set_rate_hz(struct metal_clock *clk, long hz);
-extern inline void metal_clock_register_post_rate_change_callback(struct metal_clock *clk, metal_clock_callback *cb);
-extern inline void metal_clock_register_pre_rate_change_callback(struct metal_clock *clk, metal_clock_callback *cb);
+extern __inline__ long metal_clock_get_rate_hz(const struct metal_clock *clk);
+extern __inline__ long metal_clock_set_rate_hz(struct metal_clock *clk, long hz);
+extern __inline__ void metal_clock_register_post_rate_change_callback(struct metal_clock *clk, metal_clock_callback *cb);
+extern __inline__ void metal_clock_register_pre_rate_change_callback(struct metal_clock *clk, metal_clock_callback *cb);

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -16,7 +16,7 @@ int metal_cpu_get_current_hartid()
 {
 #ifdef __riscv
     int mhartid;
-    asm volatile("csrr %0, mhartid" : "=r" (mhartid));
+    __asm__ volatile("csrr %0, mhartid" : "=r" (mhartid));
     return mhartid;
 #endif
 }

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -4,7 +4,7 @@
 #include <metal/cpu.h>
 #include <metal/machine.h>
 
-struct metal_cpu* metal_cpu_get(int hartid)
+struct metal_cpu* metal_cpu_get(unsigned int hartid)
 {
     if (hartid < __METAL_DT_MAX_HARTS) {
         return (struct metal_cpu *)__metal_cpu_table[hartid];

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -26,34 +26,34 @@ int metal_cpu_get_num_harts()
     return __METAL_DT_MAX_HARTS;
 }
 
-extern inline unsigned long long metal_cpu_get_timer(struct metal_cpu *cpu);
+extern __inline__ unsigned long long metal_cpu_get_timer(struct metal_cpu *cpu);
 
-extern inline unsigned long long metal_cpu_get_timebase(struct metal_cpu *cpu);
+extern __inline__ unsigned long long metal_cpu_get_timebase(struct metal_cpu *cpu);
 
-extern inline unsigned long long metal_cpu_get_mtime(struct metal_cpu *cpu);
+extern __inline__ unsigned long long metal_cpu_get_mtime(struct metal_cpu *cpu);
 
-extern inline int metal_cpu_set_mtimecmp(struct metal_cpu *cpu, unsigned long long time);
+extern __inline__ int metal_cpu_set_mtimecmp(struct metal_cpu *cpu, unsigned long long time);
 
-extern inline struct metal_interrupt* metal_cpu_timer_interrupt_controller(struct metal_cpu *cpu);
+extern __inline__ struct metal_interrupt* metal_cpu_timer_interrupt_controller(struct metal_cpu *cpu);
 
-extern inline int metal_cpu_timer_get_interrupt_id(struct metal_cpu *cpu);
+extern __inline__ int metal_cpu_timer_get_interrupt_id(struct metal_cpu *cpu);
 
-extern inline struct metal_interrupt* metal_cpu_software_interrupt_controller(struct metal_cpu *cpu);
+extern __inline__ struct metal_interrupt* metal_cpu_software_interrupt_controller(struct metal_cpu *cpu);
 
-extern inline int metal_cpu_software_get_interrupt_id(struct metal_cpu *cpu);
+extern __inline__ int metal_cpu_software_get_interrupt_id(struct metal_cpu *cpu);
 
-extern inline int metal_cpu_software_set_ipi(struct metal_cpu *cpu, int hartid);
+extern __inline__ int metal_cpu_software_set_ipi(struct metal_cpu *cpu, int hartid);
 
-extern inline int metal_cpu_software_clear_ipi(struct metal_cpu *cpu, int hartid);
+extern __inline__ int metal_cpu_software_clear_ipi(struct metal_cpu *cpu, int hartid);
 
-extern inline int metal_cpu_get_msip(struct metal_cpu *cpu, int hartid);
+extern __inline__ int metal_cpu_get_msip(struct metal_cpu *cpu, int hartid);
 
-extern inline struct metal_interrupt* metal_cpu_interrupt_controller(struct metal_cpu *cpu);
+extern __inline__ struct metal_interrupt* metal_cpu_interrupt_controller(struct metal_cpu *cpu);
 
-extern inline int metal_cpu_exception_register(struct metal_cpu *cpu, int ecode, metal_exception_handler_t handler);
+extern __inline__ int metal_cpu_exception_register(struct metal_cpu *cpu, int ecode, metal_exception_handler_t handler);
 
-extern inline int metal_cpu_get_instruction_length(struct metal_cpu *cpu, uintptr_t epc);
+extern __inline__ int metal_cpu_get_instruction_length(struct metal_cpu *cpu, uintptr_t epc);
 
-extern inline uintptr_t metal_cpu_get_exception_pc(struct metal_cpu *cpu);
+extern __inline__ uintptr_t metal_cpu_get_exception_pc(struct metal_cpu *cpu);
 
-extern inline int metal_cpu_set_exception_pc(struct metal_cpu *cpu, uintptr_t epc);
+extern __inline__ int metal_cpu_set_exception_pc(struct metal_cpu *cpu, uintptr_t epc);

--- a/src/drivers/fixed-clock.c
+++ b/src/drivers/fixed-clock.c
@@ -25,3 +25,5 @@ __METAL_DEFINE_VTABLE(__metal_driver_vtable_fixed_clock) = {
 };
 
 #endif /* METAL_FIXED_CLOCK */
+
+typedef int no_empty_translation_units;

--- a/src/drivers/fixed-factor-clock.c
+++ b/src/drivers/fixed-factor-clock.c
@@ -30,3 +30,5 @@ __METAL_DEFINE_VTABLE(__metal_driver_vtable_fixed_factor_clock) = {
     .clock.set_rate_hz = __metal_driver_fixed_factor_clock_set_rate_hz,
 };
 #endif /* METAL_FIXED_FACTOR_CLOCK */
+
+typedef int no_empty_translation_units;   

--- a/src/drivers/riscv_clint0.c
+++ b/src/drivers/riscv_clint0.c
@@ -120,6 +120,8 @@ int __metal_driver_riscv_clint0_enable (struct metal_interrupt *controller, int 
             rc = intc->vtable->interrupt_enable(intc, id);
         }
     }
+
+    return rc;
 }
 
 int __metal_driver_riscv_clint0_disable (struct metal_interrupt *controller, int id)
@@ -145,6 +147,8 @@ int __metal_driver_riscv_clint0_disable (struct metal_interrupt *controller, int
             rc = intc->vtable->interrupt_disable(intc, id);
         }
     }
+
+    return rc;
 }
 
 int __metal_driver_riscv_clint0_command_request (struct metal_interrupt *controller,

--- a/src/drivers/riscv_clint0.c
+++ b/src/drivers/riscv_clint0.c
@@ -220,3 +220,5 @@ __METAL_DEFINE_VTABLE(__metal_driver_vtable_riscv_clint0) = {
 };
 
 #endif /* METAL_RISCV_CLINT0 */
+
+typedef int no_empty_translation_units;

--- a/src/drivers/riscv_cpu.c
+++ b/src/drivers/riscv_cpu.c
@@ -20,7 +20,7 @@ struct metal_cpu *__metal_driver_cpu_get(int hartid)
 uintptr_t __metal_myhart_id (void)
 {
     uintptr_t myhart;
-    asm volatile ("csrr %0, mhartid" : "=r"(myhart));
+    __asm__ volatile ("csrr %0, mhartid" : "=r"(myhart));
     return myhart;
 }
 
@@ -34,54 +34,54 @@ void __metal_zero_memory (unsigned char *base, unsigned int size)
 
 void __metal_interrupt_global_enable (void) {
     uintptr_t m;
-    asm volatile ("csrrs %0, mstatus, %1" : "=r"(m) : "r"(METAL_MIE_INTERRUPT));
+    __asm__ volatile ("csrrs %0, mstatus, %1" : "=r"(m) : "r"(METAL_MIE_INTERRUPT));
 }
 
 void __metal_interrupt_global_disable (void) {
     uintptr_t m;
-    asm volatile ("csrrc %0, mstatus, %1" : "=r"(m) : "r"(METAL_MIE_INTERRUPT));
+    __asm__ volatile ("csrrc %0, mstatus, %1" : "=r"(m) : "r"(METAL_MIE_INTERRUPT));
 }
 
 void __metal_interrupt_software_enable (void) {
     uintptr_t m;
-    asm volatile ("csrrs %0, mie, %1" : "=r"(m) : "r"(METAL_LOCAL_INTERRUPT_SW));
+    __asm__ volatile ("csrrs %0, mie, %1" : "=r"(m) : "r"(METAL_LOCAL_INTERRUPT_SW));
 }
 
 void __metal_interrupt_software_disable (void) {
     uintptr_t m;
-    asm volatile ("csrrc %0, mie, %1" : "=r"(m) : "r"(METAL_LOCAL_INTERRUPT_SW));
+    __asm__ volatile ("csrrc %0, mie, %1" : "=r"(m) : "r"(METAL_LOCAL_INTERRUPT_SW));
 }
 
 void __metal_interrupt_timer_enable (void) {
     uintptr_t m;
-    asm volatile ("csrrs %0, mie, %1" : "=r"(m) : "r"(METAL_LOCAL_INTERRUPT_TMR));
+    __asm__ volatile ("csrrs %0, mie, %1" : "=r"(m) : "r"(METAL_LOCAL_INTERRUPT_TMR));
 }
 
 void __metal_interrupt_timer_disable (void) {
     uintptr_t m;
-    asm volatile ("csrrc %0, mie, %1" : "=r"(m) : "r"(METAL_LOCAL_INTERRUPT_TMR));
+    __asm__ volatile ("csrrc %0, mie, %1" : "=r"(m) : "r"(METAL_LOCAL_INTERRUPT_TMR));
 }
 
 void __metal_interrupt_external_enable (void) {
     uintptr_t m;
-    asm volatile ("csrrs %0, mie, %1" : "=r"(m) : "r"(METAL_LOCAL_INTERRUPT_EXT));
+    __asm__ volatile ("csrrs %0, mie, %1" : "=r"(m) : "r"(METAL_LOCAL_INTERRUPT_EXT));
 }
 
 void __metal_interrupt_external_disable (void) {
     unsigned long m;
-    asm volatile ("csrrc %0, mie, %1" : "=r"(m) : "r"(METAL_LOCAL_INTERRUPT_EXT));
+    __asm__ volatile ("csrrc %0, mie, %1" : "=r"(m) : "r"(METAL_LOCAL_INTERRUPT_EXT));
 }
 
 void __metal_interrupt_local_enable (int id) {
     uintptr_t b = 1 << id;
     uintptr_t m;
-    asm volatile ("csrrs %0, mie, %1" : "=r"(m) : "r"(b));
+    __asm__ volatile ("csrrs %0, mie, %1" : "=r"(m) : "r"(b));
 }
 
 void __metal_interrupt_local_disable (int id) {
     uintptr_t b = 1 << id;
     uintptr_t m;
-    asm volatile ("csrrc %0, mie, %1" : "=r"(m) : "r"(b));
+    __asm__ volatile ("csrrc %0, mie, %1" : "=r"(m) : "r"(b));
 }
 
 void __metal_default_exception_handler (struct metal_cpu *cpu, int ecode) {
@@ -97,7 +97,7 @@ void __metal_default_sw_handler (int id, void *priv) {
     struct __metal_driver_riscv_cpu_intc *intc;
     struct __metal_driver_cpu *cpu = __metal_cpu_table[__metal_myhart_id()];
 
-    asm volatile ("csrr %0, mcause" : "=r"(mcause));
+    __asm__ volatile ("csrr %0, mcause" : "=r"(mcause));
     if ( cpu ) {
         intc = (struct __metal_driver_riscv_cpu_intc *)
 	  __metal_driver_cpu_interrupt_controller((struct metal_cpu *)cpu);
@@ -121,10 +121,10 @@ void __metal_exception_handler (void) {
     struct __metal_driver_riscv_cpu_intc *intc;
     struct __metal_driver_cpu *cpu = __metal_cpu_table[__metal_myhart_id()];
 
-    asm volatile ("csrr %0, mcause" : "=r"(mcause));
-    asm volatile ("csrr %0, mepc" : "=r"(mepc));
-    asm volatile ("csrr %0, mtval" : "=r"(mtval));
-    asm volatile ("csrr %0, mtvec" : "=r"(mtvec));
+    __asm__ volatile ("csrr %0, mcause" : "=r"(mcause));
+    __asm__ volatile ("csrr %0, mepc" : "=r"(mepc));
+    __asm__ volatile ("csrr %0, mtval" : "=r"(mtval));
+    __asm__ volatile ("csrr %0, mtvec" : "=r"(mtvec));
 
     if ( cpu ) {
         intc = (struct __metal_driver_riscv_cpu_intc *)
@@ -141,7 +141,7 @@ void __metal_exception_handler (void) {
     		uintptr_t mtvt;
     		metal_interrupt_handler_t mtvt_handler;
 
-                asm volatile ("csrr %0, mtvt" : "=r"(mtvt));
+                __asm__ volatile ("csrr %0, mtvt" : "=r"(mtvt));
                	priv = intc->metal_int_table[METAL_INTERRUPT_ID_SW].sub_int;
                	mtvt_handler = (metal_interrupt_handler_t)mtvt;
                	mtvt_handler(id, priv);
@@ -157,24 +157,24 @@ void __metal_controller_interrupt_vector (metal_vector_mode mode, void *vec_tabl
 {  
     uintptr_t trap_entry, val;
 
-    asm volatile ("csrr %0, mtvec" : "=r"(val));
+    __asm__ volatile ("csrr %0, mtvec" : "=r"(val));
     val &= ~(METAL_MTVEC_CLIC_VECTORED | METAL_MTVEC_CLIC_RESERVED);
     trap_entry = (uintptr_t)vec_table;
 
     switch (mode) {
     case METAL_SELECTIVE_VECTOR_MODE:
-        asm volatile ("csrw mtvt, %0" :: "r"(trap_entry | METAL_MTVEC_CLIC));
-        asm volatile ("csrw mtvec, %0" :: "r"(val | METAL_MTVEC_CLIC));
+        __asm__ volatile ("csrw mtvt, %0" :: "r"(trap_entry | METAL_MTVEC_CLIC));
+        __asm__ volatile ("csrw mtvec, %0" :: "r"(val | METAL_MTVEC_CLIC));
         break;
     case METAL_HARDWARE_VECTOR_MODE:
-        asm volatile ("csrw mtvt, %0" :: "r"(trap_entry | METAL_MTVEC_CLIC_VECTORED));
-        asm volatile ("csrw mtvec, %0" :: "r"(val | METAL_MTVEC_CLIC_VECTORED));
+        __asm__ volatile ("csrw mtvt, %0" :: "r"(trap_entry | METAL_MTVEC_CLIC_VECTORED));
+        __asm__ volatile ("csrw mtvec, %0" :: "r"(val | METAL_MTVEC_CLIC_VECTORED));
         break;
     case METAL_VECTOR_MODE:
-        asm volatile ("csrw mtvec, %0" :: "r"(trap_entry | METAL_MTVEC_VECTORED));
+        __asm__ volatile ("csrw mtvec, %0" :: "r"(trap_entry | METAL_MTVEC_VECTORED));
         break;
     case METAL_DIRECT_MODE:
-        asm volatile ("csrw mtvec, %0" :: "r"(trap_entry & ~METAL_MTVEC_CLIC_VECTORED));
+        __asm__ volatile ("csrw mtvec, %0" :: "r"(trap_entry & ~METAL_MTVEC_CLIC_VECTORED));
         break;
     }
 }
@@ -295,25 +295,25 @@ void __metal_driver_riscv_cpu_controller_interrupt_init (struct metal_interrupt 
 
     if ( !intc->init_done ) {
         /* Disable and clear all interrupt sources */
-        asm volatile ("csrc mie, %0" :: "r"(-1));
-        asm volatile ("csrc mip, %0" :: "r"(-1));
+        __asm__ volatile ("csrc mie, %0" :: "r"(-1));
+        __asm__ volatile ("csrc mip, %0" :: "r"(-1));
 
         /* Read the misa CSR to determine if the delegation registers exist */
         uintptr_t misa;
-        asm volatile ("csrr %0, misa" : "=r" (misa));
+        __asm__ volatile ("csrr %0, misa" : "=r" (misa));
 
         /* The delegation CSRs exist if user mode interrupts (N extension) or
          * supervisor mode (S extension) are supported */
         if((misa & METAL_ISA_N_EXTENSIONS) || (misa & METAL_ISA_S_EXTENSIONS)) {
             /* Disable interrupt and exception delegation */
-            asm volatile ("csrc mideleg, %0" :: "r"(-1));
-            asm volatile ("csrc medeleg, %0" :: "r"(-1));
+            __asm__ volatile ("csrc mideleg, %0" :: "r"(-1));
+            __asm__ volatile ("csrc medeleg, %0" :: "r"(-1));
         }
 
         /* The satp CSR exists if supervisor mode (S extension) is supported */
         if(misa & METAL_ISA_S_EXTENSIONS) {
             /* Clear the entire CSR to make sure that satp.MODE = 0 */
-            asm volatile ("csrc satp, %0" :: "r"(-1));
+            __asm__ volatile ("csrc satp, %0" :: "r"(-1));
         }
 
         /* Default to use direct interrupt, setup sw cb table*/
@@ -326,11 +326,11 @@ void __metal_driver_riscv_cpu_controller_interrupt_init (struct metal_interrupt 
 	    intc->metal_exception_table[i] = __metal_default_exception_handler;
 	}
         __metal_controller_interrupt_vector(METAL_DIRECT_MODE, &__metal_exception_handler);
-	asm volatile ("csrr %0, misa" : "=r"(val));
+	__asm__ volatile ("csrr %0, misa" : "=r"(val));
 	if (val & (METAL_ISA_D_EXTENSIONS | METAL_ISA_F_EXTENSIONS | METAL_ISA_Q_EXTENSIONS)) {
 	    /* Floating point architecture, so turn on FP register saving*/
-	    asm volatile ("csrr %0, mstatus" : "=r"(val));
-	    asm volatile ("csrw mstatus, %0" :: "r"(val | METAL_MSTATUS_FS_INIT));
+	    __asm__ volatile ("csrr %0, mstatus" : "=r"(val));
+	    __asm__ volatile ("csrw mstatus, %0" :: "r"(val | METAL_MSTATUS_FS_INIT));
 	}
 	intc->init_done = 1;
     }
@@ -447,14 +447,14 @@ unsigned long long __metal_driver_cpu_mcycle_get(struct metal_cpu *cpu)
 #if __riscv_xlen == 32
     unsigned long hi, hi1, lo;
 
-    asm volatile ("csrr %0, mcycleh" : "=r"(hi));
-    asm volatile ("csrr %0, mcycle" : "=r"(lo));
-    asm volatile ("csrr %0, mcycleh" : "=r"(hi1));
+    __asm__ volatile ("csrr %0, mcycleh" : "=r"(hi));
+    __asm__ volatile ("csrr %0, mcycle" : "=r"(lo));
+    __asm__ volatile ("csrr %0, mcycleh" : "=r"(hi1));
     if (hi == hi1) {
         val = ((unsigned long long)hi << 32) | lo;
     }
 #else
-    asm volatile ("csrr %0, mcycle" : "=r"(val));
+    __asm__ volatile ("csrr %0, mcycle" : "=r"(val));
 #endif
 
     return val;
@@ -649,13 +649,13 @@ int  __metal_driver_cpu_get_instruction_length(struct metal_cpu *cpu, uintptr_t 
 uintptr_t  __metal_driver_cpu_get_exception_pc(struct metal_cpu *cpu)
 {
     uintptr_t mepc;
-    asm volatile ("csrr %0, mepc" : "=r"(mepc));
+    __asm__ volatile ("csrr %0, mepc" : "=r"(mepc));
     return mepc;
 }
 
 int  __metal_driver_cpu_set_exception_pc(struct metal_cpu *cpu, uintptr_t mepc)
 {
-    asm volatile ("csrw mepc, %0" :: "r"(mepc));
+    __asm__ volatile ("csrw mepc, %0" :: "r"(mepc));
     return 0;
 }
 

--- a/src/drivers/riscv_cpu.c
+++ b/src/drivers/riscv_cpu.c
@@ -436,7 +436,7 @@ int __metal_driver_riscv_cpu_controller_command_request (struct metal_interrupt 
     return 0;
 }
 
-extern inline int __metal_controller_interrupt_is_selective_vectored(void);
+extern __inline__ int __metal_controller_interrupt_is_selective_vectored(void);
 
 /* CPU driver !!! */
 

--- a/src/drivers/riscv_cpu.c
+++ b/src/drivers/riscv_cpu.c
@@ -420,8 +420,6 @@ int __metal_driver_riscv_cpu_controller_interrupt_enable_vector(struct metal_int
 int __metal_driver_riscv_cpu_controller_interrupt_disable_vector(struct metal_interrupt *controller,
                                                               int id)
 {
-    struct __metal_driver_riscv_cpu_intc *intc = (void *)(controller);
-
     if (id == METAL_INTERRUPT_ID_BASE) {
         __metal_controller_interrupt_vector(METAL_DIRECT_MODE, &__metal_exception_handler);
         return 0;
@@ -477,7 +475,6 @@ unsigned long long  __metal_driver_cpu_mtime_get (struct metal_cpu *cpu)
     struct metal_interrupt *tmr_intc;
     struct __metal_driver_riscv_cpu_intc *intc =
         (struct __metal_driver_riscv_cpu_intc *)__metal_driver_cpu_interrupt_controller(cpu);
-    struct __metal_driver_cpu *_cpu = (void *)cpu;
 
     if (intc) {
         tmr_intc = intc->metal_int_table[METAL_INTERRUPT_ID_TMR].sub_int;
@@ -495,7 +492,6 @@ int __metal_driver_cpu_mtimecmp_set (struct metal_cpu *cpu, unsigned long long t
     struct metal_interrupt *tmr_intc;
     struct __metal_driver_riscv_cpu_intc *intc =
         (struct __metal_driver_riscv_cpu_intc *)__metal_driver_cpu_interrupt_controller(cpu);
-    struct __metal_driver_cpu *_cpu = (void *)cpu;
 
     if (intc) {
         tmr_intc = intc->metal_int_table[METAL_INTERRUPT_ID_TMR].sub_int;
@@ -554,7 +550,6 @@ int __metal_driver_cpu_set_sw_ipi (struct metal_cpu *cpu, int hartid)
     struct metal_interrupt *sw_intc;
     struct __metal_driver_riscv_cpu_intc *intc = 
         (struct __metal_driver_riscv_cpu_intc *)__metal_driver_cpu_interrupt_controller(cpu);
-    struct __metal_driver_cpu *_cpu = (void *)cpu;
 
     if (intc) {
         sw_intc = intc->metal_int_table[METAL_INTERRUPT_ID_SW].sub_int;
@@ -572,7 +567,6 @@ int __metal_driver_cpu_clear_sw_ipi (struct metal_cpu *cpu, int hartid)
     struct metal_interrupt *sw_intc;
     struct __metal_driver_riscv_cpu_intc *intc =
         (struct __metal_driver_riscv_cpu_intc *)__metal_driver_cpu_interrupt_controller(cpu);
-    struct __metal_driver_cpu *_cpu = (void *)cpu;
 
     if (intc) {
         sw_intc = intc->metal_int_table[METAL_INTERRUPT_ID_SW].sub_int;
@@ -590,7 +584,6 @@ int __metal_driver_cpu_get_msip (struct metal_cpu *cpu, int hartid)
     struct metal_interrupt *sw_intc;
     struct __metal_driver_riscv_cpu_intc *intc =
         (struct __metal_driver_riscv_cpu_intc *)__metal_driver_cpu_interrupt_controller(cpu);
-    struct __metal_driver_cpu *_cpu = (void *)cpu;
 
     if (intc) {
         sw_intc = intc->metal_int_table[METAL_INTERRUPT_ID_SW].sub_int;

--- a/src/drivers/riscv_cpu.c
+++ b/src/drivers/riscv_cpu.c
@@ -513,7 +513,7 @@ __metal_driver_cpu_timer_controller_interrupt(struct metal_cpu *cpu)
 #ifdef __METAL_DT_SIFIVE_CLIC0_HANDLE
     return __METAL_DT_SIFIVE_CLIC0_HANDLE;
 #else
-#warning "There is no interrupt controller for Timer interrupt"
+#pragma message("There is no interrupt controller for Timer interrupt")
     return NULL;
 #endif
 #endif
@@ -533,7 +533,7 @@ __metal_driver_cpu_sw_controller_interrupt(struct metal_cpu *cpu)
 #ifdef __METAL_DT_SIFIVE_CLIC0_HANDLE
     return __METAL_DT_SIFIVE_CLIC0_HANDLE;
 #else
-#warning "There is no interrupt controller for Software interrupt"
+#pragma message("There is no interrupt controller for Software interrupt")
     return NULL;
 #endif
 #endif

--- a/src/drivers/riscv_cpu.c
+++ b/src/drivers/riscv_cpu.c
@@ -325,7 +325,7 @@ void __metal_driver_riscv_cpu_controller_interrupt_init (struct metal_interrupt 
 	for (int i = 0; i < METAL_MAX_ME; i++) {
 	    intc->metal_exception_table[i] = __metal_default_exception_handler;
 	}
-        __metal_controller_interrupt_vector(METAL_DIRECT_MODE, &__metal_exception_handler);
+        __metal_controller_interrupt_vector(METAL_DIRECT_MODE, (void *)(uintptr_t)&__metal_exception_handler);
 	__asm__ volatile ("csrr %0, misa" : "=r"(val));
 	if (val & (METAL_ISA_D_EXTENSIONS | METAL_ISA_F_EXTENSIONS | METAL_ISA_Q_EXTENSIONS)) {
 	    /* Floating point architecture, so turn on FP register saving*/
@@ -406,11 +406,11 @@ int __metal_driver_riscv_cpu_controller_interrupt_enable_vector(struct metal_int
 
     if (id == METAL_INTERRUPT_ID_BASE) {
         if (mode == METAL_DIRECT_MODE) {
-            __metal_controller_interrupt_vector(mode, &__metal_exception_handler);
+            __metal_controller_interrupt_vector(mode, (void *)(uintptr_t)&__metal_exception_handler);
             return 0;
         }   
         if (mode == METAL_VECTOR_MODE) {
-            __metal_controller_interrupt_vector(mode, &intc->metal_mtvec_table);
+            __metal_controller_interrupt_vector(mode, (void *)&intc->metal_mtvec_table);
             return 0;
         }
     }
@@ -421,7 +421,7 @@ int __metal_driver_riscv_cpu_controller_interrupt_disable_vector(struct metal_in
                                                               int id)
 {
     if (id == METAL_INTERRUPT_ID_BASE) {
-        __metal_controller_interrupt_vector(METAL_DIRECT_MODE, &__metal_exception_handler);
+        __metal_controller_interrupt_vector(METAL_DIRECT_MODE, (void *)(uintptr_t)&__metal_exception_handler);
         return 0;
     }
     return -1;

--- a/src/drivers/riscv_cpu.c
+++ b/src/drivers/riscv_cpu.c
@@ -270,7 +270,7 @@ int __metal_local_interrupt_enable (struct metal_interrupt *controller,
             __metal_interrupt_local_disable(id);
         }
         break;
-    defaut:
+    default:
         rc = -1;
     }
     return rc;
@@ -380,7 +380,7 @@ int __metal_driver_riscv_cpu_controller_interrupt_register(struct metal_interrup
             intc->metal_int_table[id].handler = __metal_default_interrupt_handler;
             intc->metal_int_table[id].sub_int = priv;
 	  break;
-	defaut:
+	default:
 	  rc = -12;
 	}
     }

--- a/src/drivers/riscv_plic0.c
+++ b/src/drivers/riscv_plic0.c
@@ -169,3 +169,5 @@ __METAL_DEFINE_VTABLE(__metal_driver_vtable_riscv_plic0) = {
 };
 
 #endif /* METAL_RISCV_PLIC0 */
+
+typedef int no_empty_translation_units;

--- a/src/drivers/riscv_plic0.c
+++ b/src/drivers/riscv_plic0.c
@@ -37,7 +37,7 @@ void __metal_plic0_set_priority(struct __metal_driver_riscv_plic0 *plic,
 			      int id, unsigned int priority)
 {
     unsigned long control_base = __metal_driver_sifive_plic0_control_base((struct metal_interrupt *)plic);
-    int max_priority = __metal_driver_sifive_plic0_max_priority((struct metal_interrupt *)plic);
+    unsigned int max_priority = __metal_driver_sifive_plic0_max_priority((struct metal_interrupt *)plic);
     if ( (max_priority) && (priority < max_priority) ) {
         __METAL_ACCESS_ONCE((__metal_io_u32 *)(control_base +
 					   METAL_RISCV_PLIC0_PRIORITY_BASE +
@@ -68,7 +68,7 @@ void __metal_plic0_handler (int id, void *priv)
 {
     struct __metal_driver_riscv_plic0 *plic = priv;
     unsigned int idx = __metal_plic0_claim_interrupt(plic);
-    int num_interrupts = __metal_driver_sifive_plic0_num_interrupts((struct metal_interrupt *)plic);
+    unsigned int num_interrupts = __metal_driver_sifive_plic0_num_interrupts((struct metal_interrupt *)plic);
 
     if ( (idx < num_interrupts) && (plic->metal_exint_table[idx]) ) {
 	plic->metal_exint_table[idx](idx,

--- a/src/drivers/riscv_plic0.c
+++ b/src/drivers/riscv_plic0.c
@@ -48,7 +48,6 @@ void __metal_plic0_set_priority(struct __metal_driver_riscv_plic0 *plic,
 void __metal_plic0_enable(struct __metal_driver_riscv_plic0 *plic, int id, int enable)
 {
     unsigned int current;
-    unsigned long hartid = __metal_myhart_id();
     unsigned long control_base = __metal_driver_sifive_plic0_control_base((struct metal_interrupt *)plic);
 
     current = __METAL_ACCESS_ONCE((__metal_io_u32 *)(control_base +

--- a/src/drivers/sifive_clic0.c
+++ b/src/drivers/sifive_clic0.c
@@ -562,3 +562,5 @@ __METAL_DEFINE_VTABLE(__metal_driver_vtable_sifive_clic0) = {
 };
 
 #endif /* METAL_SIFIVE_CLIC0 */
+
+typedef int no_empty_translation_units;

--- a/src/drivers/sifive_clic0.c
+++ b/src/drivers/sifive_clic0.c
@@ -40,7 +40,6 @@ struct __metal_clic_cfg __metal_clic0_configuration (struct __metal_driver_sifiv
 {
     volatile unsigned char val;
     struct __metal_clic_cfg cliccfg;
-    uintptr_t hartid = __metal_myhart_id();
     unsigned long control_base = __metal_driver_sifive_clic0_control_base((struct metal_interrupt *)clic);
 
     if ( cfg ) {
@@ -369,7 +368,7 @@ void __metal_driver_sifive_clic0_init (struct metal_interrupt *controller)
         /* Initialize ist parent controller, aka cpu_intc. */
         intc->vtable->interrupt_init(intc);
         __metal_controller_interrupt_vector(METAL_SELECTIVE_VECTOR_MODE,
-                                          &__metal_clic0_handler);
+                                          (void *)(uintptr_t)&__metal_clic0_handler);
 
         /*
          * Register its interrupts with with parent controller,
@@ -458,7 +457,7 @@ int __metal_driver_sifive_clic0_enable_interrupt_vector(struct metal_interrupt *
 
     if (id == METAL_INTERRUPT_ID_BASE) {
         if (mode == METAL_SELECTIVE_VECTOR_MODE) {
-            __metal_controller_interrupt_vector(mode, &__metal_clic0_handler);
+            __metal_controller_interrupt_vector(mode, (void *)(uintptr_t)&__metal_clic0_handler);
             return 0;
         }
         if (mode == METAL_HARDWARE_VECTOR_MODE) {
@@ -485,7 +484,7 @@ int __metal_driver_sifive_clic0_disable_interrupt_vector(struct metal_interrupt 
                               (struct __metal_driver_sifive_clic0 *)(controller);
 
     if (id == METAL_INTERRUPT_ID_BASE) {
-        __metal_controller_interrupt_vector(METAL_SELECTIVE_VECTOR_MODE, &__metal_clic0_handler);
+        __metal_controller_interrupt_vector(METAL_SELECTIVE_VECTOR_MODE, (void *)(uintptr_t)&__metal_clic0_handler);
         return 0;
     }
     num_subinterrupts = __metal_driver_sifive_clic0_num_subinterrupts(controller);

--- a/src/drivers/sifive_fe310-g000_hfrosc.c
+++ b/src/drivers/sifive_fe310-g000_hfrosc.c
@@ -40,3 +40,5 @@ __METAL_DEFINE_VTABLE(__metal_driver_vtable_sifive_fe310_g000_hfrosc) = {
     .clock.set_rate_hz = &__metal_driver_sifive_fe310_g000_hfrosc_set_rate_hz,
 };
 #endif /* METAL_SIFIVE_FE310_G000_HFROSC */
+
+typedef int no_empty_translation_units;

--- a/src/drivers/sifive_fe310-g000_hfrosc.c
+++ b/src/drivers/sifive_fe310-g000_hfrosc.c
@@ -23,9 +23,9 @@ long __metal_driver_sifive_fe310_g000_hfrosc_get_rate_hz(const struct metal_cloc
       __metal_driver_sifive_fe310_g000_prci_vtable();
     long cfg = vtable->get_reg(config_base, config_offset);
 
-    if (cfg & CONFIG_ENABLE == 0)
+    if ((cfg & CONFIG_ENABLE) == 0)
         return -1;
-    if (cfg & CONFIG_READY == 0)
+    if ((cfg & CONFIG_READY) == 0)
         return -1;
     return metal_clock_get_rate_hz(ref) / ((cfg & CONFIG_DIVIDER) + 1);
 }

--- a/src/drivers/sifive_fe310-g000_hfxosc.c
+++ b/src/drivers/sifive_fe310-g000_hfxosc.c
@@ -39,3 +39,5 @@ __METAL_DEFINE_VTABLE(__metal_driver_vtable_sifive_fe310_g000_hfxosc) = {
 };
 
 #endif /* METAL_SIFIVE_FE310_G000_HFXOSC */
+
+typedef int no_empty_translation_units;

--- a/src/drivers/sifive_fe310-g000_hfxosc.c
+++ b/src/drivers/sifive_fe310-g000_hfxosc.c
@@ -21,9 +21,9 @@ long __metal_driver_sifive_fe310_g000_hfxosc_get_rate_hz(const struct metal_cloc
       __metal_driver_sifive_fe310_g000_prci_vtable();
     long cfg = vtable->get_reg(config_base, config_offset);
 
-    if (cfg & CONFIG_ENABLE == 0)
+    if ((cfg & CONFIG_ENABLE) == 0)
         return -1;
-    if (cfg & CONFIG_READY == 0)
+    if ((cfg & CONFIG_READY) == 0)
         return -1;
     return metal_clock_get_rate_hz(ref);
 }

--- a/src/drivers/sifive_fe310-g000_pll.c
+++ b/src/drivers/sifive_fe310-g000_pll.c
@@ -356,3 +356,5 @@ __METAL_DEFINE_VTABLE(__metal_driver_vtable_sifive_fe310_g000_pll) = {
 };
 
 #endif /* METAL_SIFIVE_FE310_G000_PLL */
+
+typedef int no_empty_translation_units;

--- a/src/drivers/sifive_fe310-g000_pll.c
+++ b/src/drivers/sifive_fe310-g000_pll.c
@@ -133,7 +133,7 @@ void __metal_driver_sifive_fe310_g000_pll_init(struct __metal_driver_sifive_fe31
  * Returns:
  *  - PLL_CONFIG_NOT_VALID if the configuration is not valid for the input frequency
  *  - the output frequency, in hertz */
-static long get_pll_config_freq(long pll_input_rate, const struct pll_config_t *config)
+static long get_pll_config_freq(unsigned long pll_input_rate, const struct pll_config_t *config)
 {
     if(pll_input_rate < config->min_input_rate || pll_input_rate > config->max_input_rate)
         return PLL_CONFIG_NOT_VALID;

--- a/src/drivers/sifive_fe310-g000_prci.c
+++ b/src/drivers/sifive_fe310-g000_prci.c
@@ -24,3 +24,5 @@ __METAL_DEFINE_VTABLE(__metal_driver_vtable_sifive_fe310_g000_prci) = {
 };
 
 #endif /* METAL_SIFIVE_FE310_G000_PRCI */
+
+typedef int no_empty_translation_units;

--- a/src/drivers/sifive_fu540-c000_l2.c
+++ b/src/drivers/sifive_fu540-c000_l2.c
@@ -79,3 +79,5 @@ __METAL_DEFINE_VTABLE(__metal_driver_vtable_sifive_fu540_c000_l2) = {
 };
 
 #endif
+
+typedef int no_empty_translation_units;

--- a/src/drivers/sifive_global-external-interrupts0.c
+++ b/src/drivers/sifive_global-external-interrupts0.c
@@ -118,3 +118,4 @@ __METAL_DEFINE_VTABLE(__metal_driver_vtable_sifive_global_external_interrupts0) 
 
 #endif
 
+typedef int no_empty_translation_units;

--- a/src/drivers/sifive_gpio-buttons.c
+++ b/src/drivers/sifive_gpio-buttons.c
@@ -53,3 +53,5 @@ __METAL_DEFINE_VTABLE(__metal_driver_vtable_sifive_button) = {
 };
 
 #endif
+
+typedef int no_empty_translation_units;

--- a/src/drivers/sifive_gpio-leds.c
+++ b/src/drivers/sifive_gpio-leds.c
@@ -81,3 +81,5 @@ __METAL_DEFINE_VTABLE(__metal_driver_vtable_sifive_led) = {
 };
 
 #endif
+
+typedef int no_empty_translation_units;

--- a/src/drivers/sifive_gpio-switches.c
+++ b/src/drivers/sifive_gpio-switches.c
@@ -52,3 +52,5 @@ __METAL_DEFINE_VTABLE(__metal_driver_vtable_sifive_switch) = {
 };
 
 #endif
+
+typedef int no_empty_translation_units;

--- a/src/drivers/sifive_gpio0.c
+++ b/src/drivers/sifive_gpio0.c
@@ -217,3 +217,5 @@ __METAL_DEFINE_VTABLE(__metal_driver_vtable_sifive_gpio0) = {
 };
 
 #endif /* METAL_SIFIVE_GPIO0 */
+
+typedef int no_empty_translation_units;

--- a/src/drivers/sifive_local-external-interrupts0.c
+++ b/src/drivers/sifive_local-external-interrupts0.c
@@ -115,3 +115,6 @@ __METAL_DEFINE_VTABLE(__metal_driver_vtable_sifive_local_external_interrupts0) =
 };
 
 #endif
+
+typedef int no_empty_translation_units;
+

--- a/src/drivers/sifive_spi0.c
+++ b/src/drivers/sifive_spi0.c
@@ -281,3 +281,5 @@ __METAL_DEFINE_VTABLE(__metal_driver_vtable_sifive_spi0) = {
     .spi.set_baud_rate = __metal_driver_sifive_spi0_set_baud_rate,
 };
 #endif /* METAL_SIFIVE_SPI0 */
+
+typedef int no_empty_translation_units;

--- a/src/drivers/sifive_spi0.c
+++ b/src/drivers/sifive_spi0.c
@@ -145,7 +145,7 @@ int __metal_driver_sifive_spi0_transfer(struct metal_spi *gspi,
     /* Declare time_t variables to break out of infinite while loop */
     time_t endwait;
 
-    for(int i = 0; i < len; i++) {
+    for(size_t i = 0; i < len; i++) {
         /* Master send bytes to the slave */
 
         /* Wait for TXFIFO to not be full */

--- a/src/drivers/sifive_test0.c
+++ b/src/drivers/sifive_test0.c
@@ -26,3 +26,5 @@ __METAL_DEFINE_VTABLE(__metal_driver_vtable_sifive_test0) = {
     .shutdown.exit       = &__metal_driver_sifive_test0_exit,
 };
 #endif /* METAL_SIFIVE_TEST0 */
+
+typedef int no_empty_translation_units;

--- a/src/drivers/sifive_uart0.c
+++ b/src/drivers/sifive_uart0.c
@@ -120,7 +120,7 @@ static void pre_rate_change_callback_func(void *priv)
     long cycles_to_wait = bits_per_symbol * clk_freq / uart->baud_rate;
 
     for(volatile long x = 0; x < cycles_to_wait; x++)
-        asm("nop");
+        __asm__("nop");
 }
 
 static void post_rate_change_callback_func(void *priv)

--- a/src/drivers/sifive_uart0.c
+++ b/src/drivers/sifive_uart0.c
@@ -169,3 +169,5 @@ __METAL_DEFINE_VTABLE(__metal_driver_vtable_sifive_uart0) = {
 };
 
 #endif /* METAL_SIFIVE_UART0 */
+
+typedef int no_empty_translation_units;

--- a/src/gpio.c
+++ b/src/gpio.c
@@ -20,7 +20,7 @@ extern __inline__ int metal_gpio_get_interrupt_id(struct metal_gpio *gpio, int p
 extern __inline__ int metal_gpio_config_interrupt(struct metal_gpio *gpio, int pin, int intr_type);
 extern __inline__ int metal_gpio_clear_interrupt(struct metal_gpio *gpio, int pin, int intr_type);
 
-struct metal_gpio *metal_gpio_get_device(int device_num)
+struct metal_gpio *metal_gpio_get_device(unsigned int device_num)
 {
     if(device_num > __MEE_DT_MAX_GPIOS) {
 	return NULL;

--- a/src/gpio.c
+++ b/src/gpio.c
@@ -4,21 +4,21 @@
 #include <metal/machine.h>
 #include <metal/gpio.h>
 
-extern inline int metal_gpio_disable_input(struct metal_gpio *gpio, int pin);
-extern inline int metal_gpio_enable_input(struct metal_gpio *gpio, int pin);
-extern inline int metal_gpio_enable_output(struct metal_gpio *gpio, int pin);
-extern inline int metal_gpio_disable_output(struct metal_gpio *gpio, int pin);
-extern inline int metal_gpio_get_output_pin(struct metal_gpio *gpio, int pin);
-extern inline int metal_gpio_get_input_pin(struct metal_gpio *gpio, int pin);
-extern inline int metal_gpio_set_pin(struct metal_gpio *, int pin, int value);
-extern inline int metal_gpio_clear_pin(struct metal_gpio *, int pin);
-extern inline int metal_gpio_toggle_pin(struct metal_gpio *, int pin);
-extern inline int metal_gpio_enable_pinmux(struct metal_gpio *, int pin, int io_function);
-extern inline int metal_gpio_disable_pinmux(struct metal_gpio *, int pin);
-extern inline struct metal_interrupt* metal_gpio_interrupt_controller(struct metal_gpio *gpio);
-extern inline int metal_gpio_get_interrupt_id(struct metal_gpio *gpio, int pin);
-extern inline int metal_gpio_config_interrupt(struct metal_gpio *gpio, int pin, int intr_type);
-extern inline int metal_gpio_clear_interrupt(struct metal_gpio *gpio, int pin, int intr_type);
+extern __inline__ int metal_gpio_disable_input(struct metal_gpio *gpio, int pin);
+extern __inline__ int metal_gpio_enable_input(struct metal_gpio *gpio, int pin);
+extern __inline__ int metal_gpio_enable_output(struct metal_gpio *gpio, int pin);
+extern __inline__ int metal_gpio_disable_output(struct metal_gpio *gpio, int pin);
+extern __inline__ int metal_gpio_get_output_pin(struct metal_gpio *gpio, int pin);
+extern __inline__ int metal_gpio_get_input_pin(struct metal_gpio *gpio, int pin);
+extern __inline__ int metal_gpio_set_pin(struct metal_gpio *, int pin, int value);
+extern __inline__ int metal_gpio_clear_pin(struct metal_gpio *, int pin);
+extern __inline__ int metal_gpio_toggle_pin(struct metal_gpio *, int pin);
+extern __inline__ int metal_gpio_enable_pinmux(struct metal_gpio *, int pin, int io_function);
+extern __inline__ int metal_gpio_disable_pinmux(struct metal_gpio *, int pin);
+extern __inline__ struct metal_interrupt* metal_gpio_interrupt_controller(struct metal_gpio *gpio);
+extern __inline__ int metal_gpio_get_interrupt_id(struct metal_gpio *gpio, int pin);
+extern __inline__ int metal_gpio_config_interrupt(struct metal_gpio *gpio, int pin, int intr_type);
+extern __inline__ int metal_gpio_clear_interrupt(struct metal_gpio *gpio, int pin, int intr_type);
 
 struct metal_gpio *metal_gpio_get_device(int device_num)
 {

--- a/src/interrupt.c
+++ b/src/interrupt.c
@@ -4,21 +4,21 @@
 #include <metal/interrupt.h>
 #include <metal/machine.h>
 
-extern inline void metal_interrupt_init(struct metal_interrupt *controller);
+extern __inline__ void metal_interrupt_init(struct metal_interrupt *controller);
 
-extern inline int metal_interrupt_register_handler(struct metal_interrupt *controller,
+extern __inline__ int metal_interrupt_register_handler(struct metal_interrupt *controller,
 						 int id,
 						 metal_interrupt_handler_t handler,
 						 void *priv);
 
-extern inline int metal_interrupt_enable(struct metal_interrupt *controller, int id);
+extern __inline__ int metal_interrupt_enable(struct metal_interrupt *controller, int id);
 
-extern inline int metal_interrupt_disable(struct metal_interrupt *controller, int id);
+extern __inline__ int metal_interrupt_disable(struct metal_interrupt *controller, int id);
 
-extern inline int metal_interrupt_vector_enable(struct metal_interrupt *controller,
+extern __inline__ int metal_interrupt_vector_enable(struct metal_interrupt *controller,
                                                      int id, metal_vector_mode mode);
 
-extern inline int metal_interrupt_vector_disable(struct metal_interrupt *controller, int id);
+extern __inline__ int metal_interrupt_vector_disable(struct metal_interrupt *controller, int id);
 
-extern inline int _metal_interrupt_command_request(struct metal_interrupt *controller,
+extern __inline__ int _metal_interrupt_command_request(struct metal_interrupt *controller,
                                          	int cmd, void *data);

--- a/src/led.c
+++ b/src/led.c
@@ -32,7 +32,7 @@ struct metal_led* metal_led_get (char *label)
     return metal_led_get_rgb(label, "");
 }
 
-extern inline void metal_led_enable(struct metal_led *led);
-extern inline void metal_led_on(struct metal_led *led);
-extern inline void metal_led_off(struct metal_led *led);
-extern inline void metal_led_toggle(struct metal_led *led);
+extern __inline__ void metal_led_enable(struct metal_led *led);
+extern __inline__ void metal_led_on(struct metal_led *led);
+extern __inline__ void metal_led_off(struct metal_led *led);
+extern __inline__ void metal_led_toggle(struct metal_led *led);

--- a/src/lock.c
+++ b/src/lock.c
@@ -3,6 +3,6 @@
 
 #include <metal/lock.h>
 
-extern inline int metal_lock_init(struct metal_lock *lock);
-extern inline int metal_lock_take(struct metal_lock *lock);
-extern inline int metal_lock_give(struct metal_lock *lock);
+extern __inline__ int metal_lock_init(struct metal_lock *lock);
+extern __inline__ int metal_lock_take(struct metal_lock *lock);
+extern __inline__ int metal_lock_give(struct metal_lock *lock);

--- a/src/memory.c
+++ b/src/memory.c
@@ -19,8 +19,8 @@ struct metal_memory *metal_get_memory_from_address(const uintptr_t address) {
 	return NULL;
 }
 
-extern inline uintptr_t metal_memory_get_base_address(const struct metal_memory *memory);
-extern inline size_t metal_memory_get_size(const struct metal_memory *memory);
-extern inline int metal_memory_supports_atomics(const struct metal_memory *memory);
-extern inline int metal_memory_is_cachable(const struct metal_memory *memory);
+extern __inline__ uintptr_t metal_memory_get_base_address(const struct metal_memory *memory);
+extern __inline__ size_t metal_memory_get_size(const struct metal_memory *memory);
+extern __inline__ int metal_memory_supports_atomics(const struct metal_memory *memory);
+extern __inline__ int metal_memory_is_cachable(const struct metal_memory *memory);
 

--- a/src/pmp.c
+++ b/src/pmp.c
@@ -151,67 +151,67 @@ int metal_pmp_set_region(struct metal_pmp *pmp,
     if(old_address != address) {
         switch(region) {
         case 0:
-            asm("csrw pmpaddr0, %[addr]"
+            __asm__("csrw pmpaddr0, %[addr]"
                     :: [addr] "r" (address) :);
             break;
         case 1:
-            asm("csrw pmpaddr1, %[addr]"
+            __asm__("csrw pmpaddr1, %[addr]"
                     :: [addr] "r" (address) :);
             break;
         case 2:
-            asm("csrw pmpaddr2, %[addr]"
+            __asm__("csrw pmpaddr2, %[addr]"
                     :: [addr] "r" (address) :);
             break;
         case 3:
-            asm("csrw pmpaddr3, %[addr]"
+            __asm__("csrw pmpaddr3, %[addr]"
                     :: [addr] "r" (address) :);
             break;
         case 4:
-            asm("csrw pmpaddr4, %[addr]"
+            __asm__("csrw pmpaddr4, %[addr]"
                     :: [addr] "r" (address) :);
             break;
         case 5:
-            asm("csrw pmpaddr5, %[addr]"
+            __asm__("csrw pmpaddr5, %[addr]"
                     :: [addr] "r" (address) :);
             break;
         case 6:
-            asm("csrw pmpaddr6, %[addr]"
+            __asm__("csrw pmpaddr6, %[addr]"
                     :: [addr] "r" (address) :);
             break;
         case 7:
-            asm("csrw pmpaddr7, %[addr]"
+            __asm__("csrw pmpaddr7, %[addr]"
                     :: [addr] "r" (address) :);
             break;
         case 8:
-            asm("csrw pmpaddr8, %[addr]"
+            __asm__("csrw pmpaddr8, %[addr]"
                     :: [addr] "r" (address) :);
             break;
         case 9:
-            asm("csrw pmpaddr9, %[addr]"
+            __asm__("csrw pmpaddr9, %[addr]"
                     :: [addr] "r" (address) :);
             break;
         case 10:
-            asm("csrw pmpaddr10, %[addr]"
+            __asm__("csrw pmpaddr10, %[addr]"
                     :: [addr] "r" (address) :);
             break;
         case 11:
-            asm("csrw pmpaddr11, %[addr]"
+            __asm__("csrw pmpaddr11, %[addr]"
                     :: [addr] "r" (address) :);
             break;
         case 12:
-            asm("csrw pmpaddr12, %[addr]"
+            __asm__("csrw pmpaddr12, %[addr]"
                     :: [addr] "r" (address) :);
             break;
         case 13:
-            asm("csrw pmpaddr13, %[addr]"
+            __asm__("csrw pmpaddr13, %[addr]"
                     :: [addr] "r" (address) :);
             break;
         case 14:
-            asm("csrw pmpaddr14, %[addr]"
+            __asm__("csrw pmpaddr14, %[addr]"
                     :: [addr] "r" (address) :);
             break;
         case 15:
-            asm("csrw pmpaddr15, %[addr]"
+            __asm__("csrw pmpaddr15, %[addr]"
                     :: [addr] "r" (address) :);
             break;
         }
@@ -225,31 +225,31 @@ int metal_pmp_set_region(struct metal_pmp *pmp,
         
         switch(region / 4) {
         case 0:
-            asm("csrc pmpcfg0, %[mask]"
+            __asm__("csrc pmpcfg0, %[mask]"
                     :: [mask] "r" (cfgmask) :);
 
-            asm("csrs pmpcfg0, %[cfg]"
+            __asm__("csrs pmpcfg0, %[cfg]"
                     :: [cfg] "r" (pmpcfg) :);
             break;
         case 1:
-            asm("csrc pmpcfg1, %[mask]"
+            __asm__("csrc pmpcfg1, %[mask]"
                     :: [mask] "r" (cfgmask) :);
 
-            asm("csrs pmpcfg1, %[cfg]"
+            __asm__("csrs pmpcfg1, %[cfg]"
                     :: [cfg] "r" (pmpcfg) :);
             break;
         case 2:
-            asm("csrc pmpcfg2, %[mask]"
+            __asm__("csrc pmpcfg2, %[mask]"
                     :: [mask] "r" (cfgmask) :);
 
-            asm("csrs pmpcfg2, %[cfg]"
+            __asm__("csrs pmpcfg2, %[cfg]"
                     :: [cfg] "r" (pmpcfg) :);
             break;
         case 3:
-            asm("csrc pmpcfg3, %[mask]"
+            __asm__("csrc pmpcfg3, %[mask]"
                     :: [mask] "r" (cfgmask) :);
 
-            asm("csrs pmpcfg3, %[cfg]"
+            __asm__("csrs pmpcfg3, %[cfg]"
                     :: [cfg] "r" (pmpcfg) :);
             break;
         }
@@ -262,17 +262,17 @@ int metal_pmp_set_region(struct metal_pmp *pmp,
         
         switch(region / 8) {
         case 0:
-            asm("csrc pmpcfg0, %[mask]"
+            __asm__("csrc pmpcfg0, %[mask]"
                     :: [mask] "r" (cfgmask) :);
 
-            asm("csrs pmpcfg0, %[cfg]"
+            __asm__("csrs pmpcfg0, %[cfg]"
                     :: [cfg] "r" (pmpcfg) :);
             break;
         case 1:
-            asm("csrc pmpcfg2, %[mask]"
+            __asm__("csrc pmpcfg2, %[mask]"
                     :: [mask] "r" (cfgmask) :);
 
-            asm("csrs pmpcfg2, %[cfg]"
+            __asm__("csrs pmpcfg2, %[cfg]"
                     :: [cfg] "r" (pmpcfg) :);
             break;
         }
@@ -304,19 +304,19 @@ int metal_pmp_get_region(struct metal_pmp *pmp,
 #if __riscv_xlen==32
     switch(region / 4) {
     case 0:
-        asm("csrr %[cfg], pmpcfg0"
+        __asm__("csrr %[cfg], pmpcfg0"
                 : [cfg] "=r" (pmpcfg) ::);
         break;
     case 1:
-        asm("csrr %[cfg], pmpcfg1"
+        __asm__("csrr %[cfg], pmpcfg1"
                 : [cfg] "=r" (pmpcfg) ::);
         break;
     case 2:
-        asm("csrr %[cfg], pmpcfg2"
+        __asm__("csrr %[cfg], pmpcfg2"
                 : [cfg] "=r" (pmpcfg) ::);
         break;
     case 3:
-        asm("csrr %[cfg], pmpcfg3"
+        __asm__("csrr %[cfg], pmpcfg3"
                 : [cfg] "=r" (pmpcfg) ::);
         break;
     }
@@ -326,11 +326,11 @@ int metal_pmp_get_region(struct metal_pmp *pmp,
 #elif __riscv_xlen==64
     switch(region / 8) {
     case 0:
-        asm("csrr %[cfg], pmpcfg0"
+        __asm__("csrr %[cfg], pmpcfg0"
                 : [cfg] "=r" (pmpcfg) ::);
         break;
     case 1:
-        asm("csrr %[cfg], pmpcfg2"
+        __asm__("csrr %[cfg], pmpcfg2"
                 : [cfg] "=r" (pmpcfg) ::);
         break;
     }
@@ -345,67 +345,67 @@ int metal_pmp_get_region(struct metal_pmp *pmp,
 
     switch(region) {
     case 0:
-        asm("csrr %[addr], pmpaddr0"
+        __asm__("csrr %[addr], pmpaddr0"
                 : [addr] "=r" (*address) ::);
         break;
     case 1:
-        asm("csrr %[addr], pmpaddr1"
+        __asm__("csrr %[addr], pmpaddr1"
                 : [addr] "=r" (*address) ::);
         break;
     case 2:
-        asm("csrr %[addr], pmpaddr2"
+        __asm__("csrr %[addr], pmpaddr2"
                 : [addr] "=r" (*address) ::);
         break;
     case 3:
-        asm("csrr %[addr], pmpaddr3"
+        __asm__("csrr %[addr], pmpaddr3"
                 : [addr] "=r" (*address) ::);
         break;
     case 4:
-        asm("csrr %[addr], pmpaddr4"
+        __asm__("csrr %[addr], pmpaddr4"
                 : [addr] "=r" (*address) ::);
         break;
     case 5:
-        asm("csrr %[addr], pmpaddr5"
+        __asm__("csrr %[addr], pmpaddr5"
                 : [addr] "=r" (*address) ::);
         break;
     case 6:
-        asm("csrr %[addr], pmpaddr6"
+        __asm__("csrr %[addr], pmpaddr6"
                 : [addr] "=r" (*address) ::);
         break;
     case 7:
-        asm("csrr %[addr], pmpaddr7"
+        __asm__("csrr %[addr], pmpaddr7"
                 : [addr] "=r" (*address) ::);
         break;
     case 8:
-        asm("csrr %[addr], pmpaddr8"
+        __asm__("csrr %[addr], pmpaddr8"
                 : [addr] "=r" (*address) ::);
         break;
     case 9:
-        asm("csrr %[addr], pmpaddr9"
+        __asm__("csrr %[addr], pmpaddr9"
                 : [addr] "=r" (*address) ::);
         break;
     case 10:
-        asm("csrr %[addr], pmpaddr10"
+        __asm__("csrr %[addr], pmpaddr10"
                 : [addr] "=r" (*address) ::);
         break;
     case 11:
-        asm("csrr %[addr], pmpaddr11"
+        __asm__("csrr %[addr], pmpaddr11"
                 : [addr] "=r" (*address) ::);
         break;
     case 12:
-        asm("csrr %[addr], pmpaddr12"
+        __asm__("csrr %[addr], pmpaddr12"
                 : [addr] "=r" (*address) ::);
         break;
     case 13:
-        asm("csrr %[addr], pmpaddr13"
+        __asm__("csrr %[addr], pmpaddr13"
                 : [addr] "=r" (*address) ::);
         break;
     case 14:
-        asm("csrr %[addr], pmpaddr14"
+        __asm__("csrr %[addr], pmpaddr14"
                 : [addr] "=r" (*address) ::);
         break;
     case 15:
-        asm("csrr %[addr], pmpaddr15"
+        __asm__("csrr %[addr], pmpaddr15"
                 : [addr] "=r" (*address) ::);
         break;
     }

--- a/src/pmp.c
+++ b/src/pmp.c
@@ -64,7 +64,7 @@ static uintptr_t _get_pmpaddr_granularity(uintptr_t address) {
 }
 
 /* Get the number of pmp regions for the current hart */
-static int _pmp_regions() {
+static unsigned int _pmp_regions() {
     struct metal_cpu *current_cpu = metal_cpu_get(metal_cpu_get_current_hartid());
 
     return __metal_driver_cpu_num_pmp_regions(current_cpu);

--- a/src/pmp.c
+++ b/src/pmp.c
@@ -5,8 +5,8 @@
 #include <metal/pmp.h>
 #include <metal/cpu.h>
 
-#define CONFIG_TO_INT(_config) (*((size_t *) &(_config)))
-#define INT_TO_CONFIG(_int) (*((struct metal_pmp_config *) &(_int)))
+#define CONFIG_TO_INT(_config) (*((char *) &(_config)))
+#define INT_TO_CONFIG(_int) (*((struct metal_pmp_config *)(char *) &(_int)))
 
 struct metal_pmp *metal_pmp_get_device(void)
 {
@@ -290,6 +290,7 @@ int metal_pmp_get_region(struct metal_pmp *pmp,
                        size_t *address)
 {
     size_t pmpcfg = 0;
+    char *pmpcfg_convert = (char *)&pmpcfg;
 
     if(!pmp || !config || !address) {
         /* NULL pointers are invalid arguments */
@@ -341,7 +342,7 @@ int metal_pmp_get_region(struct metal_pmp *pmp,
 #error XLEN is not set to supported value for PMP driver
 #endif
 
-    *config = INT_TO_CONFIG(pmpcfg);
+    *config = INT_TO_CONFIG(*pmpcfg_convert);
 
     switch(region) {
     case 0:

--- a/src/privilege.c
+++ b/src/privilege.c
@@ -20,7 +20,7 @@ void metal_privilege_drop_to_mode(enum metal_privilege_mode mode,
 				  metal_privilege_entry_point_t entry_point)
 {
 	uintptr_t mstatus;
-	asm volatile("csrr %0, mstatus" : "=r" (mstatus));
+	__asm__ volatile("csrr %0, mstatus" : "=r" (mstatus));
 
 	/* Set xPIE bits based on current xIE bits */
 	if(mstatus && (1 << METAL_MSTATUS_MIE_OFFSET)) {
@@ -43,15 +43,15 @@ void metal_privilege_drop_to_mode(enum metal_privilege_mode mode,
 	mstatus &= ~(METAL_MSTATUS_MPP_MASK << METAL_MSTATUS_MPP_OFFSET);
 	mstatus |= (mode << METAL_MSTATUS_MPP_OFFSET);
 
-	asm volatile("csrw mstatus, %0" :: "r" (mstatus));
+	__asm__ volatile("csrw mstatus, %0" :: "r" (mstatus));
 
 	/* Set the entry point in MEPC */
-	asm volatile("csrw mepc, %0" :: "r" (entry_point));
+	__asm__ volatile("csrw mepc, %0" :: "r" (entry_point));
 
 	/* Set the register file */
-	asm volatile("mv ra, %0" :: "r" (regfile.ra));
-	asm volatile("mv sp, %0" :: "r" (regfile.sp));
+	__asm__ volatile("mv ra, %0" :: "r" (regfile.ra));
+	__asm__ volatile("mv sp, %0" :: "r" (regfile.sp));
 
-	asm volatile("mret");
+	__asm__ volatile("mret");
 }
 

--- a/src/shutdown.c
+++ b/src/shutdown.c
@@ -12,7 +12,7 @@ void metal_shutdown(int code)
     __metal_shutdown_exit(__METAL_DT_SHUTDOWN_HANDLE, code);
 }
 #else
-# warning "There is no defined shutdown mechanism, metal_shutdown() will spin."
+#pragma message("There is no defined shutdown mechanism, metal_shutdown() will spin.")
 void metal_shutdown(int code)
 {
     while (1) {

--- a/src/shutdown.c
+++ b/src/shutdown.c
@@ -4,7 +4,7 @@
 #include <metal/machine.h>
 #include <metal/shutdown.h>
 
-extern inline void __metal_shutdown_exit(const struct __metal_shutdown *sd, int code);
+extern __inline__ void __metal_shutdown_exit(const struct __metal_shutdown *sd, int code);
 
 #if defined(__METAL_DT_SHUTDOWN_HANDLE)
 void metal_shutdown(int code)

--- a/src/spi.c
+++ b/src/spi.c
@@ -9,11 +9,13 @@ extern __inline__ int metal_spi_transfer(struct metal_spi *spi, struct metal_spi
 extern __inline__ int metal_spi_get_baud_rate(struct metal_spi *spi);
 extern __inline__ int metal_spi_set_baud_rate(struct metal_spi *spi, int baud_rate);
 
-struct metal_spi *metal_spi_get_device(int device_num)
+struct metal_spi *metal_spi_get_device(unsigned int device_num)
 {
-    if(device_num >= __METAL_DT_MAX_SPIS) {
-        return NULL;
+#if __METAL_DT_MAX_SPIS > 0
+    if (device_num < __METAL_DT_MAX_SPIS) {
+        return (struct metal_spi *) __metal_spi_table[device_num];
     }
+#endif
 
-    return (struct metal_spi *) __metal_spi_table[device_num];
+    return NULL;
 }

--- a/src/spi.c
+++ b/src/spi.c
@@ -4,10 +4,10 @@
 #include <metal/machine.h>
 #include <metal/spi.h>
 
-extern inline void metal_spi_init(struct metal_spi *spi, int baud_rate);
-extern inline int metal_spi_transfer(struct metal_spi *spi, struct metal_spi_config *config, size_t len, char *tx_buf, char *rx_buf);
-extern inline int metal_spi_get_baud_rate(struct metal_spi *spi);
-extern inline int metal_spi_set_baud_rate(struct metal_spi *spi, int baud_rate);
+extern __inline__ void metal_spi_init(struct metal_spi *spi, int baud_rate);
+extern __inline__ int metal_spi_transfer(struct metal_spi *spi, struct metal_spi_config *config, size_t len, char *tx_buf, char *rx_buf);
+extern __inline__ int metal_spi_get_baud_rate(struct metal_spi *spi);
+extern __inline__ int metal_spi_set_baud_rate(struct metal_spi *spi, int baud_rate);
 
 struct metal_spi *metal_spi_get_device(int device_num)
 {

--- a/src/switch.c
+++ b/src/switch.c
@@ -22,6 +22,6 @@ struct metal_switch* metal_switch_get (char *label)
     return NULL;
 }
 
-extern inline struct metal_interrupt*
+extern __inline__ struct metal_interrupt*
     metal_switch_interrupt_controller(struct metal_switch *flip);
-extern inline int metal_switch_get_interrupt_id(struct metal_switch *flip);
+extern __inline__ int metal_switch_get_interrupt_id(struct metal_switch *flip);

--- a/src/timer.c
+++ b/src/timer.c
@@ -65,15 +65,15 @@ int nop_tick(int second) __attribute__((section(".text.metal.nop.tick")));
 int nop_tick(int second) { return -1; }
 int metal_timer_get_cyclecount(int hartid, unsigned long long *c) __attribute__((weak, alias("nop_cyclecount")))
 {
-#warning "There is no default timer device, metal_timer_get_cyclecount() will always return cyclecount -1."
+#pragma message("There is no default timer device, metal_timer_get_cyclecount() will always return cyclecount -1.")
 }
 int metal_timer_get_timebase_frequency(unsigned long long *t) __attribute__((weak, alias("nop_timebase")))
 {
-#warning "There is no default timer device, metal_timer_get_timebase_frequency() will always return timebase -1."
+#pragma message("There is no default timer device, metal_timer_get_timebase_frequency() will always return timebase -1.")
 }
 int metal_timer_set_tick(int second) __attribute__((weak, alias("nop_tick")))
 {
-#warning "There is no default timer device, metal_timer_set_tick) will always return -1."
+#pragma message("There is no default timer device, metal_timer_set_tick) will always return -1.")
 }
 
 #endif

--- a/src/tty.c
+++ b/src/tty.c
@@ -47,5 +47,5 @@ static void metal_tty_init(void)
 int nop_putc(int c) __attribute__((section(".text.metal.nop.putc")));
 int nop_putc(int c) { return -1; }
 int metal_tty_putc(int c) __attribute__((weak, alias("nop_putc")));
-#warning "There is no default output device, metal_tty_putc() will throw away all input."
+#pragma message("There is no default output device, metal_tty_putc() will throw away all input.")
 #endif

--- a/src/uart.c
+++ b/src/uart.c
@@ -3,9 +3,9 @@
 
 #include <metal/uart.h>
 
-extern inline void metal_uart_init(struct metal_uart *uart, int baud_rate);
-extern inline int metal_uart_putc(struct metal_uart *uart, int c);
-extern inline int metal_uart_txready(struct metal_uart *uart);
-extern inline int metal_uart_getc(struct metal_uart *uart, int *c);
-extern inline int metal_uart_get_baud_rate(struct metal_uart *uart);
-extern inline int metal_uart_set_baud_rate(struct metal_uart *uart, int baud_rate);
+extern __inline__ void metal_uart_init(struct metal_uart *uart, int baud_rate);
+extern __inline__ int metal_uart_putc(struct metal_uart *uart, int c);
+extern __inline__ int metal_uart_txready(struct metal_uart *uart);
+extern __inline__ int metal_uart_getc(struct metal_uart *uart, int *c);
+extern __inline__ int metal_uart_get_baud_rate(struct metal_uart *uart);
+extern __inline__ int metal_uart_set_baud_rate(struct metal_uart *uart, int baud_rate);


### PR DESCRIPTION
Fixes warnings and errors when building for
```
-std=c99 -Wall -Wextra -Wno-unused-parameter -pedantic
```