### PR TITLE
[v19.08 Backport] Fix PLL selector polarity check

### DIFF
--- a/src/drivers/sifive_fe310-g000_pll.c
+++ b/src/drivers/sifive_fe310-g000_pll.c
@@ -165,7 +165,7 @@ void __metal_driver_sifive_fe310_g000_pll_init(struct __metal_driver_sifive_fe31
     _metal_clock_call_all_callbacks(pll->clock._pre_rate_change_callback);
 
     /* If we're running off of the PLL, switch off before we start configuring it*/
-    if((__METAL_ACCESS_ONCE(pllcfg) & PLL_SEL) == 0)
+    if ((__METAL_ACCESS_ONCE(pllcfg) & PLL_SEL) != 0)
         __METAL_ACCESS_ONCE(pllcfg) &= ~(PLL_SEL);
 
     /* Make sure we're running off of the external oscillator for stability */


### PR DESCRIPTION
We want to clear the PLL_SEL bit iff it's set, so check if the value is nonzero before clearing.

This fix needs backported so that it gets picked up on the current default branch. It shouldn't affect support for Core Designer because none of those targets have an FE310 PLL.