### PR TITLE
Wait 100usec before testing FE310 PLL for lock

### DIFF
--- a/metal/drivers/riscv_clint0.h
+++ b/metal/drivers/riscv_clint0.h
@@ -21,4 +21,7 @@ struct __metal_driver_riscv_clint0 {
 };
 #undef __METAL_MACHINE_MACROS
 
+int __metal_driver_riscv_clint0_command_request(
+    struct metal_interrupt *controller, int command, void *data);
+
 #endif

--- a/metal/drivers/sifive_clic0.h
+++ b/metal/drivers/sifive_clic0.h
@@ -42,4 +42,7 @@ struct __metal_driver_sifive_clic0 {
 };
 #undef __METAL_MACHINE_MACROS
 
+int __metal_driver_sifive_clic0_command_request(
+    struct metal_interrupt *controller, int command, void *data);
+
 #endif


### PR DESCRIPTION
The FE310 PLL needs 100 usec to stabilize before testing the lock signal. This solution assumes that mtime is driven at 32768 Hz for all targets with the FE310 PLL.

Should this be backported to v19.08?

Fixes #213 