### PR TITLE
Revert "Disable all plic and clic interrupts on init"

### DIFF
--- a/src/drivers/riscv_plic0.c
+++ b/src/drivers/riscv_plic0.c
@@ -5,8 +5,6 @@
 
 #ifdef METAL_RISCV_PLIC0
 
-#define PLIC0_MAX_INTERRUPTS 1024
-
 #include <metal/drivers/riscv_plic0.h>
 #include <metal/interrupt.h>
 #include <metal/io.h>
@@ -138,14 +136,12 @@ void __metal_driver_riscv_plic0_init(struct metal_interrupt *controller) {
             /* Initialize ist parent controller, aka cpu_intc. */
             intc->vtable->interrupt_init(intc);
 
-            for (int i = 0; i < PLIC0_MAX_INTERRUPTS; i++) {
+            for (int i = 0; i < num_interrupts; i++) {
                 __metal_plic0_enable(plic, parent, i, METAL_DISABLE);
                 __metal_driver_riscv_plic0_set_priority(controller, i, 0);
-                if (i < num_interrupts) {
-                    plic->metal_exint_table[i] = NULL;
-                    plic->metal_exdata_table[i].sub_int = NULL;
-                    plic->metal_exdata_table[i].exint_data = NULL;
-                }
+                plic->metal_exint_table[i] = NULL;
+                plic->metal_exdata_table[i].sub_int = NULL;
+                plic->metal_exdata_table[i].exint_data = NULL;
             }
 
             __metal_plic0_set_threshold(controller, parent, 0);

--- a/src/drivers/sifive_clic0.c
+++ b/src/drivers/sifive_clic0.c
@@ -11,8 +11,6 @@
 #include <metal/shutdown.h>
 #include <stdint.h>
 
-#define CLIC0_MAX_INTERRUPTS 4096
-
 typedef enum metal_clic_vector_ {
     METAL_CLIC_NONVECTOR = 0,
     METAL_CLIC_VECTORED = 1
@@ -498,15 +496,11 @@ void __metal_driver_sifive_clic0_init(struct metal_interrupt *controller) {
         num_subinterrupts =
             __metal_driver_sifive_clic0_num_subinterrupts(controller);
         clic->metal_mtvt_table[0] = &__metal_clic0_handler;
-        __metal_clic0_interrupt_disable(clic, 0);
-        __metal_clic0_interrupt_set_level(clic, 0, level);
-        for (int i = 1; i < CLIC0_MAX_INTERRUPTS; i++) {
-            if (i < num_subinterrupts) {
-                clic->metal_mtvt_table[i] = NULL;
-                clic->metal_exint_table[i].handler = NULL;
-                clic->metal_exint_table[i].sub_int = NULL;
-                clic->metal_exint_table[i].exint_data = NULL;
-            }
+        for (int i = 1; i < num_subinterrupts; i++) {
+            clic->metal_mtvt_table[i] = NULL;
+            clic->metal_exint_table[i].handler = NULL;
+            clic->metal_exint_table[i].sub_int = NULL;
+            clic->metal_exint_table[i].exint_data = NULL;
             __metal_clic0_interrupt_disable(clic, i);
             __metal_clic0_interrupt_set_level(clic, i, level);
         }


### PR DESCRIPTION
This breaks the CLIC driver, but we're reverting both for now to be safe.