### PR TITLE
Create Metal Init API

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -85,6 +85,7 @@ nobase_include_HEADERS = \
 	metal/compiler.h \
 	metal/cpu.h \
 	metal/gpio.h \
+	metal/init.h \
 	metal/interrupt.h \
 	metal/io.h \
 	metal/itim.h \
@@ -186,6 +187,7 @@ libriscv__mmachine__@MACHINE_NAME@_a_SOURCES = \
 	src/cpu.c \
 	src/entry.S \
 	src/gpio.c \
+	src/init.c \
 	src/interrupt.c \
 	src/led.c \
 	src/lock.c \

--- a/Makefile.in
+++ b/Makefile.in
@@ -229,6 +229,7 @@ am_libriscv__mmachine__@MACHINE_NAME@_a_OBJECTS = src/drivers/libriscv__mmachine
 	src/libriscv__mmachine__@MACHINE_NAME@_a-cpu.$(OBJEXT) \
 	src/libriscv__mmachine__@MACHINE_NAME@_a-entry.$(OBJEXT) \
 	src/libriscv__mmachine__@MACHINE_NAME@_a-gpio.$(OBJEXT) \
+	src/libriscv__mmachine__@MACHINE_NAME@_a-init.$(OBJEXT) \
 	src/libriscv__mmachine__@MACHINE_NAME@_a-interrupt.$(OBJEXT) \
 	src/libriscv__mmachine__@MACHINE_NAME@_a-led.$(OBJEXT) \
 	src/libriscv__mmachine__@MACHINE_NAME@_a-lock.$(OBJEXT) \
@@ -506,6 +507,7 @@ nobase_include_HEADERS = \
 	metal/compiler.h \
 	metal/cpu.h \
 	metal/gpio.h \
+	metal/init.h \
 	metal/interrupt.h \
 	metal/io.h \
 	metal/itim.h \
@@ -574,6 +576,7 @@ libriscv__mmachine__@MACHINE_NAME@_a_SOURCES = \
 	src/cpu.c \
 	src/entry.S \
 	src/gpio.c \
+	src/init.c \
 	src/interrupt.c \
 	src/led.c \
 	src/lock.c \
@@ -878,6 +881,8 @@ src/libriscv__mmachine__@MACHINE_NAME@_a-entry.$(OBJEXT):  \
 	src/$(am__dirstamp) src/$(DEPDIR)/$(am__dirstamp)
 src/libriscv__mmachine__@MACHINE_NAME@_a-gpio.$(OBJEXT):  \
 	src/$(am__dirstamp) src/$(DEPDIR)/$(am__dirstamp)
+src/libriscv__mmachine__@MACHINE_NAME@_a-init.$(OBJEXT):  \
+	src/$(am__dirstamp) src/$(DEPDIR)/$(am__dirstamp)
 src/libriscv__mmachine__@MACHINE_NAME@_a-interrupt.$(OBJEXT):  \
 	src/$(am__dirstamp) src/$(DEPDIR)/$(am__dirstamp)
 src/libriscv__mmachine__@MACHINE_NAME@_a-led.$(OBJEXT):  \
@@ -994,6 +999,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-cpu.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-entry.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-gpio.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-init.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-interrupt.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-led.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-lock.Po@am__quote@
@@ -1504,6 +1510,20 @@ src/libriscv__mmachine__@MACHINE_NAME@_a-gpio.obj: src/gpio.c
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/gpio.c' object='src/libriscv__mmachine__@MACHINE_NAME@_a-gpio.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libriscv__mmachine__@MACHINE_NAME@_a_CFLAGS) $(CFLAGS) -c -o src/libriscv__mmachine__@MACHINE_NAME@_a-gpio.obj `if test -f 'src/gpio.c'; then $(CYGPATH_W) 'src/gpio.c'; else $(CYGPATH_W) '$(srcdir)/src/gpio.c'; fi`
+
+src/libriscv__mmachine__@MACHINE_NAME@_a-init.o: src/init.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libriscv__mmachine__@MACHINE_NAME@_a_CFLAGS) $(CFLAGS) -MT src/libriscv__mmachine__@MACHINE_NAME@_a-init.o -MD -MP -MF src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-init.Tpo -c -o src/libriscv__mmachine__@MACHINE_NAME@_a-init.o `test -f 'src/init.c' || echo '$(srcdir)/'`src/init.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-init.Tpo src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-init.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/init.c' object='src/libriscv__mmachine__@MACHINE_NAME@_a-init.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libriscv__mmachine__@MACHINE_NAME@_a_CFLAGS) $(CFLAGS) -c -o src/libriscv__mmachine__@MACHINE_NAME@_a-init.o `test -f 'src/init.c' || echo '$(srcdir)/'`src/init.c
+
+src/libriscv__mmachine__@MACHINE_NAME@_a-init.obj: src/init.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libriscv__mmachine__@MACHINE_NAME@_a_CFLAGS) $(CFLAGS) -MT src/libriscv__mmachine__@MACHINE_NAME@_a-init.obj -MD -MP -MF src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-init.Tpo -c -o src/libriscv__mmachine__@MACHINE_NAME@_a-init.obj `if test -f 'src/init.c'; then $(CYGPATH_W) 'src/init.c'; else $(CYGPATH_W) '$(srcdir)/src/init.c'; fi`
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-init.Tpo src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-init.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='src/init.c' object='src/libriscv__mmachine__@MACHINE_NAME@_a-init.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libriscv__mmachine__@MACHINE_NAME@_a_CFLAGS) $(CFLAGS) -c -o src/libriscv__mmachine__@MACHINE_NAME@_a-init.obj `if test -f 'src/init.c'; then $(CYGPATH_W) 'src/init.c'; else $(CYGPATH_W) '$(srcdir)/src/init.c'; fi`
 
 src/libriscv__mmachine__@MACHINE_NAME@_a-interrupt.o: src/interrupt.c
 @am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(libriscv__mmachine__@MACHINE_NAME@_a_CFLAGS) $(CFLAGS) -MT src/libriscv__mmachine__@MACHINE_NAME@_a-interrupt.o -MD -MP -MF src/$(DEPDIR)/libriscv__mmachine__@MACHINE_NAME@_a-interrupt.Tpo -c -o src/libriscv__mmachine__@MACHINE_NAME@_a-interrupt.o `test -f 'src/interrupt.c' || echo '$(srcdir)/'`src/interrupt.c

--- a/doc/sphinx/apiref/init.rst
+++ b/doc/sphinx/apiref/init.rst
@@ -1,0 +1,7 @@
+Constructors and Destructors
+============================
+
+.. doxygenfile:: metal/init.h
+   :project: metal
+   :no-link:
+

--- a/doc/sphinx/devguide/init.rst
+++ b/doc/sphinx/devguide/init.rst
@@ -1,0 +1,109 @@
+Constructors and Destructors
+============================
+
+Metal implements a mechanism for registering constructors and destructors to
+run before main and upon exit. The purpose of the Metal init API is to provide
+a unified mechanism for registering constructors for both users and drivers,
+as well as to provide a mechanism for manually overriding or disabling the
+constructors/destructors entirely.
+
+Defining a Constructor/Destructor
+---------------------------------
+
+Constructors and destructors can be defined with the following macros:
+
+.. doxygendefine:: METAL_CONSTRUCTOR
+   :project: metal
+
+.. doxygendefine:: METAL_CONSTRUCTOR_PRIO
+   :project: metal
+
+.. doxygendefine:: METAL_DESTRUCTOR
+   :project: metal
+
+.. doxygendefine:: METAL_DESTRUCTOR_PRIO
+   :project: metal
+
+For example:
+
+.. code-block:: C
+
+   METAL_CONSTRUCTOR(constructor_hello) {
+      puts("Hello from before main!\n");
+   }
+
+   METAL_DESTRUCTOR_PRIO(destructor_goodbye, METAL_INIT_HIGHEST_PRIORITY) {
+      puts("Program exiting, goodbye.\n");
+   }
+
+The above sample defines the functions ``constructor_hello()`` and
+``constructor_goodbye()`` and registers them to be run by ``metal_init()`` and
+``metal_fini()``.
+
+.. doxygenfunction:: metal_init
+   :project: metal
+
+.. doxygenfunction:: metal_fini
+   :project: metal
+
+Default Behavior
+----------------
+
+By default, Metal constructors and destructors are run before main and upon exit
+respectively. This ensures that constructors defined by Metal and
+Metal device drivers are called by default before ``main()``. For example, targets
+with the "sifive,uart0" UART device set as ``stdout-path`` automatically configure
+the UART's clock divider to the requested baud rate using a Metal constructor.
+
+The default control flow looks like the following:
+
+ * _start
+
+   * ...
+   * metal_init_run
+
+     * metal_init
+
+       * constructor_1
+       * constructor_2
+       * ...
+
+   * ...
+   * main
+
+     * ...
+
+   * exit
+
+     * ...
+     * metal_fini_run
+
+       * metal_fini
+
+         * destructor_1
+         * destructor_2
+         * ...
+
+     * ...
+
+Note ``metal_init_run()`` and ``metal_fini_run()`` in the above flow graph.
+
+.. doxygenfunction:: metal_init_run
+   :project: metal
+
+.. doxygenfunction:: metal_fini_run
+   :project: metal
+
+The purpose of these wrapper functions is to allow manual override by application
+code.
+
+Preventing Constructors/Destructors from Running
+------------------------------------------------
+
+You can prevent Metal constructors and destructors from running by redifining
+``metal_init_run()`` and ``metal_fini_run()`` in your application:
+
+.. code-block:: C
+
+   void metal_init_run() {}
+   void metal_fini_run() {}

--- a/gloss/crt0.S
+++ b/gloss/crt0.S
@@ -153,6 +153,12 @@ _start:
   call atexit
   call __libc_init_array
 
+  /* Register metal_fini_run as a destructor and call metal_init_run to
+   * run and setup Metal constructors */
+  la a0, metal_fini_run
+  call atexit
+  call metal_init_run
+
 _skip_init:
 
   /* Synchronize harts so that secondary harts wait until hart 0 finishes

--- a/metal/init.h
+++ b/metal/init.h
@@ -1,0 +1,130 @@
+/* Copyright 2019 SiFive Inc. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef METAL_INIT
+#define METAL_INIT
+
+/*!
+ * @file init.h
+ * API for Metal constructors and destructors
+ */
+
+typedef void (*metal_constructor_t)(void);
+typedef void (*metal_destructor_t)(void);
+
+#define METAL_INIT_HIGHEST_PRIORITY 0
+#define METAL_INIT_DEFAULT_PRIORITY 5000
+#define METAL_INIT_LOWEST_PRIORITY 9999
+
+/*! @def METAL_CONSTRUCTOR
+ * @brief Define a Metal constructor
+ *
+ * Functions defined with METAL_CONSTRUCTOR will be added to the list of
+ * Metal constructors. By default, these functions are called before main by
+ * the metal_init() function.
+ */
+#define METAL_CONSTRUCTOR(function_name)                                       \
+    METAL_CONSTRUCTOR_PRIO(function_name, METAL_INIT_DEFAULT_PRIORITY)
+
+/*! @def METAL_CONSTRUCTOR_PRIO
+ * @brief Define a Metal constructor with a given priority
+ *
+ * The priority argument should be an integer between 0 and 9999, where 0
+ * is the highest priority (runs first) and 9999 is the lowest priority
+ * (runs last).
+ *
+ * Functions defined with METAL_CONSTRUCTOR_PRIO will be added to the list of
+ * Metal constructors. By default, these functions are called before main by
+ * the metal_init() function.
+ */
+#define METAL_CONSTRUCTOR_PRIO(function_name, priority)                        \
+    __METAL_CONSTRUCTOR_PRIO(function_name, priority)
+
+/* We use this wrapper for METAL_CONSTRUCTOR_PRIORITY so that macros passed
+ * as 'priority' are expanded before being stringified by the # operator.
+ * If we don't do this, then
+ * METAL_CONSTRUCTOR(my_fn_name, METAL_INIT_DEFAULT_PRIORITY)
+ * results in .metal.init_array.METAL_INIT_DEFAULT_PRIORITY instead of
+ * .metal.init_array.5000 */
+#define __METAL_CONSTRUCTOR_PRIO(function_name, priority)                      \
+    __attribute__((section(".metal.ctors"))) void function_name(void);         \
+    __attribute__((section(".metal.init_array." #priority)))                   \
+        metal_constructor_t _##function_name##_ptr = &function_name;           \
+    void function_name(void)
+
+/*! @def METAL_DESTRUCTOR
+ * @brief Define a Metal destructor
+ *
+ * Functions defined with METAL_DESTRUCTOR will be added to the list of
+ * Metal destructors. By default, these functions are called on exit by
+ * the metal_fini() function.
+ */
+#define METAL_DESTRUCTOR(function_name)                                        \
+    METAL_DESTRUCTOR_PRIO(function_name, METAL_INIT_DEFAULT_PRIORITY)
+
+/*! @def METAL_DESTRUCTOR_PRIO
+ * @brief Define a Metal destructor with a given priority
+ *
+ * The priority argument should be an integer between 0 and 9999, where 0
+ * is the highest priority (runs first) and 9999 is the lowest priority
+ * (runs last).
+ *
+ * Functions defined with METAL_DESTRUCTOR_PRIO will be added to the list of
+ * Metal destructors. By default, these functions are called on exit by
+ * the metal_fini() function.
+ */
+#define METAL_DESTRUCTOR_PRIO(function_name, priority)                         \
+    __METAL_DESTRUCTOR_PRIO(function_name, priority)
+#define __METAL_DESTRUCTOR_PRIO(function_name, priority)                       \
+    __attribute__((section(".metal.dtors"))) void function_name(void);         \
+    __attribute__((section(".metal.fini_array." #priority)))                   \
+        metal_destructor_t _##function_name##_ptr = &function_name;            \
+    void function_name(void)
+
+/*!
+ * @brief Call all Metal constructors
+ *
+ * Devices supported by Metal may define Metal constructors to perform
+ * initialization before main. This function iterates over the constructors
+ * and calls them in turn.
+ *
+ * You can add your own constructors to the functions called by metal_init()
+ * by defining functions with the METAL_CONSTRUCTOR() macro.
+ *
+ * This function is called before main by default by metal_init_run().
+ */
+void metal_init(void);
+
+/*!
+ * @brief Call all Metal destructors
+ *
+ * Devices supported by Metal may define Metal destructors to perform
+ * initialization on exit. This function iterates over the destructors
+ * and calls them in turn.
+ *
+ * You can add your own destructors to the functions called by metal_fini()
+ * by defining functions with the METAL_DESTRUCTOR() macro.
+ *
+ * This function is called on exit by default by metal_fini_run().
+ */
+void metal_fini(void);
+
+/*!
+ * @brief Weak function to call metal_init() before main
+ *
+ * This function calls metal_init() before main by default. If you wish to
+ * replace or augment this call to the Metal constructors, you can redefine
+ * metal_init_run()
+ */
+void metal_init_run(void);
+
+/*!
+ * @brief Weak function to call metal_fini() before main
+ *
+ * This function calls metal_fini() at exit by default. If you wish to
+ * replace or augment this call to the Metal destructors, you can redefine
+ * metal_fini_run()
+ */
+void metal_fini_run(void);
+
+#endif /* METAL_INIT */

--- a/src/drivers/sifive_fe310-g000_pll.c
+++ b/src/drivers/sifive_fe310-g000_pll.c
@@ -8,6 +8,7 @@
 #include <limits.h>
 #include <stdio.h>
 
+#include <metal/init.h>
 #include <metal/machine.h>
 
 #include <metal/drivers/sifive_fe310-g000_pll.h>
@@ -146,8 +147,7 @@ static long get_pll_config_freq(unsigned long pll_input_rate,
 
 #ifdef __METAL_DT_SIFIVE_FE310_G000_PLL_HANDLE
 
-static void metal_sifive_fe310_g000_pll_init(void) __attribute__((constructor));
-static void metal_sifive_fe310_g000_pll_init(void) {
+METAL_CONSTRUCTOR(metal_sifive_fe310_g000_pll_init) {
     long init_rate = __metal_driver_sifive_fe310_g000_pll_init_rate();
     /* If the PLL init_rate is zero, don't initialize the PLL */
     if (init_rate != 0)
@@ -347,8 +347,7 @@ long __metal_driver_sifive_fe310_g000_pll_set_rate_hz(struct metal_clock *clock,
 }
 
 #ifdef __METAL_DT_SIFIVE_FE310_G000_PLL_HANDLE
-static void use_hfxosc(void) __attribute__((constructor));
-static void use_hfxosc(void) {
+METAL_CONSTRUCTOR(use_hfxosc) {
     long init_rate = __metal_driver_sifive_fe310_g000_pll_init_rate();
     metal_clock_set_rate_hz(&__METAL_DT_SIFIVE_FE310_G000_PLL_HANDLE->clock,
                             init_rate);

--- a/src/drivers/sifive_fu540-c000_l2.c
+++ b/src/drivers/sifive_fu540-c000_l2.c
@@ -6,6 +6,7 @@
 #ifdef METAL_SIFIVE_FU540_C000_L2
 
 #include <metal/drivers/sifive_fu540-c000_l2.h>
+#include <metal/init.h>
 #include <metal/io.h>
 #include <metal/machine.h>
 #include <stdint.h>
@@ -15,9 +16,7 @@
 
 void __metal_driver_sifive_fu540_c000_l2_init(struct metal_cache *l2, int ways);
 
-static void metal_driver_sifive_fu540_c000_l2_init(void)
-    __attribute__((constructor));
-static void metal_driver_sifive_fu540_c000_l2_init(void) {
+METAL_CONSTRUCTOR(metal_driver_sifive_fu540_c000_l2_init) {
 #ifdef __METAL_DT_SIFIVE_FU540_C000_L2_HANDLE
     /* Get the handle for the L2 cache controller */
     struct metal_cache *l2 = __METAL_DT_SIFIVE_FU540_C000_L2_HANDLE;

--- a/src/init.c
+++ b/src/init.c
@@ -1,0 +1,72 @@
+/* Copyright 2019 SiFive Inc. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include <metal/init.h>
+
+/*
+ * These function pointers are created by the linker script
+ * in the .init_array section. The arrays defined by these
+ * and end points are the set of functions defined by instances
+ * of METAL_CONSTRUCTOR() and METAL_DESTRUCTOR().
+ */
+extern metal_constructor_t metal_constructors_start;
+extern metal_constructor_t metal_constructors_end;
+extern metal_destructor_t metal_destructors_start;
+extern metal_destructor_t metal_destructors_end;
+
+void metal_init(void) {
+    /* Make sure the constructors only run once */
+    static int init_done = 0;
+    if (!init_done) {
+        return;
+    }
+    init_done = 1;
+
+    if (metal_constructors_end <= metal_constructors_start) {
+        return;
+    }
+
+    metal_constructor_t *funcptr = &metal_constructors_start;
+    while (funcptr != &metal_constructors_end) {
+        metal_constructor_t func = *funcptr;
+
+        func();
+
+        funcptr += 1;
+    }
+}
+
+void metal_fini(void) {
+    /* Make sure the destructors only run once */
+    static int fini_done = 0;
+    if (!fini_done) {
+        return;
+    }
+    fini_done = 1;
+
+    if (metal_destructors_end <= metal_destructors_start) {
+        return;
+    }
+
+    metal_destructor_t *funcptr = &metal_destructors_start;
+    while (funcptr != &metal_destructors_end) {
+        metal_destructor_t func = *funcptr;
+
+        func();
+
+        funcptr += 1;
+    }
+}
+
+/*
+ * metal_init_run() and metal_fini_run() are marked weak so that users
+ * can redefine them for their own purposes, including to no-ops
+ * in the case that users don't want the metal constructors or
+ * destructors to run.
+ */
+
+void metal_init_run(void) __attribute__((weak));
+void metal_init_run(void) { metal_init(); }
+
+void metal_fini_run(void) __attribute__((weak));
+void metal_fini_run(void) { metal_fini(); }

--- a/src/tty.c
+++ b/src/tty.c
@@ -1,6 +1,7 @@
 /* Copyright 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 
+#include <metal/init.h>
 #include <metal/machine.h>
 #include <metal/tty.h>
 #include <metal/uart.h>
@@ -31,8 +32,7 @@ int metal_tty_getc(int *c) {
 #define __METAL_DT_STDOUT_UART_BAUD 115200
 #endif
 
-static void metal_tty_init(void) __attribute__((constructor));
-static void metal_tty_init(void) {
+METAL_CONSTRUCTOR(metal_tty_init) {
     metal_uart_init(__METAL_DT_STDOUT_UART_HANDLE, __METAL_DT_STDOUT_UART_BAUD);
 }
 #else


### PR DESCRIPTION
This creates the Metal Init API for defining constructors and destructors to run before main/upon exit, both within Metal drivers and in user application code.

This also allows users to disable constructors/destructors from running automatically by redefining the following functions in their application:
```
void metal_init_run(void) {}
void metal_fini_run(void) {}
```

Users can then call `metal_init()` and `metal_fini()` at their leisure to run Metal constructors/destructors.

Depends on [freedom-devicetree-tools#149](https://github.com/sifive/freedom-devicetree-tools/pull/149).