### PR TITLE
Add button/switch definitions that use labels

### DIFF
--- a/metal/button.h
+++ b/metal/button.h
@@ -23,13 +23,23 @@ struct metal_button {
     uint32_t __button_index;
 };
 
+#define METAL_BUTTON_NONE UINT32_MAX
+
+#define metal_button_none ((struct metal_button){METAL_BUTTON_NONE})
+
+static inline bool metal_button_is_none(struct metal_button button) {
+    return button.__button_index == METAL_BUTTON_NONE;
+}
+
 /*!
  * @brief Get a reference to a button
  *
  * @param index The button index
  * @return A handle for the button
  */
-struct metal_button metal_button_get(uint32_t index);
+static inline struct metal_button metal_button_get(uint32_t index) {
+    return ((struct metal_button){index});
+}
 
 /*!
  * @brief Returns if the button is currently pressed

--- a/metal/switch.h
+++ b/metal/switch.h
@@ -20,6 +20,14 @@ struct metal_switch {
     uint32_t __switch_index;
 };
 
+#define METAL_SWITCH_NONE UINT32_MAX
+
+#define metal_switch_none ((struct metal_switch){METAL_SWITCH_NONE})
+
+static inline bool metal_switch_is_none(struct metal_switch sw) {
+    return sw.__switch_index == METAL_SWITCH_NONE;
+}
+
 /*!
  * @brief Get a handle for a switch
  * @param index The index of the switch

--- a/sifive-blocks/src/drivers/sifive_gpio_buttons.c
+++ b/sifive-blocks/src/drivers/sifive_gpio_buttons.c
@@ -10,18 +10,24 @@
 #include <metal/gpio.h>
 
 bool sifive_gpio_buttons_is_pressed(struct metal_button button) {
+    if (metal_button_is_none(button))
+        return false;
     metal_gpio_enable_input(BUTTON_GPIO(button), BUTTON_GPIO_PIN(button));
     return metal_gpio_get_input_pin(BUTTON_GPIO(button),
                                     BUTTON_GPIO_PIN(button));
 }
 
 int sifive_gpio_buttons_enable_interrupt(struct metal_button button) {
+    if (metal_button_is_none(button))
+        return 0;
     metal_gpio_enable_input(BUTTON_GPIO(button), BUTTON_GPIO_PIN(button));
     return metal_gpio_config_interrupt(
         BUTTON_GPIO(button), BUTTON_GPIO_PIN(button), METAL_GPIO_INT_RISING);
 }
 
 int sifive_gpio_buttons_disable_interrupt(struct metal_button button) {
+    if (metal_button_is_none(button))
+        return 0;
     metal_gpio_enable_input(BUTTON_GPIO(button), BUTTON_GPIO_PIN(button));
     return metal_gpio_config_interrupt(
         BUTTON_GPIO(button), BUTTON_GPIO_PIN(button), METAL_GPIO_INT_DISABLE);

--- a/sifive-blocks/src/drivers/sifive_gpio_switches.c
+++ b/sifive-blocks/src/drivers/sifive_gpio_switches.c
@@ -9,6 +9,8 @@
 #include <metal/switch.h>
 
 bool sifive_gpio_switches_is_pressed(struct metal_switch sw) {
+    if (metal_switch_is_none(sw))
+        return false;
     if (SWITCH_HAS_GPIO(sw)) {
         metal_gpio_enable_input(SWITCH_GPIO(sw), SWITCH_GPIO_PIN(sw));
         return metal_gpio_get_input_pin(SWITCH_GPIO(sw), SWITCH_GPIO_PIN(sw));
@@ -17,6 +19,8 @@ bool sifive_gpio_switches_is_pressed(struct metal_switch sw) {
 }
 
 int sifive_gpio_switches_enable_interrupt(struct metal_switch sw) {
+    if (metal_switch_is_none(sw))
+        return -1;
     if (SWITCH_HAS_GPIO(sw)) {
         metal_gpio_enable_input(SWITCH_GPIO(sw), SWITCH_GPIO_PIN(sw));
         return metal_gpio_config_interrupt(SWITCH_GPIO(sw), SWITCH_GPIO_PIN(sw),
@@ -26,6 +30,8 @@ int sifive_gpio_switches_enable_interrupt(struct metal_switch sw) {
 }
 
 int sifive_gpio_switches_disable_interrupt(struct metal_switch sw) {
+    if (metal_switch_is_none(sw))
+        return -1;
     if (SWITCH_HAS_GPIO(sw)) {
         metal_gpio_enable_input(SWITCH_GPIO(sw), SWITCH_GPIO_PIN(sw));
         return metal_gpio_config_interrupt(SWITCH_GPIO(sw), SWITCH_GPIO_PIN(sw),

--- a/src/button.c
+++ b/src/button.c
@@ -5,11 +5,6 @@
 #include <metal/button.h>
 #include <metal/generated/button.h>
 
-struct metal_button metal_button_get(uint32_t index) {
-    assert(index < __METAL_DT_NUM_BUTTONS);
-    return (struct metal_button){index};
-}
-
 bool metal_button_is_pressed(struct metal_button button) __attribute__((weak));
 bool metal_button_is_pressed(struct metal_button button) { return false; }
 

--- a/src/switch.c
+++ b/src/switch.c
@@ -5,11 +5,6 @@
 #include <metal/generated/switch.h>
 #include <metal/switch.h>
 
-struct metal_switch metal_switch_get(uint32_t index) {
-    assert(index < __METAL_DT_NUM_SWITCHES);
-    return (struct metal_switch){index};
-}
-
 bool metal_switch_is_on(struct metal_switch sw) __attribute__((weak));
 bool metal_switch_is_on(struct metal_switch sw) { return false; }
 

--- a/templates/metal/generated/button.h.j2
+++ b/templates/metal/generated/button.h.j2
@@ -4,18 +4,24 @@
 {% include 'template_comment.h.j2' %}
 
 {% if 'button' in default_drivers and default_drivers['button'] in devices %}
+{% set buttons = devices[default_drivers['button']] %}
 #define __METAL_DT_NUM_BUTTONS {{ devices[button_compatible]|length }}
 
-{% for button in devices[default_drivers['button']] %}
+{% for button in buttons %}
     {% if 'gpios' in button %}
 #define metal_{{ to_snakecase(button.compatible[0]) }}_{{ button.id }}_interrupt_handler metal_{{ to_snakecase(button.gpios[0].compatible[0]) }}_source_{{ button.gpios[1] }}_handler
+#define metal_button_{{ to_snakecase(button.label[0]) }}_interrupt_handler metal_{{ to_snakecase(button.gpios[0].compatible[0]) }}_source_{{ button.gpios[1] }}_handler
     {% endif %}
 {% endfor %}
 
 {% set driver_string = to_snakecase(default_drivers['button']) %}
 #define metal_button_is_pressed {{ driver_string}}_is_pressed
-#define metal_buttenable_interrupt_enable_interrupt {{ driver_string }}_enable_interrupt
+#define metal_button_enable_interrupt {{ driver_string }}_enable_interrupt
 #define metal_button_disable_interrupt {{ driver_string }}_disable_interrupt
+
+{% for button in buttons %}
+#define metal_button_{{ to_snakecase(button.label[0]) }} ((struct metal_button) { {{ button.id }} })
+{% endfor %}
 
 {% else %}
 #define __METAL_DT_NUM_BUTTONS 0

--- a/templates/metal/generated/switch.h.j2
+++ b/templates/metal/generated/switch.h.j2
@@ -4,9 +4,10 @@
 {% include 'template_comment.h.j2' %}
 
 {% if 'switch' in default_drivers and default_drivers['switch'] in devices %}
+{% set switches = devices[default_drivers['switch']] %}
 #define __METAL_DT_NUM_SWITCHES {{ devices[switch_compatible]|length }}
 
-{% for switch in devices[default_drivers['switch']] %}
+{% for switch in switches %}
     {% if 'gpios' in switch %}
 #define metal_{{ to_snakecase(switch.compatible[0]) }}_{{ switch.id }}_interrupt_handler metal_{{ to_snakecase(switch.gpios[0].compatible[0]) }}_source_{{ switch.gpios[1] }}_handler
     {% elif 'interrupts_extended' in switch %}
@@ -18,6 +19,10 @@
 #define metal_switch_is_on {{ driver_string }}_is_on
 #define metal_switch_enable_interrupt {{ driver_string }}_enable_interrupt
 #define metal_switch_disable_interrupt {{ driver_string }}_disable_interrupt
+
+{% for switch in switches %}
+#define metal_switch_{{ to_snakecase(switch.label[0]) }} ((struct metal_switch) { {{ switch.id }} })
+{% endfor %}
 
 {% else %}
 #define __METAL_DT_NUM_SWITCHES 0


### PR DESCRIPTION
This creates defines for applications to use buttons and switches
by label. A DTS entry like:

	button@0 {
			compatible = "sifive,gpio-buttons";
			label = "BTN0";
			gpios = <&L12 4>;
			interrupts-extended = <&L14 4>;
			linux,code = "none";
	};

creates definitions like this:

	#define metal_button_btn0_interrupt_handler metal_sifive_gpio0_source_4_handler

	#define metal_button_btn0 ((struct metal_button) { 0 })

In code, this allows the ISR to be declared like:

	void metal_button_btn0_interrupt_handler (void);

and controlled with:

	metal_button_enable_interrupt(but0);
	...
	metal_button_disable_interrupt(but0);

Signed-off-by: Keith Packard <keithp@keithp.com>