### PR TITLE
Refine Makefile.am and Makefile.in

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -138,7 +138,6 @@ libmetal_a_SOURCES = \
 	src/cpu.c \
 	src/entry.S \
 	src/scrub.S \
-	src/trap.S \
 	src/gpio.c \
 	src/hpm.c \
 	src/i2c.c \

--- a/Makefile.in
+++ b/Makefile.in
@@ -261,15 +261,14 @@ am_libmetal_a_OBJECTS = src/drivers/fixed-clock.$(OBJEXT) \
 	src/drivers/ucb_htif0.$(OBJEXT) src/atomic.$(OBJEXT) \
 	src/button.$(OBJEXT) src/cache.$(OBJEXT) src/clock.$(OBJEXT) \
 	src/cpu.$(OBJEXT) src/entry.$(OBJEXT) src/scrub.$(OBJEXT) \
-	src/trap.$(OBJEXT) src/gpio.$(OBJEXT) src/hpm.$(OBJEXT) \
-	src/i2c.$(OBJEXT) src/init.$(OBJEXT) src/interrupt.$(OBJEXT) \
-	src/led.$(OBJEXT) src/lock.$(OBJEXT) src/memory.$(OBJEXT) \
-	src/pmp.$(OBJEXT) src/privilege.$(OBJEXT) src/pwm.$(OBJEXT) \
-	src/rtc.$(OBJEXT) src/shutdown.$(OBJEXT) src/spi.$(OBJEXT) \
-	src/switch.$(OBJEXT) src/synchronize_harts.$(OBJEXT) \
-	src/timer.$(OBJEXT) src/time.$(OBJEXT) src/trap.$(OBJEXT) \
-	src/tty.$(OBJEXT) src/uart.$(OBJEXT) src/vector.$(OBJEXT) \
-	src/watchdog.$(OBJEXT)
+	src/gpio.$(OBJEXT) src/hpm.$(OBJEXT) src/i2c.$(OBJEXT) \
+	src/init.$(OBJEXT) src/interrupt.$(OBJEXT) src/led.$(OBJEXT) \
+	src/lock.$(OBJEXT) src/memory.$(OBJEXT) src/pmp.$(OBJEXT) \
+	src/privilege.$(OBJEXT) src/pwm.$(OBJEXT) src/rtc.$(OBJEXT) \
+	src/shutdown.$(OBJEXT) src/spi.$(OBJEXT) src/switch.$(OBJEXT) \
+	src/synchronize_harts.$(OBJEXT) src/timer.$(OBJEXT) \
+	src/time.$(OBJEXT) src/trap.$(OBJEXT) src/tty.$(OBJEXT) \
+	src/uart.$(OBJEXT) src/vector.$(OBJEXT) src/watchdog.$(OBJEXT)
 libmetal_a_OBJECTS = $(am_libmetal_a_OBJECTS)
 AM_V_P = $(am__v_P_@AM_V@)
 am__v_P_ = $(am__v_P_@AM_DEFAULT_V@)
@@ -543,7 +542,6 @@ libmetal_a_SOURCES = \
 	src/cpu.c \
 	src/entry.S \
 	src/scrub.S \
-	src/trap.S \
 	src/gpio.c \
 	src/hpm.c \
 	src/i2c.c \
@@ -869,7 +867,6 @@ src/clock.$(OBJEXT): src/$(am__dirstamp) src/$(DEPDIR)/$(am__dirstamp)
 src/cpu.$(OBJEXT): src/$(am__dirstamp) src/$(DEPDIR)/$(am__dirstamp)
 src/entry.$(OBJEXT): src/$(am__dirstamp) src/$(DEPDIR)/$(am__dirstamp)
 src/scrub.$(OBJEXT): src/$(am__dirstamp) src/$(DEPDIR)/$(am__dirstamp)
-src/trap.$(OBJEXT): src/$(am__dirstamp) src/$(DEPDIR)/$(am__dirstamp)
 src/gpio.$(OBJEXT): src/$(am__dirstamp) src/$(DEPDIR)/$(am__dirstamp)
 src/hpm.$(OBJEXT): src/$(am__dirstamp) src/$(DEPDIR)/$(am__dirstamp)
 src/i2c.$(OBJEXT): src/$(am__dirstamp) src/$(DEPDIR)/$(am__dirstamp)
@@ -894,6 +891,7 @@ src/synchronize_harts.$(OBJEXT): src/$(am__dirstamp) \
 	src/$(DEPDIR)/$(am__dirstamp)
 src/timer.$(OBJEXT): src/$(am__dirstamp) src/$(DEPDIR)/$(am__dirstamp)
 src/time.$(OBJEXT): src/$(am__dirstamp) src/$(DEPDIR)/$(am__dirstamp)
+src/trap.$(OBJEXT): src/$(am__dirstamp) src/$(DEPDIR)/$(am__dirstamp)
 src/tty.$(OBJEXT): src/$(am__dirstamp) src/$(DEPDIR)/$(am__dirstamp)
 src/uart.$(OBJEXT): src/$(am__dirstamp) src/$(DEPDIR)/$(am__dirstamp)
 src/vector.$(OBJEXT): src/$(am__dirstamp) \


### PR DESCRIPTION
There are two trap.S in the list, if we use '-Wl,--whole-archive' to link libmetal.a, it causes the error of multiple definition.

The error messages as follows:
/scratch/zongl/toolchain/riscv64-unknown-elf-gcc-8.3.0-2019.08.0-x86_64-linux-ubuntu14/bin/../lib/gcc/riscv64-unknown-elf/8.3.0/../../../../riscv64-unknown-elf/bin/ld: /scratch/zongl/tmp/freedom-e-sdk/bsp/freedom-e31
0-arty/install/lib/debug//libmetal.a(trap.o): in function `.L0 ':
/scratch/zongl/tmp/freedom-e-sdk/freedom-metal/src/trap.S:20: multiple definition of `_metal_trap'; /scratch/zongl/tmp/freedom-e-sdk/bsp/freedom-e310-arty/install/lib/debug//libmetal.a(trap.o):/scratch/zongl/tmp/free
dom-e-sdk/freedom-metal/src/trap.S:20: first defined here
/scratch/zongl/toolchain/riscv64-unknown-elf-gcc-8.3.0-2019.08.0-x86_64-linux-ubuntu14/bin/../lib/gcc/riscv64-unknown-elf/8.3.0/../../../../riscv64-unknown-elf/bin/ld: /scratch/zongl/tmp/freedom-e-sdk/bsp/freedom-e31
0-arty/install/lib/debug//libmetal.a(trap.o): in function `.L0 ':
/scratch/zongl/tmp/freedom-e-sdk/freedom-metal/src/trap.S:64: multiple definition of `early_trap_vector'; /scratch/zongl/tmp/freedom-e-sdk/bsp/freedom-e310-arty/install/lib/debug//libmetal.a(trap.o):/scratch/zongl/tm
p/freedom-e-sdk/freedom-metal/src/trap.S:64: first defined here