### PR TITLE
Revert "Always clear feature disable register"

### DIFF
--- a/src/entry.S
+++ b/src/entry.S
@@ -28,8 +28,11 @@ _enter:
      * the boot process. */
     la t0, early_trap_vector
     csrw mtvec, t0
-    /* Always clear the feature disable register for all cores series*/
+    /* enable chicken bit if core is bullet series*/
+    la t0, __metal_chicken_bit
+    beqz t0, 1f
     csrwi 0x7C1, 0
+1:
 
     /* There may be pre-initialization routines inside the MBI code that run in
      * C, so here we set up a C environment.  First we set up a stack pointer,


### PR DESCRIPTION
QEMU and Spike don't properly emulate this CSR and crash when we attempt
to clear it.

We can put this back when we have a solution that doesn't break our emulators, be that a workaround in devicetree tools or fixing the emulators.