### PR TITLE
Return (void *)-1 on error for sbrk

### DIFF
--- a/gloss/sys_sbrk.c
+++ b/gloss/sys_sbrk.c
@@ -20,7 +20,7 @@ char *_sbrk(ptrdiff_t incr) {
 
     /* If __heap_size == 0, we can't allocate memory on the heap */
     if (&metal_segment_heap_target_start == &metal_segment_heap_target_end) {
-        return NULL;
+        return (void *)-1;
     }
 
     /* Don't move the break past the end of the heap */
@@ -28,6 +28,7 @@ char *_sbrk(ptrdiff_t incr) {
         brk += incr;
     } else {
         brk = &metal_segment_heap_target_end;
+        return (void *)-1;
     }
 
     return old;


### PR DESCRIPTION
newlib will check the return value, it treat -1 as error, return NULL or just set it to end will made newlib thought it succeeded and then continue to use those region, that's might cause memory corruption on other memory region.