### PR TITLE
Correct logic for detecting external low frequency clock

### DIFF
--- a/src/drivers/sifive_fe310-g000_lfrosc.c
+++ b/src/drivers/sifive_fe310-g000_lfrosc.c
@@ -33,7 +33,9 @@ long __metal_driver_sifive_fe310_g000_lfrosc_get_rate_hz(
     unsigned long int mux_reg =
         __metal_driver_sifive_fe310_g000_lfrosc_mux_reg(clock);
 
-    if (LFROSC_REGW(mux_reg) & METAL_LFCLKMUX_EXT_MUX_STATUS) {
+    if ((mux_reg != 0) &&
+        (!(LFROSC_REGW(mux_reg) & METAL_LFCLKMUX_EXT_MUX_STATUS) ||
+         (LFROSC_REGW(mux_reg) & METAL_LFCLKMUX_SEL))) {
         return metal_clock_get_rate_hz(external_ref);
     }
 


### PR DESCRIPTION
Part of a solution to #238, tested on Sifive HiFive1 RevB. Also adds logic for using the LFCLKMUX_SEL register which is active high instead, but as the RevB has the EXT_MUX tied to ground permanently and that mux takes priority, I cannot test that condition.