### PR TITLE
Fix PLL selector polarity check

### DIFF
--- a/src/drivers/sifive_fe310-g000_pll.c
+++ b/src/drivers/sifive_fe310-g000_pll.c
@@ -173,7 +173,7 @@ void __metal_driver_sifive_fe310_g000_pll_init(
 
     /* If we're running off of the PLL, switch off before we start configuring
      * it*/
-    if ((__METAL_ACCESS_ONCE(pllcfg) & PLL_SEL) == 0)
+    if ((__METAL_ACCESS_ONCE(pllcfg) & PLL_SEL) != 0)
         __METAL_ACCESS_ONCE(pllcfg) &= ~(PLL_SEL);
 
     /* Make sure we're running off of the external oscillator for stability */


### PR DESCRIPTION
We want to clear the PLL_SEL bit iff it's set, so check if the value is nonzero before clearing.

Fixes #210