### PR TITLE
Link _synchronize_harts() into .init [v201905 backport]

### DIFF
--- a/gloss/synchronize_harts.c
+++ b/gloss/synchronize_harts.c
@@ -15,6 +15,7 @@
  * hart 0 to finish copying the datat section, zeroing the BSS, and running
  * the libc contstructors.
  */
+__attribute__((section(".init")))
 void _synchronize_harts() {
 #if __METAL_DT_MAX_HARTS > 1
 

--- a/gloss/synchronize_harts.c
+++ b/gloss/synchronize_harts.c
@@ -19,7 +19,10 @@ __attribute__((section(".init")))
 void _synchronize_harts() {
 #if __METAL_DT_MAX_HARTS > 1
 
-    int hart = metal_cpu_get_current_hartid();
+    /* Read the current hartid */
+    int hart;
+    __asm__ volatile("csrr %0, mhartid" : "=r" (hart) :: "memory");
+
     uintptr_t msip_base = 0;
 
     /* Get the base address of the MSIP registers */


### PR DESCRIPTION
Make sure that _synchronize_harts() is in .init instead of .text to make
sure that it doesn't get placed in the ITIM. It must be linked into the
ROM so that it's available even before the ITIM is initialized.