### PR TITLE
Fix warnings as error issues when following options applied

### DIFF
--- a/src/drivers/riscv_plic0.c
+++ b/src/drivers/riscv_plic0.c
@@ -221,7 +221,7 @@ __metal_driver_riscv_plic0_get_threshold(struct metal_interrupt *controller) {
 metal_affinity
 __metal_driver_riscv_plic0_affinity_enable(struct metal_interrupt *controller,
                                            metal_affinity bitmask, int id) {
-    metal_affinity ret;
+    metal_affinity ret = {0};
     int context;
 
     struct __metal_driver_riscv_plic0 *plic = (void *)(controller);
@@ -244,7 +244,7 @@ __metal_driver_riscv_plic0_affinity_enable(struct metal_interrupt *controller,
 metal_affinity
 __metal_driver_riscv_plic0_affinity_disable(struct metal_interrupt *controller,
                                             metal_affinity bitmask, int id) {
-    metal_affinity ret;
+    metal_affinity ret = {0};
     int context;
 
     struct __metal_driver_riscv_plic0 *plic = (void *)(controller);
@@ -267,7 +267,7 @@ __metal_driver_riscv_plic0_affinity_disable(struct metal_interrupt *controller,
 metal_affinity __metal_driver_riscv_plic0_affinity_set_threshold(
     struct metal_interrupt *controller, metal_affinity bitmask,
     unsigned int threshold) {
-    metal_affinity ret;
+    metal_affinity ret = {0};
     int context;
 
     for_each_metal_affinity(context, bitmask) {

--- a/src/i2c.c
+++ b/src/i2c.c
@@ -19,7 +19,7 @@ extern inline int metal_i2c_get_baud_rate(struct metal_i2c *i2c);
 extern inline int metal_i2c_set_baud_rate(struct metal_i2c *i2c, int baud_rate);
 
 struct metal_i2c *metal_i2c_get_device(int device_num) {
-    if (device_num >= __METAL_DT_MAX_I2CS) {
+    if (device_num >= __METAL_DT_MAX_I2CS || device_num < 0) {
         return NULL;
     }
 

--- a/src/i2c.c
+++ b/src/i2c.c
@@ -19,9 +19,10 @@ extern inline int metal_i2c_get_baud_rate(struct metal_i2c *i2c);
 extern inline int metal_i2c_set_baud_rate(struct metal_i2c *i2c, int baud_rate);
 
 struct metal_i2c *metal_i2c_get_device(int device_num) {
-    if (device_num >= __METAL_DT_MAX_I2CS || device_num < 0) {
-        return NULL;
+#if __METAL_DT_MAX_I2CS > 0
+    if (device_num < __METAL_DT_MAX_I2CS) {
+        return (struct metal_i2c *)__metal_i2c_table[device_num];
     }
-
-    return (struct metal_i2c *)__metal_i2c_table[device_num];
+#endif
+    return NULL;
 }


### PR DESCRIPTION
Fix warning as error issues when following options applied:

-std=c99 -Wall -Wextra -Werror -Wpedantic -Werror -Wno-unused-parameter