### PR TITLE
Create a ringbuffer implementation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -78,6 +78,7 @@ nobase_include_HEADERS += \
 	metal/memory.h \
 	metal/pmp.h \
 	metal/privilege.h \
+	metal/ringbuf.h \
 	metal/rtc.h \
 	metal/shutdown.h \
 	metal/spi.h \
@@ -139,6 +140,7 @@ libmetal_a_SOURCES = \
 	src/memory.c \
 	src/pmp.c \
 	src/privilege.c \
+	src/ringbuf.c \
 	src/rtc.c \
 	src/shutdown.c \
 	src/spi.c \

--- a/Makefile.in
+++ b/Makefile.in
@@ -236,11 +236,11 @@ am_libmetal_a_OBJECTS = src/drivers/fixed-clock.$(OBJEXT) \
 	src/gpio.$(OBJEXT) src/i2c.$(OBJEXT) src/init.$(OBJEXT) \
 	src/interrupt.$(OBJEXT) src/led.$(OBJEXT) src/lock.$(OBJEXT) \
 	src/memory.$(OBJEXT) src/pmp.$(OBJEXT) src/privilege.$(OBJEXT) \
-	src/rtc.$(OBJEXT) src/shutdown.$(OBJEXT) src/spi.$(OBJEXT) \
-	src/switch.$(OBJEXT) src/synchronize_harts.$(OBJEXT) \
-	src/timer.$(OBJEXT) src/time.$(OBJEXT) src/trap.$(OBJEXT) \
-	src/tty.$(OBJEXT) src/uart.$(OBJEXT) src/vector.$(OBJEXT) \
-	src/watchdog.$(OBJEXT)
+	src/ringbuf.$(OBJEXT) src/rtc.$(OBJEXT) src/shutdown.$(OBJEXT) \
+	src/spi.$(OBJEXT) src/switch.$(OBJEXT) \
+	src/synchronize_harts.$(OBJEXT) src/timer.$(OBJEXT) \
+	src/time.$(OBJEXT) src/trap.$(OBJEXT) src/tty.$(OBJEXT) \
+	src/uart.$(OBJEXT) src/vector.$(OBJEXT) src/watchdog.$(OBJEXT)
 libmetal_a_OBJECTS = $(am_libmetal_a_OBJECTS)
 AM_V_P = $(am__v_P_@AM_V@)
 am__v_P_ = $(am__v_P_@AM_DEFAULT_V@)
@@ -458,9 +458,9 @@ nobase_include_HEADERS = metal/machine.h metal/machine/inline.h \
 	metal/csr.h metal/gpio.h metal/i2c.h metal/init.h \
 	metal/interrupt.h metal/io.h metal/itim.h metal/led.h \
 	metal/lock.h metal/memory.h metal/pmp.h metal/privilege.h \
-	metal/rtc.h metal/shutdown.h metal/spi.h metal/switch.h \
-	metal/timer.h metal/time.h metal/tty.h metal/uart.h \
-	metal/watchdog.h
+	metal/ringbuf.h metal/rtc.h metal/shutdown.h metal/spi.h \
+	metal/switch.h metal/timer.h metal/time.h metal/tty.h \
+	metal/uart.h metal/watchdog.h
 
 # This will generate these sources before the compilation step
 BUILT_SOURCES = \
@@ -518,6 +518,7 @@ libmetal_a_SOURCES = \
 	src/memory.c \
 	src/pmp.c \
 	src/privilege.c \
+	src/ringbuf.c \
 	src/rtc.c \
 	src/shutdown.c \
 	src/spi.c \
@@ -811,6 +812,8 @@ src/memory.$(OBJEXT): src/$(am__dirstamp) \
 src/pmp.$(OBJEXT): src/$(am__dirstamp) src/$(DEPDIR)/$(am__dirstamp)
 src/privilege.$(OBJEXT): src/$(am__dirstamp) \
 	src/$(DEPDIR)/$(am__dirstamp)
+src/ringbuf.$(OBJEXT): src/$(am__dirstamp) \
+	src/$(DEPDIR)/$(am__dirstamp)
 src/rtc.$(OBJEXT): src/$(am__dirstamp) src/$(DEPDIR)/$(am__dirstamp)
 src/shutdown.$(OBJEXT): src/$(am__dirstamp) \
 	src/$(DEPDIR)/$(am__dirstamp)
@@ -890,6 +893,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/memory.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/pmp.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/privilege.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/ringbuf.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/rtc.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/shutdown.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/spi.Po@am__quote@

--- a/doc/sphinx/apiref/ringbuf.rst
+++ b/doc/sphinx/apiref/ringbuf.rst
@@ -1,0 +1,6 @@
+Ring Buffers
+============
+
+.. doxygenfile:: metal/ringbuf.h
+   :project: metal
+

--- a/metal/ringbuf.h
+++ b/metal/ringbuf.h
@@ -85,7 +85,7 @@ size_t metal_ringbuf_num_items(struct metal_ringbuf *rb);
  *
  * @param rb The ring buffer
  * @param val The value to append
- * @return 0 if the value is added, nonzero if no space remains
+ * @return 0 if the value is added, -ENOMEM if no space remains
  */
 int metal_ringbuf_put(struct metal_ringbuf *rb, const void *val);
 
@@ -100,7 +100,7 @@ int metal_ringbuf_put(struct metal_ringbuf *rb, const void *val);
  *
  * @param rb The ring buffer
  * @param val Stores the popped value
- * @return 0 if a value is popped, nonzero if the buffer is empty
+ * @return 0 if a value is popped, -ENODATA if the buffer is empty
  */
 int metal_ringbuf_get(struct metal_ringbuf *rb, void *val);
 
@@ -113,7 +113,7 @@ int metal_ringbuf_get(struct metal_ringbuf *rb, void *val);
  *
  * @param rb The ring buffer
  * @param val Stores the popped value
- * @return 0 if a value is peeked, nonzero if the buffer is empty
+ * @return 0 if a value is peeked, -ENODATA if the buffer is empty
  */
 int metal_ringbuf_peek(struct metal_ringbuf *rb, void *val);
 

--- a/metal/ringbuf.h
+++ b/metal/ringbuf.h
@@ -12,23 +12,27 @@
  * @brief The handle for a ring buffer
  */
 struct metal_ringbuf {
-    /* _buf points at the base of the ring buffer memory */
-    void *_buf;
-    /* _start points at the ring buffer location containing the first value to
-     * be read by metal_ringbuf_get */
-    void *_start;
-    /* _end points at the first empty location after the buffer contents */
-    void *_end;
-    /* _capacity is the number of items the ring buffer can hold */
-    size_t _capacity;
-    /* _item_size is the size of each element in the ring buffer memory */
-    size_t _item_size;
-    /* _empty is 0 when the buffer is empty, 1 otherwise. This is used to
-     * differentiate
-     * the full condition from the empty condition, for which both cases have
-     * _start == _end */
-    bool _empty;
+    /* _read is the index into _buf to begin reading from the buffer */
+    uint32_t _read;
+    /* _count is the number of elements in the buffer */
+    uint32_t _count;
+    /* _capacity is the total number of bytes in the buffer */
+    uint32_t _capacity;
+    /* A Flexible Array Member for holding the contents of the ringbuffer,
+     * requires C >= C99 and must be the last element in the struct */
+    uint8_t _buf[];
 };
+
+/*!
+ * @def METAL_RINGBUF_SIZEOF
+ * @brief Get the required size of the memory to hold a ringbuf of N bytes
+ *
+ * When allocating memory for use in `metal_ringbuf_create()`, users should use
+ * this macro to determine the amount of memory to allocate for a ring buffer
+ * capacity of `capacity` bytes.
+ */
+#define METAL_RINGBUF_SIZEOF(capacity)                                         \
+    (sizeof(struct metal_ringbuf) + (capacity))
 
 /*!
  * @def METAL_RINGBUF_DECLARE
@@ -37,15 +41,23 @@ struct metal_ringbuf {
  * Ring buffers bust be declared with METAL_RINGBUF_DECLARE to
  * allocate storage for the buffer.
  */
-#define METAL_RINGBUF_DECLARE(name, capacity, item_size)                       \
-    uint8_t __metal_ringbuf_##name##_buf[capacity * item_size];                \
-    struct metal_ringbuf name = {._buf = (void *)__metal_ringbuf_##name##_buf, \
-                                 ._start =                                     \
-                                     (void *)__metal_ringbuf_##name##_buf,     \
-                                 ._end = (void *)__metal_ringbuf_##name##_buf, \
-                                 ._capacity = capacity,                        \
-                                 ._item_size = item_size,                      \
-                                 ._empty = true};
+#define METAL_RINGBUF_DECLARE(name, capacity)                                  \
+    uint8_t                                                                    \
+        __metal_ringbuf_##name[sizeof(struct metal_ringbuf) + (capacity)] = {  \
+            0,                                                                 \
+            0,                                                                 \
+            0,                                                                 \
+            0,                                                                 \
+            0,                                                                 \
+            0,                                                                 \
+            0,                                                                 \
+            0,                                                                 \
+            (0xFF & (capacity)),                                               \
+            (0xFF & ((capacity) >> 8)),                                        \
+            (0xFF & ((capacity) >> 16)),                                       \
+            (0xFF & ((capacity) >> 24))};                                      \
+    struct __attribute__((__packed__)) metal_ringbuf *name =                   \
+        (struct metal_ringbuf *)&__metal_ringbuf_##name;
 
 /*!
  * @brief Creates a ring buffer, given the memory to hold the buffer
@@ -54,25 +66,37 @@ struct metal_ringbuf {
  * runtime
  *
  * @param rb A pointer to a struct metal_ringbuf to be initialized
- * @param buf The memory for the buffer
- * @param capacity The number of items the buffer can hold
- * @param item_size the size of each item in bytes
- * @return 0 if successfully created, -EINVAL if rb or buf are NULL
+ * @param capacity The number of bytes the buffer can hold
+ * @return 0 if successfully created, -EINVAL if rb is NULL
  */
-int metal_ringbuf_create(struct metal_ringbuf *rb, void *buf, size_t capacity,
-                         size_t item_size);
+int metal_ringbuf_create(struct metal_ringbuf *rb, uint32_t capacity);
 
 /*!
- * @brief Returns the number of items in the ring buffer
+ * @brief Returns the number of bytes in the ring buffer
  *
  * WARNING: This action is not thread-safe! If your application requires
  * thread-safety, you should wrap this method in the appropriate synchronization
  * mechanism.
  *
  * @param rb The ring buffer
- * @return the number of items in the ring buffer
+ * @return the number of bytes in the ring buffer, or -EINVAL if rb is NULL
  */
-size_t metal_ringbuf_num_items(struct metal_ringbuf *rb);
+int metal_ringbuf_num_bytes(struct metal_ringbuf *rb);
+
+/*!
+ * @brief Append a byte to the ring buffer
+ *
+ * Adds a byte to the end of the ring buffer, if space exists
+ *
+ * WARNING: This action is not thread-safe! If your application requires
+ * thread-safety, you should wrap this method in the appropriate synchronization
+ * mechanism.
+ *
+ * @param rb The ring buffer
+ * @param val The byte to append
+ * @return 0 if the value is added, -ENOMEM if no space remains
+ */
+int metal_ringbuf_put(struct metal_ringbuf *rb, uint8_t val);
 
 /*!
  * @brief Append a value to the ring buffer
@@ -85,9 +109,26 @@ size_t metal_ringbuf_num_items(struct metal_ringbuf *rb);
  *
  * @param rb The ring buffer
  * @param val The value to append
+ * @param len The size of the value in bytes
  * @return 0 if the value is added, -ENOMEM if no space remains
  */
-int metal_ringbuf_put(struct metal_ringbuf *rb, const void *val);
+int metal_ringbuf_put_bytes(struct metal_ringbuf *rb, const void *val,
+                            size_t len);
+
+/*!
+ * @brief Get a byte from the ring buffer
+ *
+ * Pops a byte off the front of the ring buffer, if the buffer is not empty
+ *
+ * WARNING: This action is not thread-safe! If your application requires
+ * thread-safety, you should wrap this method in the appropriate synchronization
+ * mechanism.
+ *
+ * @param rb The ring buffer
+ * @param val Stores the popped value
+ * @return 0 if a value is popped, -ENODATA if the buffer is empty
+ */
+int metal_ringbuf_get(struct metal_ringbuf *rb, uint8_t *val);
 
 /*!
  * @brief Get a value from the ring buffer
@@ -102,7 +143,20 @@ int metal_ringbuf_put(struct metal_ringbuf *rb, const void *val);
  * @param val Stores the popped value
  * @return 0 if a value is popped, -ENODATA if the buffer is empty
  */
-int metal_ringbuf_get(struct metal_ringbuf *rb, void *val);
+int metal_ringbuf_get_bytes(struct metal_ringbuf *rb, void *val, size_t len);
+
+/*!
+ * @brief Get a byte from the ring buffer without removing it from the buffer
+ *
+ * WARNING: This action is not thread-safe! If your application requires
+ * thread-safety, you should wrap this method in the appropriate synchronization
+ * mechanism.
+ *
+ * @param rb The ring buffer
+ * @param val Stores the popped byte
+ * @return 0 if a value is peeked, -ENODATA if the buffer is empty
+ */
+int metal_ringbuf_peek(struct metal_ringbuf *rb, uint8_t *val);
 
 /*!
  * @brief Get a value from the ring buffer without removing it from the buffer
@@ -113,8 +167,9 @@ int metal_ringbuf_get(struct metal_ringbuf *rb, void *val);
  *
  * @param rb The ring buffer
  * @param val Stores the popped value
+ * @param len The size of the value in bytes
  * @return 0 if a value is peeked, -ENODATA if the buffer is empty
  */
-int metal_ringbuf_peek(struct metal_ringbuf *rb, void *val);
+int metal_ringbuf_peek_bytes(struct metal_ringbuf *rb, void *val, size_t len);
 
 #endif /* METAL__RINGBUF_H */

--- a/metal/ringbuf.h
+++ b/metal/ringbuf.h
@@ -1,0 +1,120 @@
+/* Copyright 2019 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef METAL__RINGBUF_H
+#define METAL__RINGBUF_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/*!
+ * @brief The handle for a ring buffer
+ */
+struct metal_ringbuf {
+    /* _buf points at the base of the ring buffer memory */
+    void *_buf;
+    /* _start points at the ring buffer location containing the first value to
+     * be read by metal_ringbuf_get */
+    void *_start;
+    /* _end points at the first empty location after the buffer contents */
+    void *_end;
+    /* _capacity is the number of items the ring buffer can hold */
+    size_t _capacity;
+    /* _item_size is the size of each element in the ring buffer memory */
+    size_t _item_size;
+    /* _empty is 0 when the buffer is empty, 1 otherwise. This is used to
+     * differentiate
+     * the full condition from the empty condition, for which both cases have
+     * _start == _end */
+    bool _empty;
+};
+
+/*!
+ * @def METAL_RINGBUF_DECLARE
+ * @brief Declare a ring buffer
+ *
+ * Ring buffers bust be declared with METAL_RINGBUF_DECLARE to
+ * allocate storage for the buffer.
+ */
+#define METAL_RINGBUF_DECLARE(name, capacity, item_size)                       \
+    uint8_t __metal_ringbuf_##name##_buf[capacity * item_size];                \
+    struct metal_ringbuf name = {._buf = (void *)__metal_ringbuf_##name##_buf, \
+                                 ._start =                                     \
+                                     (void *)__metal_ringbuf_##name##_buf,     \
+                                 ._end = (void *)__metal_ringbuf_##name##_buf, \
+                                 ._capacity = capacity,                        \
+                                 ._item_size = item_size,                      \
+                                 ._empty = true};
+
+/*!
+ * @brief Creates a ring buffer, given the memory to hold the buffer
+ *
+ * This can be used in place of METAL_RINGBUF_DECLARE to create a ring buffer at
+ * runtime
+ *
+ * @param rb A pointer to a struct metal_ringbuf to be initialized
+ * @param buf The memory for the buffer
+ * @param capacity The number of items the buffer can hold
+ * @param item_size the size of each item in bytes
+ * @return 0 if successfully created, -EINVAL if rb or buf are NULL
+ */
+int metal_ringbuf_create(struct metal_ringbuf *rb, void *buf, size_t capacity,
+                         size_t item_size);
+
+/*!
+ * @brief Returns the number of items in the ring buffer
+ *
+ * WARNING: This action is not thread-safe! If your application requires
+ * thread-safety, you should wrap this method in the appropriate synchronization
+ * mechanism.
+ *
+ * @param rb The ring buffer
+ * @return the number of items in the ring buffer
+ */
+size_t metal_ringbuf_num_items(struct metal_ringbuf *rb);
+
+/*!
+ * @brief Append a value to the ring buffer
+ *
+ * Adds a value to the end of the ring buffer, if space exists
+ *
+ * WARNING: This action is not thread-safe! If your application requires
+ * thread-safety, you should wrap this method in the appropriate synchronization
+ * mechanism.
+ *
+ * @param rb The ring buffer
+ * @param val The value to append
+ * @return 0 if the value is added, nonzero if no space remains
+ */
+int metal_ringbuf_put(struct metal_ringbuf *rb, const void *val);
+
+/*!
+ * @brief Get a value from the ring buffer
+ *
+ * Pops a value off the front of the ring buffer, if the buffer is not empty
+ *
+ * WARNING: This action is not thread-safe! If your application requires
+ * thread-safety, you should wrap this method in the appropriate synchronization
+ * mechanism.
+ *
+ * @param rb The ring buffer
+ * @param val Stores the popped value
+ * @return 0 if a value is popped, nonzero if the buffer is empty
+ */
+int metal_ringbuf_get(struct metal_ringbuf *rb, void *val);
+
+/*!
+ * @brief Get a value from the ring buffer without removing it from the buffer
+ *
+ * WARNING: This action is not thread-safe! If your application requires
+ * thread-safety, you should wrap this method in the appropriate synchronization
+ * mechanism.
+ *
+ * @param rb The ring buffer
+ * @param val Stores the popped value
+ * @return 0 if a value is peeked, nonzero if the buffer is empty
+ */
+int metal_ringbuf_peek(struct metal_ringbuf *rb, void *val);
+
+#endif /* METAL__RINGBUF_H */

--- a/src/ringbuf.c
+++ b/src/ringbuf.c
@@ -1,0 +1,133 @@
+/* Copyright 2019 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include <string.h>
+
+#include <metal/ringbuf.h>
+
+int metal_ringbuf_create(struct metal_ringbuf *rb, void *buf, size_t capacity,
+                         size_t item_size) {
+    if (rb == NULL || buf == NULL) {
+        return -EINVAL;
+    }
+
+    rb->_buf = buf;
+    rb->_start = buf;
+    rb->_end = buf;
+    rb->_capacity = capacity;
+    rb->_item_size = item_size;
+    rb->_empty = true;
+
+    return 0;
+}
+
+size_t metal_ringbuf_num_items(struct metal_ringbuf *rb) {
+    if (rb->_start > rb->_end) {
+        /*
+         *  size = 10
+         *  empty = 0
+         *  address  0 1 2 3 4 5 6 7 8 9
+         *  buf     | |a|b|c|d| | | | | |
+         *  start      ^
+         *  end                ^
+         *  len = (end - start)
+         *      = (5 - 1)
+         *      = 4
+         */
+        return (rb->_capacity - ((rb->_start - rb->_end) / rb->_item_size));
+    } else if (rb->_start < rb->_end) {
+        /*
+         *  size = 10
+         *  empty = 0
+         *  address  0 1 2 3 4 5 6 7 8 9
+         *  buf     |d| | | | | | |a|b|c|
+         *  start                  ^
+         *  end        ^
+         *  len = size - (start - end)
+         *      = 10 - (7 - 1)
+         *      = 4
+         */
+        return ((rb->_end - rb->_start) / rb->_item_size);
+    } else if (!rb->_empty) {
+        /*
+         *  size = 10
+         *  empty = 0
+         *  address  0 1 2 3 4 5 6 7 8 9
+         *  buf     |d|e|f|g|h|i|j|a|b|c|
+         *  start                  ^
+         *  end                    ^
+         *  len = size
+         */
+        return rb->_capacity;
+    }
+    /*
+     *  size = 10
+     *  empty = 1
+     *  address  0 1 2 3 4 5 6 7 8 9
+     *  buf     | | | | | | | | | | |
+     *  start                  ^
+     *  end                    ^
+     *  len = 0
+     */
+    return 0;
+}
+
+int metal_ringbuf_put(struct metal_ringbuf *rb, const void *val) {
+    size_t len = metal_ringbuf_num_items(rb);
+    if (len == rb->_capacity) {
+        /* buffer is full */
+        return 1;
+    }
+
+    /* write to the buffer */
+    memcpy(rb->_end, val, rb->_item_size);
+
+    if (len == 0) {
+        /* mark the buffer as no longer empty */
+        rb->_empty = false;
+    }
+
+    /* increment the end pointer, wrapping if we've hit the end of the buffer */
+    if (rb->_end == (rb->_buf + ((rb->_capacity - 1) * rb->_item_size))) {
+        rb->_end = rb->_buf;
+    } else {
+        rb->_end += rb->_item_size;
+    }
+
+    return 0;
+}
+
+int metal_ringbuf_get(struct metal_ringbuf *rb, void *val) {
+    if (rb->_empty) {
+        return 1;
+    }
+
+    /* read from the buffer */
+    memcpy(val, rb->_start, rb->_item_size);
+
+    /* increment the start pointer, wrapping if we've hit the end of the buffer
+     */
+    if (rb->_start == (rb->_buf + ((rb->_capacity - 1) * rb->_item_size))) {
+        rb->_start = rb->_buf;
+    } else {
+        rb->_start += rb->_item_size;
+    }
+
+    if (rb->_start == rb->_end) {
+        /* mark the buffer as now empty */
+        rb->_empty = true;
+    }
+
+    return 0;
+}
+
+int metal_ringbuf_peek(struct metal_ringbuf *rb, void *val) {
+    if (rb->_empty) {
+        return 1;
+    }
+
+    /* read from the buffer */
+    memcpy(val, rb->_start, rb->_item_size);
+
+    return 0;
+}

--- a/src/ringbuf.c
+++ b/src/ringbuf.c
@@ -1,6 +1,7 @@
 /* Copyright 2019 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 
+#include <errno.h>
 #include <string.h>
 
 #include <metal/ringbuf.h>
@@ -22,6 +23,9 @@ int metal_ringbuf_create(struct metal_ringbuf *rb, void *buf, size_t capacity,
 }
 
 size_t metal_ringbuf_num_items(struct metal_ringbuf *rb) {
+    if (rb == NULL) {
+        return -EINVAL;
+    }
     if (rb->_start > rb->_end) {
         /*
          *  size = 10
@@ -73,10 +77,13 @@ size_t metal_ringbuf_num_items(struct metal_ringbuf *rb) {
 }
 
 int metal_ringbuf_put(struct metal_ringbuf *rb, const void *val) {
+    if (rb == NULL || val == NULL) {
+        return -EINVAL;
+    }
     size_t len = metal_ringbuf_num_items(rb);
     if (len == rb->_capacity) {
         /* buffer is full */
-        return 1;
+        return -ENOMEM;
     }
 
     /* write to the buffer */
@@ -98,8 +105,11 @@ int metal_ringbuf_put(struct metal_ringbuf *rb, const void *val) {
 }
 
 int metal_ringbuf_get(struct metal_ringbuf *rb, void *val) {
+    if (rb == NULL || val == NULL) {
+        return -EINVAL;
+    }
     if (rb->_empty) {
-        return 1;
+        return -ENODATA;
     }
 
     /* read from the buffer */
@@ -122,8 +132,11 @@ int metal_ringbuf_get(struct metal_ringbuf *rb, void *val) {
 }
 
 int metal_ringbuf_peek(struct metal_ringbuf *rb, void *val) {
+    if (rb == NULL || val == NULL) {
+        return -EINVAL;
+    }
     if (rb->_empty) {
-        return 1;
+        return -ENODATA;
     }
 
     /* read from the buffer */

--- a/src/ringbuf.c
+++ b/src/ringbuf.c
@@ -6,141 +6,113 @@
 
 #include <metal/ringbuf.h>
 
-int metal_ringbuf_create(struct metal_ringbuf *rb, void *buf, size_t capacity,
-                         size_t item_size) {
-    if (rb == NULL || buf == NULL) {
-        return -EINVAL;
-    }
-
-    rb->_buf = buf;
-    rb->_start = buf;
-    rb->_end = buf;
-    rb->_capacity = capacity;
-    rb->_item_size = item_size;
-    rb->_empty = true;
-
-    return 0;
-}
-
-size_t metal_ringbuf_num_items(struct metal_ringbuf *rb) {
+int metal_ringbuf_create(struct metal_ringbuf *rb, uint32_t capacity) {
     if (rb == NULL) {
         return -EINVAL;
     }
-    if (rb->_start > rb->_end) {
-        /*
-         *  size = 10
-         *  empty = 0
-         *  address  0 1 2 3 4 5 6 7 8 9
-         *  buf     | |a|b|c|d| | | | | |
-         *  start      ^
-         *  end                ^
-         *  len = (end - start)
-         *      = (5 - 1)
-         *      = 4
-         */
-        return (rb->_capacity - ((rb->_start - rb->_end) / rb->_item_size));
-    } else if (rb->_start < rb->_end) {
-        /*
-         *  size = 10
-         *  empty = 0
-         *  address  0 1 2 3 4 5 6 7 8 9
-         *  buf     |d| | | | | | |a|b|c|
-         *  start                  ^
-         *  end        ^
-         *  len = size - (start - end)
-         *      = 10 - (7 - 1)
-         *      = 4
-         */
-        return ((rb->_end - rb->_start) / rb->_item_size);
-    } else if (!rb->_empty) {
-        /*
-         *  size = 10
-         *  empty = 0
-         *  address  0 1 2 3 4 5 6 7 8 9
-         *  buf     |d|e|f|g|h|i|j|a|b|c|
-         *  start                  ^
-         *  end                    ^
-         *  len = size
-         */
-        return rb->_capacity;
-    }
-    /*
-     *  size = 10
-     *  empty = 1
-     *  address  0 1 2 3 4 5 6 7 8 9
-     *  buf     | | | | | | | | | | |
-     *  start                  ^
-     *  end                    ^
-     *  len = 0
-     */
+
+    rb->_read = 0;
+    rb->_count = 0;
+    rb->_capacity = capacity;
+
     return 0;
 }
 
-int metal_ringbuf_put(struct metal_ringbuf *rb, const void *val) {
-    if (rb == NULL || val == NULL) {
+int metal_ringbuf_num_bytes(struct metal_ringbuf *rb) {
+    if (rb == NULL) {
         return -EINVAL;
     }
-    size_t len = metal_ringbuf_num_items(rb);
-    if (len == rb->_capacity) {
+    return rb->_count;
+}
+
+int metal_ringbuf_put(struct metal_ringbuf *rb, uint8_t val) {
+    if (rb == NULL) {
+        return -EINVAL;
+    }
+    if (rb->_count == rb->_capacity) {
         /* buffer is full */
         return -ENOMEM;
     }
 
-    /* write to the buffer */
-    memcpy(rb->_end, val, rb->_item_size);
+    rb->_buf[(rb->_read + rb->_count) % rb->_capacity] = val;
+    rb->_count += 1;
 
-    if (len == 0) {
-        /* mark the buffer as no longer empty */
-        rb->_empty = false;
+    return 0;
+}
+
+int metal_ringbuf_put_bytes(struct metal_ringbuf *rb, const void *val,
+                            size_t len) {
+    if (rb == NULL) {
+        return -EINVAL;
+    }
+    if ((rb->_count + len) > rb->_capacity) {
+        /* buffer doesn't have enough space */
+        return -ENOMEM;
     }
 
-    /* increment the end pointer, wrapping if we've hit the end of the buffer */
-    if (rb->_end == (rb->_buf + ((rb->_capacity - 1) * rb->_item_size))) {
-        rb->_end = rb->_buf;
-    } else {
-        rb->_end += rb->_item_size;
+    const uint8_t *arr = (const uint8_t *)val;
+
+    for (size_t i = 0; i < len; i++) {
+        metal_ringbuf_put(rb, arr[i]);
     }
 
     return 0;
 }
 
-int metal_ringbuf_get(struct metal_ringbuf *rb, void *val) {
+int metal_ringbuf_get(struct metal_ringbuf *rb, uint8_t *val) {
     if (rb == NULL || val == NULL) {
         return -EINVAL;
     }
-    if (rb->_empty) {
+    if (rb->_count == 0) {
         return -ENODATA;
     }
 
-    /* read from the buffer */
-    memcpy(val, rb->_start, rb->_item_size);
+    *val = rb->_buf[rb->_read];
+    rb->_read = (rb->_read + 1) % rb->_capacity;
+    rb->_count -= 1;
 
-    /* increment the start pointer, wrapping if we've hit the end of the buffer
-     */
-    if (rb->_start == (rb->_buf + ((rb->_capacity - 1) * rb->_item_size))) {
-        rb->_start = rb->_buf;
-    } else {
-        rb->_start += rb->_item_size;
+    return 0;
+}
+
+int metal_ringbuf_get_bytes(struct metal_ringbuf *rb, void *val, size_t len) {
+    if (rb == NULL || val == NULL) {
+        return -EINVAL;
+    }
+    if (rb->_count < len) {
+        return -ENODATA;
     }
 
-    if (rb->_start == rb->_end) {
-        /* mark the buffer as now empty */
-        rb->_empty = true;
+    for (size_t i = 0; i < len; i++) {
+        metal_ringbuf_get(rb, (uint8_t *)(val + i));
     }
 
     return 0;
 }
 
-int metal_ringbuf_peek(struct metal_ringbuf *rb, void *val) {
+int metal_ringbuf_peek(struct metal_ringbuf *rb, uint8_t *val) {
     if (rb == NULL || val == NULL) {
         return -EINVAL;
     }
-    if (rb->_empty) {
+    if (rb->_count == 0) {
         return -ENODATA;
     }
 
-    /* read from the buffer */
-    memcpy(val, rb->_start, rb->_item_size);
+    *val = rb->_buf[rb->_read];
+
+    return 0;
+}
+
+int metal_ringbuf_peek_bytes(struct metal_ringbuf *rb, void *val, size_t len) {
+    if (rb == NULL || val == NULL) {
+        return -EINVAL;
+    }
+    if (rb->_count < len) {
+        return -ENODATA;
+    }
+
+    for (size_t i = 0; i < len; i++) {
+        *((uint8_t *)val + i) = rb->_buf[(rb->_read + i) & rb->_capacity];
+    }
 
     return 0;
 }


### PR DESCRIPTION
This creates a ringbuffer implementation we can use as a default buffer for asynchronous peripheral APIs.

This implementation is specifically **not thread-safe** and is intended to be replaced by the thread-safe queue implementation of the API consumer's choice which is entitled to provide thread-safety in the context of the consumer's chosen kernel.

As long as I was in here, I thought I'd throw in some error codes from `errno.h`. Any thoughts on that decision instead of the current "return random non-zero numbers on failure" of other APIs?