### PR TITLE
[19.08 Backport] Don't call metal API in synchronize_harts()

### DIFF
--- a/src/synchronize_harts.c
+++ b/src/synchronize_harts.c
@@ -19,7 +19,9 @@ __attribute__((section(".init")))
 void __metal_synchronize_harts() {
 #if __METAL_DT_MAX_HARTS > 1
 
-    int hart = metal_cpu_get_current_hartid();
+    int hart;
+    __asm__ volatile("csrr %0, mhartid" : "=r" (hart) ::);
+
     uintptr_t msip_base = 0;
 
     /* Get the base address of the MSIP registers */


### PR DESCRIPTION
metal_cpu_get_current_hartid() might be in the ITIM and is not available
at the time that synchronize_harts() is called. Use inline assembly
instead.