### PR TITLE
Add to get number of PMP regions

### DIFF
--- a/metal/pmp.h
+++ b/metal/pmp.h
@@ -74,6 +74,11 @@ struct metal_pmp {
 struct metal_pmp *metal_pmp_get_device(void);
 
 /*!
+ * @brief Get the number of pmp regions for the hartid
+ */
+int metal_pmp_num_regions(int hartid);
+
+/*!
  * @brief Initialize the PMP
  * @param pmp The PMP device handle to be initialized
  *

--- a/src/pmp.c
+++ b/src/pmp.c
@@ -63,13 +63,18 @@ static uintptr_t _get_pmpaddr_granularity(uintptr_t address) {
     return (1 << (index + 3));
 }
 
-/* Get the number of pmp regions for the current hart */
-static unsigned int _pmp_regions() {
-    struct metal_cpu *current_cpu = metal_cpu_get(metal_cpu_get_current_hartid());
+/* Get the number of pmp regions for the given hart */
+int metal_pmp_num_regions(int hartid)
+{
+    struct metal_cpu *cpu = metal_cpu_get(hartid);
 
-    return __metal_driver_cpu_num_pmp_regions(current_cpu);
+    return __metal_driver_cpu_num_pmp_regions(cpu);
 }
 
+/* Get the number of pmp regions for the current hart */
+static unsigned int _pmp_regions() {
+    return metal_pmp_num_regions(metal_cpu_get_current_hartid());
+}
 
 void metal_pmp_init(struct metal_pmp *pmp) {
     if(!pmp) {


### PR DESCRIPTION
Add these APIs because opensbi need these APIs to get the device information. The number of pmp regions and baud rate of UART could be hard coded in opensbi but it seem that provided by freedom-metal would be better.
