### PR TITLE
Fix mtvec overwrite

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -185,6 +185,7 @@ libriscv__mmachine__@MACHINE_NAME@_a_SOURCES = \
 	src/clock.c \
 	src/cpu.c \
 	src/entry.S \
+	src/trap.S \
 	src/gpio.c \
 	src/interrupt.c \
 	src/led.c \

--- a/Makefile.in
+++ b/Makefile.in
@@ -228,6 +228,7 @@ am_libriscv__mmachine__@MACHINE_NAME@_a_OBJECTS = src/drivers/libriscv__mmachine
 	src/libriscv__mmachine__@MACHINE_NAME@_a-clock.$(OBJEXT) \
 	src/libriscv__mmachine__@MACHINE_NAME@_a-cpu.$(OBJEXT) \
 	src/libriscv__mmachine__@MACHINE_NAME@_a-entry.$(OBJEXT) \
+	src/libriscv__mmachine__@MACHINE_NAME@_a-trap.$(OBJEXT) \
 	src/libriscv__mmachine__@MACHINE_NAME@_a-gpio.$(OBJEXT) \
 	src/libriscv__mmachine__@MACHINE_NAME@_a-interrupt.$(OBJEXT) \
 	src/libriscv__mmachine__@MACHINE_NAME@_a-led.$(OBJEXT) \
@@ -573,6 +574,7 @@ libriscv__mmachine__@MACHINE_NAME@_a_SOURCES = \
 	src/clock.c \
 	src/cpu.c \
 	src/entry.S \
+	src/trap.S \
 	src/gpio.c \
 	src/interrupt.c \
 	src/led.c \
@@ -876,6 +878,8 @@ src/libriscv__mmachine__@MACHINE_NAME@_a-cpu.$(OBJEXT):  \
 	src/$(am__dirstamp) src/$(DEPDIR)/$(am__dirstamp)
 src/libriscv__mmachine__@MACHINE_NAME@_a-entry.$(OBJEXT):  \
 	src/$(am__dirstamp) src/$(DEPDIR)/$(am__dirstamp)
+src/libriscv__mmachine__@MACHINE_NAME@_a-trap.$(OBJEXT):  \
+	src/$(am__dirstamp) src/$(DEPDIR)/$(am__dirstamp)
 src/libriscv__mmachine__@MACHINE_NAME@_a-gpio.$(OBJEXT):  \
 	src/$(am__dirstamp) src/$(DEPDIR)/$(am__dirstamp)
 src/libriscv__mmachine__@MACHINE_NAME@_a-interrupt.$(OBJEXT):  \
@@ -903,8 +907,6 @@ src/libriscv__mmachine__@MACHINE_NAME@_a-synchronize_harts.$(OBJEXT):  \
 src/libriscv__mmachine__@MACHINE_NAME@_a-timer.$(OBJEXT):  \
 	src/$(am__dirstamp) src/$(DEPDIR)/$(am__dirstamp)
 src/libriscv__mmachine__@MACHINE_NAME@_a-time.$(OBJEXT):  \
-	src/$(am__dirstamp) src/$(DEPDIR)/$(am__dirstamp)
-src/libriscv__mmachine__@MACHINE_NAME@_a-trap.$(OBJEXT):  \
 	src/$(am__dirstamp) src/$(DEPDIR)/$(am__dirstamp)
 src/libriscv__mmachine__@MACHINE_NAME@_a-tty.$(OBJEXT):  \
 	src/$(am__dirstamp) src/$(DEPDIR)/$(am__dirstamp)

--- a/src/entry.S
+++ b/src/entry.S
@@ -80,18 +80,6 @@ _enter:
 
     .cfi_endproc
 
-/* For sanity's sake we set up an early trap vector that just does nothing.  If
- * you end up here then there's a bug in the early boot code somewhere. */
-.section .text.metal.init.trapvec
-.align 2
-early_trap_vector:
-    .cfi_startproc
-    csrr t0, mcause
-    csrr t1, mepc
-    csrr t2, mtval
-    j early_trap_vector
-    .cfi_endproc
-
 /* The GCC port might not emit a __register_frame_info symbol, which eventually
  * results in a weak undefined reference that eventually causes crash when it
  * is dereference early in boot.  We really shouldn't need to put this here,

--- a/src/trap.S
+++ b/src/trap.S
@@ -51,3 +51,18 @@ _metal_trap:
     /* Jump to mtvec */
     jr t0
 
+
+/*
+ * For sanity's sake we set up an early trap vector that just does nothing.
+ * If you end up here then there's a bug in the early boot code somewhere.
+ */
+.section .text.metal.init.trapvec
+.global early_trap_vector
+.align 2
+early_trap_vector:
+    .cfi_startproc
+    csrr t0, mcause
+    csrr t1, mepc
+    csrr t2, mtval
+    j early_trap_vector
+    .cfi_endproc


### PR DESCRIPTION
We got some discussion on #161 . In some cases, when user call the interrupt initial API, it would overwrite the mtvec which holds the user's trap handler.
These patches contains adding the condition for the mtvec assignment, and separating early_trap_vector to trap.S to ensure that we only link the stuff we needed.