### PR TITLE
Update autoconf_wrapper argument parsing with correct number of arguments.

### DIFF
--- a/scripts/autoconf_wrapper
+++ b/scripts/autoconf_wrapper
@@ -2,7 +2,7 @@
 
 set -e
 
-if [ "$#" -ne 7 ]; then
+if [ "$#" -ne 5 ]; then
   echo "Illegal number of parameters" >&2
   exit 1
 fi


### PR DESCRIPTION
Fixes https://github.com/sifive/freedom-metal/issues/212.

Assuming that I correctly understand the problem, which I commented [here](https://github.com/sifive/freedom-metal/issues/212#issuecomment-572673009), I think this is just a one-character fix. The tl;dr is that when `autoconf_wrapper` was refactored to take in different arguments, the `if` statement at the top of the file wasn't updated with the new expected number of arguments.

Note that I have done absolutely zero testing of this, but I wanted to propose this PR to expedite the process of getting this fixed if it's the correct fix.