### PR TITLE
Support multi-core of PLIC driver

### DIFF
--- a/metal/interrupt.h
+++ b/metal/interrupt.h
@@ -256,8 +256,8 @@ __inline__ int metal_interrupt_disable(struct metal_interrupt *controller,
  * @param threshold The interrupt threshold level
  * @return 0 upon success
  */
-inline int metal_interrupt_set_threshold(struct metal_interrupt *controller,
-                                         unsigned int level) {
+__inline__ int metal_interrupt_set_threshold(struct metal_interrupt *controller,
+                                             unsigned int level) {
     return controller->vtable->interrupt_set_threshold(controller, level);
 }
 
@@ -266,7 +266,7 @@ inline int metal_interrupt_set_threshold(struct metal_interrupt *controller,
  * @param controller The handle for the interrupt controller
  * @return The interrupt threshold level
  */
-inline unsigned int
+__inline__ unsigned int
 metal_interrupt_get_threshold(struct metal_interrupt *controller) {
     return controller->vtable->interrupt_get_threshold(controller);
 }
@@ -278,8 +278,8 @@ metal_interrupt_get_threshold(struct metal_interrupt *controller) {
  * @param priority The interrupt priority level
  * @return 0 upon success
  */
-inline int metal_interrupt_set_priority(struct metal_interrupt *controller,
-                                        int id, unsigned int priority) {
+__inline__ int metal_interrupt_set_priority(struct metal_interrupt *controller,
+                                            int id, unsigned int priority) {
     return controller->vtable->interrupt_set_priority(controller, id, priority);
 }
 
@@ -289,7 +289,7 @@ inline int metal_interrupt_set_priority(struct metal_interrupt *controller,
  * @param id The interrupt ID to enable
  * @return The interrupt priority level
  */
-inline unsigned int
+__inline__ unsigned int
 metal_interrupt_get_priority(struct metal_interrupt *controller, int id) {
     return controller->vtable->interrupt_get_priority(controller, id);
 }

--- a/src/drivers/riscv_plic0.c
+++ b/src/drivers/riscv_plic0.c
@@ -26,8 +26,8 @@ void __metal_plic0_complete_interrupt(struct __metal_driver_riscv_plic0 *plic,
         (__metal_io_u32 *)(control_base + METAL_RISCV_PLIC0_CLAIM)) = id;
 }
 
-int __metal_driver_riscv_plic0_set_threshold(struct metal_interrupt *controller,
-                                             unsigned int threshold) {
+int __metal_plic0_set_threshold(struct metal_interrupt *controller,
+                                unsigned int threshold) {
     unsigned long control_base =
         __metal_driver_sifive_plic0_control_base(controller);
     __METAL_ACCESS_ONCE(
@@ -36,8 +36,7 @@ int __metal_driver_riscv_plic0_set_threshold(struct metal_interrupt *controller,
     return 0;
 }
 
-unsigned int
-__metal_driver_riscv_plic0_get_threshold(struct metal_interrupt *controller) {
+unsigned int __metal_plic0_get_threshold(struct metal_interrupt *controller) {
     unsigned long control_base =
         __metal_driver_sifive_plic0_control_base(controller);
 
@@ -187,6 +186,16 @@ int __metal_driver_riscv_plic0_disable(struct metal_interrupt *controller,
     }
     __metal_plic0_enable(plic, id, METAL_DISABLE);
     return 0;
+}
+
+int __metal_driver_riscv_plic0_set_threshold(struct metal_interrupt *controller,
+                                             unsigned int threshold) {
+    return __metal_plic0_set_threshold(controller, threshold);
+}
+
+unsigned int
+__metal_driver_riscv_plic0_get_threshold(struct metal_interrupt *controller) {
+    return __metal_plic0_get_threshold(controller);
 }
 
 __METAL_DEFINE_VTABLE(__metal_driver_vtable_riscv_plic0) = {

--- a/src/drivers/riscv_plic0.c
+++ b/src/drivers/riscv_plic0.c
@@ -6,42 +6,51 @@
 #ifdef METAL_RISCV_PLIC0
 
 #include <metal/drivers/riscv_plic0.h>
+#include <metal/interrupt.h>
 #include <metal/io.h>
 #include <metal/machine.h>
 #include <metal/shutdown.h>
 
 unsigned int
-__metal_plic0_claim_interrupt(struct __metal_driver_riscv_plic0 *plic) {
+__metal_plic0_claim_interrupt(struct __metal_driver_riscv_plic0 *plic,
+                              int context_id) {
     unsigned long control_base = __metal_driver_sifive_plic0_control_base(
         (struct metal_interrupt *)plic);
     return __METAL_ACCESS_ONCE(
-        (__metal_io_u32 *)(control_base + METAL_RISCV_PLIC0_CLAIM));
+        (__metal_io_u32 *)(control_base + METAL_RISCV_PLIC0_CONTEXT_BASE +
+                           (context_id * METAL_RISCV_PLIC0_CONTEXT_PER_HART) +
+                           METAL_RISCV_PLIC0_CONTEXT_CLAIM));
 }
 
 void __metal_plic0_complete_interrupt(struct __metal_driver_riscv_plic0 *plic,
-                                      unsigned int id) {
+                                      int context_id, unsigned int id) {
     unsigned long control_base = __metal_driver_sifive_plic0_control_base(
         (struct metal_interrupt *)plic);
     __METAL_ACCESS_ONCE(
-        (__metal_io_u32 *)(control_base + METAL_RISCV_PLIC0_CLAIM)) = id;
+        (__metal_io_u32 *)(control_base + METAL_RISCV_PLIC0_CONTEXT_BASE +
+                           (context_id * METAL_RISCV_PLIC0_CONTEXT_PER_HART) +
+                           METAL_RISCV_PLIC0_CONTEXT_CLAIM)) = id;
 }
 
 int __metal_plic0_set_threshold(struct metal_interrupt *controller,
-                                unsigned int threshold) {
+                                int context_id, unsigned int threshold) {
     unsigned long control_base =
         __metal_driver_sifive_plic0_control_base(controller);
     __METAL_ACCESS_ONCE(
-        (__metal_io_u32 *)(control_base + METAL_RISCV_PLIC0_THRESHOLD)) =
-        threshold;
+        (__metal_io_u32 *)(control_base + METAL_RISCV_PLIC0_CONTEXT_BASE +
+                           (context_id * METAL_RISCV_PLIC0_CONTEXT_PER_HART) +
+                           METAL_RISCV_PLIC0_CONTEXT_THRESHOLD)) = threshold;
     return 0;
 }
 
-unsigned int __metal_plic0_get_threshold(struct metal_interrupt *controller) {
+unsigned int __metal_plic0_get_threshold(struct metal_interrupt *controller,
+                                         int context_id) {
     unsigned long control_base =
         __metal_driver_sifive_plic0_control_base(controller);
-
     return __METAL_ACCESS_ONCE(
-        (__metal_io_u32 *)(control_base + METAL_RISCV_PLIC0_THRESHOLD));
+        (__metal_io_u32 *)(control_base + METAL_RISCV_PLIC0_CONTEXT_BASE +
+                           (context_id * METAL_RISCV_PLIC0_CONTEXT_PER_HART) +
+                           METAL_RISCV_PLIC0_CONTEXT_THRESHOLD));
 }
 
 int __metal_driver_riscv_plic0_set_priority(struct metal_interrupt *controller,
@@ -71,27 +80,33 @@ __metal_driver_riscv_plic0_get_priority(struct metal_interrupt *controller,
                            (id << METAL_PLIC_SOURCE_PRIORITY_SHIFT)));
 }
 
-void __metal_plic0_enable(struct __metal_driver_riscv_plic0 *plic, int id,
-                          int enable) {
+int __metal_plic0_enable(struct __metal_driver_riscv_plic0 *plic,
+                         int context_id, int id, int enable) {
     unsigned int current;
     unsigned long control_base = __metal_driver_sifive_plic0_control_base(
         (struct metal_interrupt *)plic);
 
     current = __METAL_ACCESS_ONCE(
         (__metal_io_u32 *)(control_base + METAL_RISCV_PLIC0_ENABLE_BASE +
+                           (context_id * METAL_RISCV_PLIC0_ENABLE_PER_HART) +
                            (id >> METAL_PLIC_SOURCE_SHIFT) * 4));
     __METAL_ACCESS_ONCE(
         (__metal_io_u32 *)(control_base + METAL_RISCV_PLIC0_ENABLE_BASE +
+                           (context_id * METAL_RISCV_PLIC0_ENABLE_PER_HART) +
                            ((id >> METAL_PLIC_SOURCE_SHIFT) * 4))) =
         enable ? (current | (1 << (id & METAL_PLIC_SOURCE_MASK)))
                : (current & ~(1 << (id & METAL_PLIC_SOURCE_MASK)));
+
+    return 0;
 }
 
 void __metal_plic0_default_handler(int id, void *priv) { metal_shutdown(300); }
 
 void __metal_plic0_handler(int id, void *priv) {
     struct __metal_driver_riscv_plic0 *plic = priv;
-    unsigned int idx = __metal_plic0_claim_interrupt(plic);
+    int contextid =
+        __metal_driver_sifive_plic0_context_ids(__metal_myhart_id());
+    unsigned int idx = __metal_plic0_claim_interrupt(plic, contextid);
     unsigned int num_interrupts = __metal_driver_sifive_plic0_num_interrupts(
         (struct metal_interrupt *)plic);
 
@@ -100,7 +115,7 @@ void __metal_plic0_handler(int id, void *priv) {
                                      plic->metal_exdata_table[idx].exint_data);
     }
 
-    __metal_plic0_complete_interrupt(plic, idx);
+    __metal_plic0_complete_interrupt(plic, contextid, idx);
 }
 
 void __metal_driver_riscv_plic0_init(struct metal_interrupt *controller) {
@@ -122,14 +137,14 @@ void __metal_driver_riscv_plic0_init(struct metal_interrupt *controller) {
             intc->vtable->interrupt_init(intc);
 
             for (int i = 0; i < num_interrupts; i++) {
-                __metal_plic0_enable(plic, i, METAL_DISABLE);
+                __metal_plic0_enable(plic, parent, i, METAL_DISABLE);
                 __metal_driver_riscv_plic0_set_priority(controller, i, 0);
                 plic->metal_exint_table[i] = NULL;
                 plic->metal_exdata_table[i].sub_int = NULL;
                 plic->metal_exdata_table[i].exint_data = NULL;
             }
 
-            __metal_driver_riscv_plic0_set_threshold(controller, 0);
+            __metal_plic0_set_threshold(controller, parent, 0);
 
             /* Register plic (ext) interrupt with with parent controller */
             intc->vtable->interrupt_register(intc, line, NULL, plic);
@@ -173,7 +188,7 @@ int __metal_driver_riscv_plic0_enable(struct metal_interrupt *controller,
         return -1;
     }
 
-    __metal_plic0_enable(plic, id, METAL_ENABLE);
+    __metal_plic0_enable(plic, __metal_myhart_id(), id, METAL_ENABLE);
     return 0;
 }
 
@@ -184,18 +199,87 @@ int __metal_driver_riscv_plic0_disable(struct metal_interrupt *controller,
     if (id >= __metal_driver_sifive_plic0_num_interrupts(controller)) {
         return -1;
     }
-    __metal_plic0_enable(plic, id, METAL_DISABLE);
+    __metal_plic0_enable(plic, __metal_myhart_id(), id, METAL_DISABLE);
     return 0;
 }
 
 int __metal_driver_riscv_plic0_set_threshold(struct metal_interrupt *controller,
                                              unsigned int threshold) {
-    return __metal_plic0_set_threshold(controller, threshold);
+    return __metal_plic0_set_threshold(controller, __metal_myhart_id(),
+                                       threshold);
 }
 
 unsigned int
 __metal_driver_riscv_plic0_get_threshold(struct metal_interrupt *controller) {
-    return __metal_plic0_get_threshold(controller);
+    return __metal_plic0_get_threshold(controller, __metal_myhart_id());
+}
+
+metal_affinity
+__metal_driver_riscv_plic0_affinity_enable(struct metal_interrupt *controller,
+                                           metal_affinity bitmask, int id) {
+    metal_affinity ret;
+    int context;
+
+    struct __metal_driver_riscv_plic0 *plic = (void *)(controller);
+
+    if (id >= __metal_driver_sifive_plic0_num_interrupts(controller)) {
+        metal_affinity_set_val(ret, -1);
+        return ret;
+    }
+
+    for_each_metal_affinity(context, bitmask) {
+        if (context != 0)
+            metal_affinity_set_bit(
+                ret, context,
+                __metal_plic0_enable(plic, context, id, METAL_ENABLE));
+    }
+
+    return ret;
+}
+
+metal_affinity
+__metal_driver_riscv_plic0_affinity_disable(struct metal_interrupt *controller,
+                                            metal_affinity bitmask, int id) {
+    metal_affinity ret;
+    int context;
+
+    struct __metal_driver_riscv_plic0 *plic = (void *)(controller);
+
+    if (id >= __metal_driver_sifive_plic0_num_interrupts(controller)) {
+        metal_affinity_set_val(ret, -1);
+        return ret;
+    }
+
+    for_each_metal_affinity(context, bitmask) {
+        if (context != 0)
+            metal_affinity_set_bit(
+                ret, context,
+                __metal_plic0_enable(plic, context, id, METAL_DISABLE));
+    }
+
+    return ret;
+}
+
+metal_affinity __metal_driver_riscv_plic0_affinity_set_threshold(
+    struct metal_interrupt *controller, metal_affinity bitmask,
+    unsigned int threshold) {
+    metal_affinity ret;
+    int context;
+
+    for_each_metal_affinity(context, bitmask) {
+        if (context != 0)
+            metal_affinity_set_bit(
+                ret, context,
+                __metal_plic0_set_threshold(controller, context, threshold));
+    }
+
+    return ret;
+}
+
+unsigned int __metal_driver_riscv_plic0_affinity_get_threshold(
+    struct metal_interrupt *controller, int context_id) {
+    __metal_plic0_get_threshold(controller, context_id);
+    return 0;
 }
 
 __METAL_DEFINE_VTABLE(__metal_driver_vtable_riscv_plic0) = {
@@ -211,6 +295,14 @@ __METAL_DEFINE_VTABLE(__metal_driver_vtable_riscv_plic0) = {
         __metal_driver_riscv_plic0_get_priority,
     .plic_vtable.interrupt_set_priority =
         __metal_driver_riscv_plic0_set_priority,
+    .plic_vtable.interrupt_affinity_enable =
+        __metal_driver_riscv_plic0_affinity_enable,
+    .plic_vtable.interrupt_affinity_disable =
+        __metal_driver_riscv_plic0_affinity_disable,
+    .plic_vtable.interrupt_affinity_get_threshold =
+        __metal_driver_riscv_plic0_affinity_get_threshold,
+    .plic_vtable.interrupt_affinity_set_threshold =
+        __metal_driver_riscv_plic0_affinity_set_threshold,
 };
 
 #endif /* METAL_RISCV_PLIC0 */

--- a/src/drivers/riscv_plic0.c
+++ b/src/drivers/riscv_plic0.c
@@ -26,8 +26,8 @@ void __metal_plic0_complete_interrupt(struct __metal_driver_riscv_plic0 *plic,
         (__metal_io_u32 *)(control_base + METAL_RISCV_PLIC0_CLAIM)) = id;
 }
 
-int __metal_plic0_set_threshold(struct metal_interrupt *controller,
-                                unsigned int threshold) {
+int __metal_driver_riscv_plic0_set_threshold(struct metal_interrupt *controller,
+                                             unsigned int threshold) {
     unsigned long control_base =
         __metal_driver_sifive_plic0_control_base(controller);
     __METAL_ACCESS_ONCE(
@@ -36,7 +36,8 @@ int __metal_plic0_set_threshold(struct metal_interrupt *controller,
     return 0;
 }
 
-unsigned int __metal_plic0_get_threshold(struct metal_interrupt *controller) {
+unsigned int
+__metal_driver_riscv_plic0_get_threshold(struct metal_interrupt *controller) {
     unsigned long control_base =
         __metal_driver_sifive_plic0_control_base(controller);
 
@@ -44,8 +45,8 @@ unsigned int __metal_plic0_get_threshold(struct metal_interrupt *controller) {
         (__metal_io_u32 *)(control_base + METAL_RISCV_PLIC0_THRESHOLD));
 }
 
-int __metal_plic0_set_priority(struct metal_interrupt *controller, int id,
-                               unsigned int priority) {
+int __metal_driver_riscv_plic0_set_priority(struct metal_interrupt *controller,
+                                            int id, unsigned int priority) {
     unsigned long control_base = __metal_driver_sifive_plic0_control_base(
         (struct metal_interrupt *)controller);
     unsigned int max_priority = __metal_driver_sifive_plic0_max_priority(
@@ -60,7 +61,8 @@ int __metal_plic0_set_priority(struct metal_interrupt *controller, int id,
     return -1;
 }
 
-unsigned int __metal_plic0_get_priority(struct metal_interrupt *controller,
+unsigned int
+__metal_driver_riscv_plic0_get_priority(struct metal_interrupt *controller,
                                         int id) {
     unsigned long control_base =
         __metal_driver_sifive_plic0_control_base(controller);
@@ -122,13 +124,13 @@ void __metal_driver_riscv_plic0_init(struct metal_interrupt *controller) {
 
             for (int i = 0; i < num_interrupts; i++) {
                 __metal_plic0_enable(plic, i, METAL_DISABLE);
-                __metal_plic0_set_priority(controller, i, 0);
+                __metal_driver_riscv_plic0_set_priority(controller, i, 0);
                 plic->metal_exint_table[i] = NULL;
                 plic->metal_exdata_table[i].sub_int = NULL;
                 plic->metal_exdata_table[i].exint_data = NULL;
             }
 
-            __metal_plic0_set_threshold(controller, 0);
+            __metal_driver_riscv_plic0_set_threshold(controller, 0);
 
             /* Register plic (ext) interrupt with with parent controller */
             intc->vtable->interrupt_register(intc, line, NULL, plic);
@@ -152,11 +154,11 @@ int __metal_driver_riscv_plic0_register(struct metal_interrupt *controller,
     }
 
     if (isr) {
-        __metal_plic0_set_priority(controller, id, 2);
+        __metal_driver_riscv_plic0_set_priority(controller, id, 2);
         plic->metal_exint_table[id] = isr;
         plic->metal_exdata_table[id].exint_data = priv;
     } else {
-        __metal_plic0_set_priority(controller, id, 1);
+        __metal_driver_riscv_plic0_set_priority(controller, id, 1);
         plic->metal_exint_table[id] = __metal_plic0_default_handler;
         plic->metal_exdata_table[id].sub_int = priv;
     }
@@ -192,10 +194,14 @@ __METAL_DEFINE_VTABLE(__metal_driver_vtable_riscv_plic0) = {
     .plic_vtable.interrupt_register = __metal_driver_riscv_plic0_register,
     .plic_vtable.interrupt_enable = __metal_driver_riscv_plic0_enable,
     .plic_vtable.interrupt_disable = __metal_driver_riscv_plic0_disable,
-    .plic_vtable.interrupt_get_threshold = __metal_plic0_get_threshold,
-    .plic_vtable.interrupt_set_threshold = __metal_plic0_set_threshold,
-    .plic_vtable.interrupt_get_priority = __metal_plic0_get_priority,
-    .plic_vtable.interrupt_set_priority = __metal_plic0_set_priority,
+    .plic_vtable.interrupt_get_threshold =
+        __metal_driver_riscv_plic0_get_threshold,
+    .plic_vtable.interrupt_set_threshold =
+        __metal_driver_riscv_plic0_set_threshold,
+    .plic_vtable.interrupt_get_priority =
+        __metal_driver_riscv_plic0_get_priority,
+    .plic_vtable.interrupt_set_priority =
+        __metal_driver_riscv_plic0_set_priority,
 };
 
 #endif /* METAL_RISCV_PLIC0 */

--- a/src/interrupt.c
+++ b/src/interrupt.c
@@ -76,20 +76,6 @@ extern __inline__ int metal_interrupt_enable(struct metal_interrupt *controller,
 extern __inline__ int
 metal_interrupt_disable(struct metal_interrupt *controller, int id);
 
-extern __inline__ unsigned int
-metal_interrupt_get_threshold(struct metal_interrupt *controller);
-
-extern __inline__ int
-metal_interrupt_set_threshold(struct metal_interrupt *controller,
-                              unsigned int threshold);
-
-extern __inline__ unsigned int
-metal_interrupt_get_priority(struct metal_interrupt *controller, int id);
-
-extern __inline__ int
-metal_interrupt_set_priority(struct metal_interrupt *controller, int id,
-                             unsigned int priority);
-
 extern __inline__ int
 metal_interrupt_vector_enable(struct metal_interrupt *controller, int id);
 

--- a/src/interrupt.c
+++ b/src/interrupt.c
@@ -85,3 +85,19 @@ metal_interrupt_vector_disable(struct metal_interrupt *controller, int id);
 extern __inline__ int
 _metal_interrupt_command_request(struct metal_interrupt *controller, int cmd,
                                  void *data);
+
+extern __inline__ metal_affinity
+metal_interrupt_affinity_enable(struct metal_interrupt *controller,
+                                metal_affinity bitmask, int id);
+
+extern __inline__ metal_affinity
+metal_interrupt_affinity_disable(struct metal_interrupt *controller,
+                                 metal_affinity bitmask, int id);
+
+extern __inline__ metal_affinity
+metal_interrupt_affinity_set_threshold(struct metal_interrupt *controller,
+                                       metal_affinity bitmask,
+                                       unsigned int level);
+extern __inline__ unsigned int
+metal_interrupt_affinity_get_threshold(struct metal_interrupt *controller,
+                                       int contextid);


### PR DESCRIPTION
This patchset contains the supporting multi-core of PLIC driver. It should calculate the offset by hart context id to access the relevant region of each hart.

It would use the new stuff in metal header files which generated by freedom-devicetree-tools [PR freedom-devicetree-tools](https://github.com/sifive/freedom-devicetree-tools/pull/150).

This patchset doesn't support the multi-core of CLIC driver. In the CLIC specification, the multicore systems might have a CLIC per-core, so CLIC driver need to more other changed.

We also need to modify all test programs in freedom-e-sdk/software. All test program has own git repository, I would push the modification respectively.