### PR TITLE
Hook up txready in sifive_uart0

### DIFF
--- a/src/drivers/sifive_uart0.c
+++ b/src/drivers/sifive_uart0.c
@@ -73,7 +73,7 @@ int __metal_driver_sifive_uart0_rx_interrupt_disable(struct metal_uart *uart) {
 int __metal_driver_sifive_uart0_txready(struct metal_uart *uart) {
     long control_base = __metal_driver_sifive_uart0_control_base(uart);
 
-    return !((UART_REGW(METAL_SIFIVE_UART0_TXDATA) & UART_TXFULL));
+    return !!((UART_REGW(METAL_SIFIVE_UART0_TXDATA) & UART_TXFULL));
 }
 
 int __metal_driver_sifive_uart0_set_tx_watermark(struct metal_uart *uart,
@@ -107,7 +107,7 @@ size_t __metal_driver_sifive_uart0_get_rx_watermark(struct metal_uart *uart) {
 int __metal_driver_sifive_uart0_putc(struct metal_uart *uart, int c) {
     long control_base = __metal_driver_sifive_uart0_control_base(uart);
 
-    while (!__metal_driver_sifive_uart0_txready(uart)) {
+    while (__metal_driver_sifive_uart0_txready(uart) != 0) {
         /* wait */
     }
     UART_REGW(METAL_SIFIVE_UART0_TXDATA) = c;
@@ -221,6 +221,7 @@ __METAL_DEFINE_VTABLE(__metal_driver_vtable_sifive_uart0) = {
     .uart.init = __metal_driver_sifive_uart0_init,
     .uart.putc = __metal_driver_sifive_uart0_putc,
     .uart.getc = __metal_driver_sifive_uart0_getc,
+    .uart.txready = __metal_driver_sifive_uart0_txready,
     .uart.get_baud_rate = __metal_driver_sifive_uart0_get_baud_rate,
     .uart.set_baud_rate = __metal_driver_sifive_uart0_set_baud_rate,
     .uart.controller_interrupt =


### PR DESCRIPTION
There's a spot in the uart vtable for this function, but it wasn't
getting initialized. That function didn't match the required API as it
was returning 1 when not blocked and 0 when blocked instead of 0 when
not blocked and non-zero when blocked.

Signed-off-by: Keith Packard <keithp@keithp.com>