### PR TITLE
Add metal/time.h and metal/timer.h

### DIFF
--- a/metal/time.h
+++ b/metal/time.h
@@ -1,0 +1,26 @@
+/* Copyright 2019 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef METAL__TIME_H
+#define METAL__TIME_H
+
+#define _POSIX_MONOTONIC_CLOCK 200809L
+#define _POSIX_TIMERS
+#include <time.h>
+
+/*!
+ * @file time.h
+ * @brief API for dealing with time
+ */
+
+/*!
+ * @brief Get monotonic time in seconds
+ * @return time relative to unknown base in seconds
+ */
+static __inline__ time_t metal_time(void) {
+    struct timespec tp;
+    clock_gettime(CLOCK_MONOTONIC, &tp);
+    return tp.tv_sec;
+}
+
+#endif

--- a/metal/timer.h
+++ b/metal/timer.h
@@ -1,0 +1,40 @@
+/* Copyright 2018 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef METAL__TIMER_H
+#define METAL__TIMER_H
+
+#include <metal/cpu.h>
+
+/*!
+ * @file timer.h
+ * @brief API for reading and manipulating the machine timer
+ */
+
+/*!
+ * @brief Read the machine cycle count
+ * @param hartid The hart ID to read the cycle count of
+ * @param cyclecount The variable to hold the value
+ * @return 0 upon success
+ */
+static __inline__ int
+metal_timer_get_cyclecount(unsigned int hartid,
+                           unsigned long long *cyclecount) {
+    *cyclecount = metal_cpu_get_timer(metal_cpu_get(hartid));
+    return 0;
+}
+
+/*!
+ * @brief Get the machine timebase frequency
+ * @param hartid The hart ID to read the timebase of
+ * @param timebase The variable to hold the value
+ * @return 0 upon success
+ */
+static __inline__ int
+metal_timer_get_timebase_frequency(unsigned int hartid,
+                                   unsigned long long *timebase) {
+    *timebase = metal_cpu_get_timebase(metal_cpu_get(hartid));
+    return 0;
+}
+
+#endif

--- a/sifive-blocks/src/drivers/sifive_spi0.c
+++ b/sifive-blocks/src/drivers/sifive_spi0.c
@@ -9,9 +9,7 @@
 #include <metal/cpu.h>
 #include <metal/generated/sifive_spi0.h>
 #include <metal/io.h>
-#define _POSIX_MONOTONIC_CLOCK 200809L
-#define _POSIX_TIMERS
-#include <time.h>
+#include <metal/time.h>
 
 /* Register fields */
 #define METAL_SPI_SCKDIV_MASK 0xFFF
@@ -62,12 +60,6 @@ static struct {
 };
 
 #define get_index(spi) ((spi).__spi_index)
-
-static time_t metal_time(void) {
-    struct timespec tp;
-    clock_gettime(CLOCK_MONOTONIC, &tp);
-    return tp.tv_sec;
-}
 
 static int configure_spi(struct metal_spi spi,
                          struct metal_spi_config *config) {


### PR DESCRIPTION
These just wrap existing functions in a different API, so make
them static inline instead of separate functions.

Signed-off-by: Keith Packard <keithp@keithp.com>