### PR TITLE
add wake build rule fixes to v201905

### DIFF
--- a/build.wake
+++ b/build.wake
@@ -97,6 +97,7 @@ global def runFreedomMetalInstall options =
     relative runDir meeInline.getPathName,
     relative runDir platformHeader.getPathName,
     relative runDir meeLdScript.getPathName,
+    relative runDir outputDir,
     Nil
 
   def inputs = mkdir outputDir, wrapperScript, meeHeader, meeLdScript, installedFreedomMetal

--- a/scripts/autoconf_wrapper
+++ b/scripts/autoconf_wrapper
@@ -3,7 +3,8 @@
 set -e
 
 if [ "$#" -ne 7 ]; then
-    echo "Illegal number of parameters"
+  echo "Illegal number of parameters" >&2
+  exit 1
 fi
 
 host=$1

--- a/scripts/autoconf_wrapper
+++ b/scripts/autoconf_wrapper
@@ -1,5 +1,11 @@
 #!/bin/bash -x
 
+set -e
+
+if [ "$#" -ne 7 ]; then
+    echo "Illegal number of parameters"
+fi
+
 host=$1
 machine_name=$2
 machine_header=$3
@@ -15,7 +21,7 @@ machine_ldscript=$(pwd)/$machine_ldscript
 install_dir=$(pwd)/${install_dir}
 
 export RISCV_PATH=$RISCV
-make clean
+
 autoreconf -i
 ./configure \
   --host=$host \
@@ -30,5 +36,11 @@ autoreconf -i
   --with-machine-ldscript=$machine_ldscript \
   --with-builtin-libgloss \
   --prefix=
-make
-make DESTDIR=$install_dir install
+make \
+  RANLIB="riscv64-unknown-elf-ranlib -D" \
+  ARFLAGS=Dcr
+make  \
+  RANLIB="riscv64-unknown-elf-ranlib -D" \
+  ARFLAGS=Dcr \
+  DESTDIR=$install_dir \
+  install


### PR DESCRIPTION
the PR is to merge the same branch from https://github.com/sifive/freedom-metal/pull/124 into the v201905 branch

Makes outputs of the `freedom-metal` compile job reproducible and adds a missing argument.