### PR TITLE
[19.08 Backport] Fixed the cs pin assignment.

### DIFF
--- a/src/drivers/sifive_spi0.c
+++ b/src/drivers/sifive_spi0.c
@@ -108,7 +108,7 @@ static int configure_spi(struct __metal_driver_sifive_spi0 *spi, struct metal_sp
     }
 
     /* Set CS line */
-    METAL_SPI_REGW(METAL_SIFIVE_SPI0_CSID) = config->csid;
+    METAL_SPI_REGW(METAL_SIFIVE_SPI0_CSID) = 1 << (config->csid);
 
     /* Toggle off memory-mapped SPI flash mode, toggle on programmable IO mode
      * It seems that with this line uncommented, the debugger cannot have access 


### PR DESCRIPTION
Backports #160 to v201908-branch