### PR TITLE
Use PRCI/AON registers for FE310 Oscillator Drivers

### DIFF
--- a/sifive-blocks/src/drivers/sifive_fe310_g000_hfrosc.c
+++ b/sifive-blocks/src/drivers/sifive_fe310_g000_hfrosc.c
@@ -9,27 +9,30 @@
 #include <metal/generated/sifive_fe310_g000_hfrosc.h>
 #include <metal/io.h>
 
-#define CONFIG_DIVIDER 0x0000003FUL
-#define CONFIG_TRIM 0x001F0000UL
-#define CONFIG_ENABLE 0x40000000UL
-#define CONFIG_READY 0x80000000UL
+#ifndef METAL_SIFIVE_FE310_G000_PRCI
+#error No SiFive FE310-G000 PRCI available.
+#endif
 
-#define get_index(clk) ((clk).__clock_index)
+#define PRCI_HFROSCCFG_ENABLE (1 << 30)
+#define PRCI_HFROSCCFG_READY (1 << 31)
+
+#define PRCI_REGW(offset)                                                      \
+    __METAL_ACCESS_ONCE(                                                       \
+        (__metal_io_u32 *)(METAL_SIFIVE_FE310_G000_PRCI_0_BASE_ADDR +          \
+                           (offset)))
 
 uint64_t sifive_fe310_g000_hfrosc_get_rate_hz(struct metal_clock clock) {
 
-    uintptr_t base = dt_clock_data[get_index(clock)].base;
-    uint32_t cfg = __METAL_ACCESS_ONCE((__metal_io_u32 *)base);
-
-    if ((cfg & CONFIG_ENABLE) == 0)
+    if (!PRCI_REGW(METAL_SIFIVE_FE310_G000_PRCI_HFROSCCFG) &
+        PRCI_HFROSCCFG_ENABLE) {
         return 0;
-    if ((cfg & CONFIG_READY) == 0)
-        return 0;
+    }
+    while (!PRCI_REGW(METAL_SIFIVE_FE310_G000_PRCI_HFROSCCFG) &
+           PRCI_HFROSCCFG_READY)
+        ;
 
-    struct metal_clock ref = dt_clock_data[get_index(clock)].ref;
-    uint64_t ref_rate = metal_clock_get_rate_hz(clock);
-
-    return ref_rate / ((cfg & CONFIG_DIVIDER) + 1);
+    struct metal_clock ref = REF_CLOCK(clock);
+    return metal_clock_get_rate_hz(ref);
 }
 
 uint64_t sifive_fe310_g000_hfrosc_set_rate_hz(struct metal_clock clock,

--- a/sifive-blocks/templates/MANIFEST.ini
+++ b/sifive-blocks/templates/MANIFEST.ini
@@ -18,3 +18,6 @@ Compatible = sifive,gpio-switches
 
 [led]
 Compatible = sifive,gpio-leds
+
+[prci]
+Compatible = sifive,fe310-g000,prci

--- a/sifive-blocks/templates/MANIFEST.ini
+++ b/sifive-blocks/templates/MANIFEST.ini
@@ -21,3 +21,6 @@ Compatible = sifive,gpio-leds
 
 [prci]
 Compatible = sifive,fe310-g000,prci
+
+[aon]
+Compatible = sifive,aon0

--- a/sifive-blocks/templates/metal/generated/sifive_fe310_g000_hfrosc.h.j2
+++ b/sifive-blocks/templates/metal/generated/sifive_fe310_g000_hfrosc.h.j2
@@ -13,17 +13,23 @@
 
 #define __METAL_DT_NUM_SIFIVE_FE310_G000_HFROSCS {{ sifive_fe310_g000_hfroscs|length }}
 
-static const struct dt_sifive_fe310_g000_hfrosc_clock_data {
-	uintptr_t base;
-	struct metal_clock ref;
-} dt_clock_data[__METAL_DT_NUM_SIFIVE_FE310_G000_HFROSCS] = {
-	{% for clk in sifive_fe310_g000_hfroscs %}
-	{
-		.base = {{ clk.regs_by_name['config'][0] }},
-		.ref = (struct metal_clock) { {{ clk.clocks[0].id }} },
-	},
-	{% endfor %}
+{% if sifive_fe310_g000_hfroscs|length > 1 %}
+
+static const struct metal_clock ref_clocks[__METAL_DT_NUM_SIFIVE_FE310_G000_HFROSCS] = {
+{% for clk in sifive_fe310_g000_hfroscs %}
+	.ref = (struct metal_clock) { {{ clk.clocks[0].id }} },
+{% endfor %}
 };
+
+#define get_index(clock) ((clock).__clock_index)
+#define REF_CLOCK(clock) ref_clocks[get_index(clock)]
+
+{% else %}
+
+#define get_index(clock) 0
+#define REF_CLOCK(clock) ((struct metal_clock) { {{ sifive_fe310_g000_hfroscs[0].clocks[0].id }} })
+
+{% endif %}
 
 {% set driver_string = to_snakecase(sifive_fe310_g000_hfroscs[0].clocks[0].compatible[0]) %}
 {% include 'clock_dispatch.h.j2' %}

--- a/sifive-blocks/templates/metal/generated/sifive_fe310_g000_hfxosc.h.j2
+++ b/sifive-blocks/templates/metal/generated/sifive_fe310_g000_hfxosc.h.j2
@@ -13,17 +13,23 @@
 
 #define __METAL_DT_NUM_SIFIVE_FE310_G000_HFXOSCS {{ sifive_fe310_g000_hfxoscs|length }}
 
-static const struct dt_sifive_fe310_g000_hfxosc_clock_data {
-	uintptr_t base;
-	struct metal_clock ref;
-} dt_clock_data[__METAL_DT_NUM_SIFIVE_FE310_G000_HFXOSCS] = {
-	{% for clk in sifive_fe310_g000_hfxoscs %}
-	{
-		.base = {{ clk.regs_by_name['config'][0] }},
-		.ref = (struct metal_clock) { {{ clk.clocks[0].id }} },
-	},
-	{% endfor %}
+{% if sifive_fe310_g000_hfxoscs|length > 1 %}
+
+static const struct metal_clock ref_clocks[__METAL_DT_NUM_SIFIVE_FE310_G000_HFXOSCS] = {
+{% for clk in sifive_fe310_g000_hfxoscs %}
+	.ref = (struct metal_clock) { {{ clk.clocks[0].id }} },
+{% endfor %}
 };
+
+#define get_index(clock) ((clock).__clock_index)
+#define REF_CLOCK(clock) ref_clocks[get_index(clock)]
+
+{% else %}
+
+#define get_index(clock) 0
+#define REF_CLOCK(clock) ((struct metal_clock) { {{ sifive_fe310_g000_hfxoscs[0].clocks[0].id }} })
+
+{% endif %}
 
 {% set driver_string = to_snakecase(sifive_fe310_g000_hfxoscs[0].clocks[0].compatible[0]) %} 
 {% include 'clock_dispatch.h.j2' %}

--- a/sifive-blocks/templates/metal/generated/sifive_fe310_g000_lfrosc.h.j2
+++ b/sifive-blocks/templates/metal/generated/sifive_fe310_g000_lfrosc.h.j2
@@ -13,23 +13,20 @@
 
 #define __METAL_DT_NUM_SIFIVE_FE310_G000_LFROSCS {{ sifive_fe310_g000_lfroscs|length }}
 
+{% if sifive_fe310_g000_lfroscs|length > 1 %}
+
 static const struct dt_sifive_fe310_g000_lfrosc_clock_data {
-	uintptr_t config;
-	uintptr_t mux;
 	struct metal_clock lfrosc;
 	struct metal_clock psdlfaltclk;
 } dt_clock_data[__METAL_DT_NUM_SIFIVE_FE310_G000_LFROSCS] = {
 	{% for clk in sifive_fe310_g000_lfroscs %}
 	{
-		.config = {{ clk.regs_by_name["config"][0] }},
-
-		{% if "mux" in clk.regs_by_name %}
-		.mux = {{ clk.regs_by_name["mux"][0] }},
-		{% endif %}
-
 		{% if "clock_names" in clk %}
 		.lfrosc = (struct metal_clock) { {{ clk.clocks_by_name["lfrosc"].id }} },
 		.psdlfaltclk = (struct metal_clock) { {{ clk.clocks_by_name["psdlfaltclk"].id }} },
+		{% elif clk.clocks|length > 1 %}
+		.lfrosc = (struct metal_clock) { {{ clk.clocks[0].id }} },
+		.psdlfaltclk = (struct metal_clock) { {{ clk.clocks[1].id }} },
 		{% else %}
 		.lfrosc = (struct metal_clock) { {{ clk.clocks[0].id }} },
 		.psdlfaltclk = (struct metal_clock) { {{ clk.clocks[0].id }} },
@@ -37,6 +34,27 @@ static const struct dt_sifive_fe310_g000_lfrosc_clock_data {
 	},
 	{% endfor %}
 };
+
+#define get_index(clock) ((clock).__clock_index)
+#define REF_LFROSC(clock) (dt_clock_data[get_index(clock)].lfrosc)
+#define REF_PSDLFALTCLK(clock) (dt_clock_data[get_index(clock)].psdlfaltclk)
+
+{% else %}
+
+#define get_index(clock) 0
+
+{% if "clock_names" in sifive_fe310_g000_lfroscs[0] %}
+#define REF_LFROSC(clock) ((struct metal_clock) { {{ sifive_fe310_g000_lfroscs[0].clocks_by_name["lfrosc"].id }} })
+#define REF_PSDLFALTCLK(clock) ((struct metal_clock) { {{ sifive_fe310_g000_lfroscs[0].clocks_by_name["psdlfaltclk"].id }} })
+{% elif sifive_fe310_g000_lfroscs[0].clocks|length > 1 %}
+#define REF_LFROSC(clock) ((struct metal_clock) { {{ sifive_fe310_g000_lfroscs[0].clocks[0].id }} })
+#define REF_PSDLFALTCLK(clock) ((struct metal_clock) { {{ sifive_fe310_g000_lfroscs[0].clocks[1].id }} })
+{% else %}
+#define REF_LFROSC(clock) ((struct metal_clock) { {{ sifive_fe310_g000_lfroscs[0].clocks[0].id }} })
+#define REF_PSDLFALTCLK(clock) ((struct metal_clock) { {{ sifive_fe310_g000_lfroscs[0].clocks[1].id }} })
+{% endif %}
+
+{% endif %}
 
 {% set driver_string = to_snakecase(sifive_fe310_g000_lfroscs[0].clocks[0].compatible[0]) %}
 {% include 'clock_dispatch.h.j2' %}

--- a/sifive-blocks/templates/metal/generated/sifive_fe310_g000_pll.h.j2
+++ b/sifive-blocks/templates/metal/generated/sifive_fe310_g000_pll.h.j2
@@ -17,10 +17,10 @@
 
 #define __METAL_DT_NUM_SIFIVE_FE310_G000_PLLS {{ sifive_fe310_g000_plls|length }}
 
+{% if sifive_fe310_g000_plls|length > 1 %}
+
 static const struct dt_sifive_fe310_g000_pll_clock_data {
 	uint64_t init_rate;
-	uintptr_t config;
-	uintptr_t divider;
 	bool has_hfxosc;
 	struct metal_clock hfrosc;
 	struct metal_clock hfxosc;
@@ -28,8 +28,6 @@ static const struct dt_sifive_fe310_g000_pll_clock_data {
 	{% for clk in sifive_fe310_g000_plls %}
 	{
 		.init_rate = {{ clk.clock_frequency[0] }},
-		.config = {{ clk.regs_by_name["config"][0] }},
-		.divider = {{ clk.regs_by_name["divider"][0] }},
 
 	{% if "pllref" in clk.clock_names %}
 		.has_hfxosc = true,
@@ -43,6 +41,27 @@ static const struct dt_sifive_fe310_g000_pll_clock_data {
 	},
 	{% endfor %}
 };
+
+#define get_index(pll) ((pll).__clock_index)
+#define PLL_INIT_RATE(pll) dt_clock_data[get_index(pll)].init_rate
+#define PLL_HAS_HFXOSC(pll) dt_clock_data[get_index(pll)].has_hfxosc
+#define PLL_HFXOSC(pll) dt_clock_data[get_index(pll)].hfrosc
+#define PLL_HFROSC(pll) dt_clock_data[get_index(pll)].hfxosc
+
+{% else %}
+
+#define get_index(pll) 0
+#define PLL_INIT_RATE(pll) {{ sifive_fe310_g000_plls[0].clock_frequency[0] }}
+{% if 'pllref' in sifive_fe310_g000_plls[0].clock_names %}
+#define PLL_HAS_HFXOSC(pll) true
+#define PLL_HFXOSC(pll) ((struct metal_clock) { {{ sifive_fe310_g000_plls[0].clocks_by_name["pllref"].id }} })
+{% else %}
+#define PLL_HAS_HFXOSC(pll) false
+#define PLL_HFXOSC(pll) ((struct metal_clock) { 0 })
+{% endif %}
+#define PLL_HFROSC(pll) ((struct metal_clock) { {{ sifive_fe310_g000_plls[0].clocks_by_name["pllsel0"].id }} })
+
+{% endif %}
 
 {% if 'uart' in default_drivers and default_drivers['uart'] in devices %}
 {% set uarts = devices[default_drivers['uart']] %}

--- a/sifive-blocks/templates/metal/machine/sifive_aon0.h.j2
+++ b/sifive-blocks/templates/metal/machine/sifive_aon0.h.j2
@@ -1,0 +1,19 @@
+/* Copyright 2020 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef METAL__PLATFORM__SIFIVE_AON0_H
+#define METAL__PLATFORM__SIFIVE_AON0_H
+
+{% if 'sifive,aon0' in devices %}
+
+{% for aon in devices['sifive,aon0'] %}
+#define METAL_SIFIVE_AON0_{{ loop.index0 }}_BASE_ADDR {{ "0x%x" % aon.reg[0][0] }}UL
+{% endfor %}
+
+#define METAL_SIFIVE_AON0
+#define METAL_SIFIVE_AON0_LFROSCCFG 0x70UL
+#define METAL_SIFIVE_AON0_LFCLKMUX  0x7CUL
+
+{% endif %}
+
+#endif

--- a/sifive-blocks/templates/metal/machine/sifive_fe310_g000_prci.h.j2
+++ b/sifive-blocks/templates/metal/machine/sifive_fe310_g000_prci.h.j2
@@ -1,0 +1,22 @@
+/* Copyright 2020 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef METAL__PLATFORM__SIFIVE_FE310_G000_PRCI_H
+#define METAL__PLATFORM__SIFIVE_FE310_G000_PRCI_H
+
+{% if 'sifive,fe310-g000,prci' in devices %}
+
+{% for prci in devices['sifive,fe310-g000,prci'] %}
+#define METAL_SIFIVE_FE310_G000_PRCI_{{ loop.index0 }}_BASE_ADDR {{ "0x%x" % prci.reg[0][0] }}UL
+{% endfor %}
+
+#define METAL_SIFIVE_FE310_G000_PRCI
+#define METAL_SIFIVE_FE310_G000_PRCI_HFROSCCFG  0x00UL
+#define METAL_SIFIVE_FE310_G000_PRCI_HFXOSCCFG  0x04UL
+#define METAL_SIFIVE_FE310_G000_PRCI_PLLCFG     0x08UL
+#define METAL_SIFIVE_FE310_G000_PRCI_PLLOUTDIV  0x0CUL
+#define METAL_SIFIVE_FE310_G000_PRCI_PROCMONCFG 0xF0UL
+
+{% endif %}
+
+#endif


### PR DESCRIPTION
Instead of depending upon the devicetree nodes for the oscillators to point at specific memory locations in the PRCI/AON to describe their control registers, just define their registers explicitly in the platform header.