### PR TITLE
Add a nop hint to nop_putc()

### DIFF
--- a/src/tty.c
+++ b/src/tty.c
@@ -8,6 +8,18 @@
  * provide a shim that eats all the characters so we can ensure that everything
  * can link to metal_tty_putc. */
 int nop_putc(int c) __attribute__((section(".text.metal.nop.putc")));
-int nop_putc(int c) { return -1; }
+// Use a customizable NOP hint instruction so that a post-processor parser can
+// look for this instruction, and use the value in a0 as the character to be
+// printed.
+int nop_putc(int c) {
+    // The ABI states that c will be passed in a0. However, under an LTO
+    // (link-time-optimizer), it may choose to optimize in ways that would
+    // break this assumption.  We want to ensure that the passed argument is
+    // truly in a0, for easier post-processing, and so there is a single
+    // 32-bit opcode to match against.
+    // So explicitly ensure that the argument is placed into a0 first.
+    __asm__ volatile("mv a0, %0; slli x0,a0,0x11" ::"r"(c));
+    return -1;
+}
 
 int metal_tty_putc(int c) __attribute__((weak, alias("nop_putc")));


### PR DESCRIPTION
Port of #271 to Freedom Metal refactor work.

Allows standard out to be extracted from an instruction trace when no
other stdio method is available.