### PR TITLE
Link _synchronize_harts() into .init

### DIFF
--- a/gloss/synchronize_harts.c
+++ b/gloss/synchronize_harts.c
@@ -15,6 +15,7 @@
  * hart 0 to finish copying the datat section, zeroing the BSS, and running
  * the libc contstructors.
  */
+__attribute__((section(".init")))
 void _synchronize_harts() {
 #if __METAL_DT_MAX_HARTS > 1
 


### PR DESCRIPTION
Make sure that _synchronize_harts() is in .init instead of .text to make
sure that it doesn't get placed in the ITIM. It must be linked into the
ROM so that it's available even before the ITIM is initialized.