### PR TITLE
tty.c: added a nop hint to nop_putc() so that post-processing can see…

### DIFF
--- a/src/tty.c
+++ b/src/tty.c
@@ -44,7 +44,7 @@ int nop_putc(int c) __attribute__((section(".text.metal.nop.putc")));
 // look for this instruction, and use the value in a0 as the character to be
 // printed.
 int nop_putc(int c) {
-    asm volatile("slli x0,a0,0x11");
+    __asm__ volatile("slli x0,a0,0x11");
     return -1;
 }
 int metal_tty_putc(int c) __attribute__((weak, alias("nop_putc")));

--- a/src/tty.c
+++ b/src/tty.c
@@ -50,7 +50,7 @@ int nop_putc(int c) {
     // truly in a0, for easier post-processing, and so there is a single
     // 32-bit opcode to match against.
     // So explicitly ensure that the argument is placed into a0 first.
-    __asm__ volatile("mv a0, %0; slli x0,a0,0x11" :: "r"(c));
+    __asm__ volatile("mv a0, %0; slli x0,a0,0x11" ::"r"(c));
     return -1;
 }
 int metal_tty_putc(int c) __attribute__((weak, alias("nop_putc")));

--- a/src/tty.c
+++ b/src/tty.c
@@ -40,7 +40,9 @@ METAL_CONSTRUCTOR(metal_tty_init) {
  * provide a shim that eats all the characters so we can ensure that everything
  * can link to metal_tty_putc. */
 int nop_putc(int c) __attribute__((section(".text.metal.nop.putc")));
-int nop_putc(int c) { return -1; }
+// Use a customizable NOP hint instruction so that a post-processor parser can
+// look for this instruction, and use the value in a0 as the character to be printed.
+int nop_putc(int c) { asm volatile ("slli x0,a0,0x11"); return -1; }
 int metal_tty_putc(int c) __attribute__((weak, alias("nop_putc")));
 #pragma message(                                                               \
     "There is no default output device, metal_tty_putc() will throw away all input.")

--- a/src/tty.c
+++ b/src/tty.c
@@ -42,7 +42,10 @@ METAL_CONSTRUCTOR(metal_tty_init) {
 int nop_putc(int c) __attribute__((section(".text.metal.nop.putc")));
 // Use a customizable NOP hint instruction so that a post-processor parser can
 // look for this instruction, and use the value in a0 as the character to be printed.
-int nop_putc(int c) { asm volatile ("slli x0,a0,0x11"); return -1; }
+int nop_putc(int c) {
+  asm volatile ("slli x0,a0,0x11");
+  return -1;
+}
 int metal_tty_putc(int c) __attribute__((weak, alias("nop_putc")));
 #pragma message(                                                               \
     "There is no default output device, metal_tty_putc() will throw away all input.")

--- a/src/tty.c
+++ b/src/tty.c
@@ -41,10 +41,11 @@ METAL_CONSTRUCTOR(metal_tty_init) {
  * can link to metal_tty_putc. */
 int nop_putc(int c) __attribute__((section(".text.metal.nop.putc")));
 // Use a customizable NOP hint instruction so that a post-processor parser can
-// look for this instruction, and use the value in a0 as the character to be printed.
+// look for this instruction, and use the value in a0 as the character to be
+// printed.
 int nop_putc(int c) {
-  asm volatile ("slli x0,a0,0x11");
-  return -1;
+    asm volatile ("slli x0,a0,0x11");
+    return -1;
 }
 int metal_tty_putc(int c) __attribute__((weak, alias("nop_putc")));
 #pragma message(                                                               \

--- a/src/tty.c
+++ b/src/tty.c
@@ -44,7 +44,13 @@ int nop_putc(int c) __attribute__((section(".text.metal.nop.putc")));
 // look for this instruction, and use the value in a0 as the character to be
 // printed.
 int nop_putc(int c) {
-    __asm__ volatile("slli x0,a0,0x11");
+    // The ABI states that c will be passed in a0. However, under an LTO
+    // (link-time-optimizer), it may choose to optimize in ways that would
+    // break this assumption.  We want to ensure that the passed argument is
+    // truly in a0, for easier post-processing, and so there is a single
+    // 32-bit opcode to match against.
+    // So explicitly ensure that the argument is placed into a0 first.
+    __asm__ volatile("mv a0, %0; slli x0,a0,0x11" :: "r"(c));
     return -1;
 }
 int metal_tty_putc(int c) __attribute__((weak, alias("nop_putc")));

--- a/src/tty.c
+++ b/src/tty.c
@@ -44,7 +44,7 @@ int nop_putc(int c) __attribute__((section(".text.metal.nop.putc")));
 // look for this instruction, and use the value in a0 as the character to be
 // printed.
 int nop_putc(int c) {
-    asm volatile ("slli x0,a0,0x11");
+    asm volatile("slli x0,a0,0x11");
     return -1;
 }
 int metal_tty_putc(int c) __attribute__((weak, alias("nop_putc")));


### PR DESCRIPTION
… the characters being output to the serial port.

With this change, a "customizable non-reserved NOP hint" instruction (slli x0, a0, 0x11) is used, with the character to be output in the specified register. This allows a post-processing tool to find occurrences of that instruction, grab the character value out of the register fields, and output the character.

A simple awk script suffices to parse the output files. Here's a one-liner version:
awk '/inst=.01151013/{printf "%c",strtonum("0x"substr($(NF-4),21,2));}' myfile