### PR TITLE
Correct the API name in document

### DIFF
--- a/doc/sphinx/devguide/exceptions.rst
+++ b/doc/sphinx/devguide/exceptions.rst
@@ -18,7 +18,7 @@ To initialize the Freedom Metal exception handlers, initialize CPU interrupts:
 
 .. code-block:: C
 
-   struct metal_cpu *cpu0 = metal_get_cpu(0);
+   struct metal_cpu *cpu0 = metal_cpu_get(0);
    if(!cpu) {
       /* There was an error acquiring the CPU hart 0 handle */
    }
@@ -60,7 +60,7 @@ code.
 
    /* CPU Hart 0's interrupt controller must be initialized
     * if it is not already */
-   struct metal_cpu *cpu0 = metal_get_cpu(0);
+   struct metal_cpu *cpu0 = metal_cpu_get(0);
 
    int rc = metal_cpu_exception_register(cpu0,
                <my_ecode>, /* Set to your desired value */

--- a/doc/sphinx/devguide/interrupts.rst
+++ b/doc/sphinx/devguide/interrupts.rst
@@ -37,7 +37,7 @@ initialized before any other interrupt controllers are initialized. In example:
 
 .. code-block:: C
 
-   struct metal_cpu *cpu0 = metal_get_cpu(0);
+   struct metal_cpu *cpu0 = metal_cpu_get(0);
    if(!cpu) {
       /* Unable to get CPU handle */
    }


### PR DESCRIPTION
There is no metal_get_cpu API. The real API name should be
metal_cpu_get

Signed-off-by: Zong Li <zong.li@sifive.com>