### PR TITLE
Add enable/disable for the external interrupt

### DIFF
--- a/metal/cpu.h
+++ b/metal/cpu.h
@@ -87,6 +87,20 @@ int metal_cpu_enable_timer_interrupt(struct metal_cpu cpu);
  */
 int metal_cpu_disable_timer_interrupt(struct metal_cpu cpu);
 
+/*!
+ * @brief Enables the external interrupt for the hart
+ * @param cpu The handle for the current hart
+ * @return 0 upon success
+ */
+void metal_cpu_enable_external_interrupt();
+
+/*!
+ * @brief Diasble sthe external interrupt for the hart
+ * @param cpu The handle for the current hart
+ * @return 0 upon success
+ */
+void metal_cpu_disable_external_interrupt()
+
 /*! @brief Get the CPU cycle count timer value
  *
  * Get the value of the cycle count timer for a given CPU

--- a/metal/cpu.h
+++ b/metal/cpu.h
@@ -47,59 +47,43 @@ int metal_cpu_get_num_harts(void);
 
 /*!
  * @brief Enables the global interrupt enable for the hart
- * @param cpu The handle for the current hart
- * @return 0 upon success
  */
-int metal_cpu_enable_interrupts(struct metal_cpu cpu);
+void metal_cpu_enable_interrupts(void);
 
 /*!
  * @brief Disables the global interrupt enable for the hart
- * @param cpu The handle for the current hart
- * @return 0 upon success
  */
-int metal_cpu_disable_interrupts(struct metal_cpu cpu);
+void metal_cpu_disable_interrupts(void);
 
 /*!
  * @brief Enables the inter-process interrupt for the hart
- * @param cpu The handle for the current hart
- * @return 0 upon success
  */
-int metal_cpu_enable_ipi(struct metal_cpu cpu);
+void metal_cpu_enable_ipi(void);
 
 /*!
  * @brief Disables the inter-process interrupt for the hart
- * @param cpu The handle for the current hart
- * @return 0 upon success
  */
-int metal_cpu_disable_ipi(struct metal_cpu cpu);
+void metal_cpu_disable_ipi(void);
 
 /*!
  * @brief Enables the timer interrupt for the hart
- * @param cpu The handle for the current hart
- * @return 0 upon success
  */
-int metal_cpu_enable_timer_interrupt(struct metal_cpu cpu);
+void metal_cpu_enable_timer_interrupt(void);
 
 /*!
  * @brief Disables the timer interrupt for the hart
- * @param cpu The handle for the current hart
- * @return 0 upon success
  */
-int metal_cpu_disable_timer_interrupt(struct metal_cpu cpu);
+void metal_cpu_disable_timer_interrupt(void);
 
 /*!
  * @brief Enables the external interrupt for the hart
- * @param cpu The handle for the current hart
- * @return 0 upon success
  */
-void metal_cpu_enable_external_interrupt();
+void metal_cpu_enable_external_interrupt(void);
 
 /*!
  * @brief Diasble sthe external interrupt for the hart
- * @param cpu The handle for the current hart
- * @return 0 upon success
  */
-void metal_cpu_disable_external_interrupt()
+void metal_cpu_disable_external_interrupt(void);
 
 /*! @brief Get the CPU cycle count timer value
  *
@@ -152,7 +136,7 @@ int metal_cpu_set_mtimecmp(struct metal_cpu cpu, uint64_t time);
  * @param cpu The CPU device handle for the hart to be interrupted
  * @return 0 upon success
  */
-int metal_cpu_set_ipi(struct metal_cpu cpu);
+void metal_cpu_set_ipi(struct metal_cpu cpu);
 
 /*!
  * @brief Clear the inter-process interrupt for a hart
@@ -164,7 +148,7 @@ int metal_cpu_set_ipi(struct metal_cpu cpu);
  * @param cpu The CPU device handle for the hart to clear
  * @return 0 upon success
  */
-int metal_cpu_clear_ipi(struct metal_cpu cpu);
+void metal_cpu_clear_ipi(struct metal_cpu cpu);
 
 /*!
  * @brief Get the value of MSIP for the given hart

--- a/metal/riscv.h
+++ b/metal/riscv.h
@@ -25,9 +25,11 @@ typedef uint64_t riscv_xlen_t;
 
 #define RISCV_MIE_MSIE (1 << 3)
 #define RISCV_MIE_MTIE (1 << 7)
+#define RISCV_MIE_MEIE (1 << 11)
 
-#define RISCV_MIP_MSIE (1 << 3)
-#define RISCV_MIP_MTIE (1 << 7)
+#define RISCV_MIP_MSIP (1 << 3)
+#define RISCV_MIP_MTIP (1 << 7)
+#define RISCV_MIP_MEIP (1 << 11)
 
 #define RISCV_MISA_A_EXTENSIONS 0x0001
 #define RISCV_MISA_C_EXTENSIONS 0x0004

--- a/src/drivers/riscv_clint0.c
+++ b/src/drivers/riscv_clint0.c
@@ -12,14 +12,12 @@
     __METAL_ACCESS_ONCE((__metal_io_u32 *)(uintptr_t)(                         \
         METAL_RISCV_CLINT0_0_BASE_ADDRESS + (offset)))
 
-int metal_cpu_clear_ipi(struct metal_cpu cpu) {
+void metal_cpu_clear_ipi(struct metal_cpu cpu) {
     CLINT_REGW(METAL_RISCV_CLINT0_MSIP_BASE + (4 * cpu.__hartid)) = 0;
-    return 0;
 }
 
-int metal_cpu_set_ipi(struct metal_cpu cpu) {
+void metal_cpu_set_ipi(struct metal_cpu cpu) {
     CLINT_REGW(METAL_RISCV_CLINT0_MSIP_BASE + (4 * cpu.__hartid)) = 1;
-    return 0;
 }
 
 int metal_cpu_get_ipi(struct metal_cpu cpu) {

--- a/src/drivers/riscv_cpu.c
+++ b/src/drivers/riscv_cpu.c
@@ -87,6 +87,18 @@ int metal_cpu_disable_timer_interrupt(struct metal_cpu cpu) {
     __asm__ volatile("csrc mie, %0" ::"r"(RISCV_MIE_MTIE));
 }
 
+void metal_cpu_enable_external_interrupt()
+    __attribute__((weak));
+void metal_cpu_enable_external_interrupt() {
+    __asm__ volatile("csrs mie, %0" ::"r"(RISCV_MIE_MEIE));
+}
+
+void metal_cpu_disable_external_interrupt()
+    __attribute__((weak));
+void metal_cpu_disable_external_interrupt() {
+    __asm__ volatile("csrc mie, %0" ::"r"(RISCV_MIE_MEIE));
+}
+
 struct metal_interrupt metal_cpu_interrupt_controller(struct metal_cpu cpu) {
     return (struct metal_interrupt){cpu.__hartid};
 }

--- a/src/drivers/riscv_cpu.c
+++ b/src/drivers/riscv_cpu.c
@@ -39,63 +39,50 @@ unsigned long long metal_cpu_get_timebase(struct metal_cpu cpu) {
     return dt_cpu_data[get_hartid(cpu)].timebase;
 }
 
-uint64_t metal_cpu_get_mtime(struct metal_cpu cpu) __attribute__((weak));
-uint64_t metal_cpu_get_mtime(struct metal_cpu cpu) { return 0; }
+__attribute__((weak)) uint64_t metal_cpu_get_mtime(struct metal_cpu cpu) {
+    return 0;
+}
 
-int metal_cpu_set_mtimecmp(struct metal_cpu cpu, uint64_t time)
-    __attribute__((weak));
-int metal_cpu_set_mtimecmp(struct metal_cpu cpu, uint64_t time) { return -1; }
+__attribute__((weak)) int metal_cpu_set_mtimecmp(struct metal_cpu cpu,
+                                                 uint64_t time) {
+    return -1;
+}
 
-int metal_cpu_enable_interrupts(struct metal_cpu cpu) __attribute__((weak));
-int metal_cpu_enable_interrupts(struct metal_cpu cpu) {
+__attribute__((weak)) void metal_cpu_enable_interrupts(void) {
     __asm__ volatile("csrs mstatus, %0" ::"r"(RISCV_MSTATUS_MIE));
 }
 
-int metal_cpu_disable_interrupts(struct metal_cpu cpu) __attribute__((weak));
-int metal_cpu_disable_interrupts(struct metal_cpu cpu) {
+__attribute__((weak)) void metal_cpu_disable_interrupts(void) {
     __asm__ volatile("csrc mstatus, %0" ::"r"(RISCV_MSTATUS_MIE));
 }
 
-int metal_cpu_enable_ipi(struct metal_cpu cpu) __attribute__((weak));
-int metal_cpu_enable_ipi(struct metal_cpu cpu) {
+__attribute__((weak)) void metal_cpu_enable_ipi(void) {
     __asm__ volatile("csrs mie, %0" ::"r"(RISCV_MIE_MSIE));
 }
 
-int metal_cpu_disable_ipi(struct metal_cpu cpu) __attribute__((weak));
-int metal_cpu_disable_ipi(struct metal_cpu cpu) {
+__attribute__((weak)) void metal_cpu_disable_ipi(void) {
     __asm__ volatile("csrc mie, %0" ::"r"(RISCV_MIE_MSIE));
 }
 
-int metal_cpu_set_ipi(struct metal_cpu cpu) __attribute__((weak));
-int metal_cpu_set_ipi(struct metal_cpu cpu) { return -1; }
+__attribute__((weak)) void metal_cpu_set_ipi(struct metal_cpu cpu) {}
 
-int metal_cpu_clear_ipi(struct metal_cpu cpu) __attribute__((weak));
-int metal_cpu_clear_ipi(struct metal_cpu cpu) { return -1; }
+__attribute__((weak)) void metal_cpu_clear_ipi(struct metal_cpu cpu) {}
 
-int metal_cpu_get_ipi(struct metal_cpu cpu) __attribute__((weak));
-int metal_cpu_get_ipi(struct metal_cpu cpu) { return 0; }
+__attribute__((weak)) int metal_cpu_get_ipi(struct metal_cpu cpu) { return 0; }
 
-int metal_cpu_enable_timer_interrupt(struct metal_cpu cpu)
-    __attribute__((weak));
-int metal_cpu_enable_timer_interrupt(struct metal_cpu cpu) {
+__attribute__((weak)) void metal_cpu_enable_timer_interrupt(void) {
     __asm__ volatile("csrs mie, %0" ::"r"(RISCV_MIE_MTIE));
 }
 
-int metal_cpu_disable_timer_interrupt(struct metal_cpu cpu)
-    __attribute__((weak));
-int metal_cpu_disable_timer_interrupt(struct metal_cpu cpu) {
+__attribute__((weak)) void metal_cpu_disable_timer_interrupt(void) {
     __asm__ volatile("csrc mie, %0" ::"r"(RISCV_MIE_MTIE));
 }
 
-void metal_cpu_enable_external_interrupt()
-    __attribute__((weak));
-void metal_cpu_enable_external_interrupt() {
+__attribute__((weak)) void metal_cpu_enable_external_interrupt(void) {
     __asm__ volatile("csrs mie, %0" ::"r"(RISCV_MIE_MEIE));
 }
 
-void metal_cpu_disable_external_interrupt()
-    __attribute__((weak));
-void metal_cpu_disable_external_interrupt() {
+__attribute__((weak)) void metal_cpu_disable_external_interrupt(void) {
     __asm__ volatile("csrc mie, %0" ::"r"(RISCV_MIE_MEIE));
 }
 

--- a/src/drivers/riscv_cpu_intc.c
+++ b/src/drivers/riscv_cpu_intc.c
@@ -132,8 +132,7 @@ int riscv_cpu_intc_enable(struct metal_interrupt controller, int id) {
     return 0;
 }
 
-int riscv_cpu_intc_interrupt_disable(struct metal_interrupt controller,
-                                     int id) {
+int riscv_cpu_intc_disable(struct metal_interrupt controller, int id) {
 
     if (id >= __METAL_NUM_LOCAL_INTERRUPTS) {
         return -1;


### PR DESCRIPTION
Also makes interrupt enable/disables in the CPU API return void. Since they can operate only on the current hart, this also removes the `struct metal_cpu` parameter.