### PR TITLE
Refactor L1 and L2 Cache APIs

### DIFF
--- a/metal/cache.h
+++ b/metal/cache.h
@@ -1,0 +1,90 @@
+/* Copyright 2018 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef METAL__CACHE_H
+#define METAL__CACHE_H
+
+/*!
+ * @file cache.h
+ *
+ * @brief API for configuring caches
+ */
+#include <stdint.h>
+
+struct metal_cache;
+
+struct __metal_cache_vtable {
+    void (*init)(struct metal_cache *cache, int ways);
+    int (*get_enabled_ways)(struct metal_cache *cache);
+    int (*set_enabled_ways)(struct metal_cache *cache, int ways);
+};
+
+/*!
+ * @brief a handle for a cache
+ */
+struct metal_cache {
+    const struct __metal_cache_vtable *vtable;
+};
+
+/*!
+ * @brief Initialize a cache
+ * @param cache The handle for the cache to initialize
+ * @param ways The number of ways to enable
+ *
+ * Initializes a cache with the requested number of ways enabled.
+ */
+__inline__ void metal_cache_init(struct metal_cache *cache, int ways) {
+    cache->vtable->init(cache, ways);
+}
+
+/*!
+ * @brief Get the current number of enabled cache ways
+ * @param cache The handle for the cache
+ * @return The current number of enabled cache ways
+ */
+__inline__ int metal_cache_get_enabled_ways(struct metal_cache *cache) {
+    return cache->vtable->get_enabled_ways(cache);
+}
+
+/*!
+ * @brief Enable the requested number of cache ways
+ * @param cache The handle for the cache
+ * @param ways The number of ways to enabled
+ * @return 0 if the ways are successfully enabled
+ */
+__inline__ int metal_cache_set_enabled_ways(struct metal_cache *cache,
+                                            int ways) {
+    return cache->vtable->set_enabled_ways(cache, ways);
+}
+
+/*!
+ * @brief Check if dcache is supported on the core
+ * @param hartid The core to check
+ * @return 1 if dcache is present
+ */
+int metal_dcache_l1_available(int hartid);
+
+/*!
+ * @brief Flush dcache for L1 on the requested core with write back
+ * @param hartid  The core to flush
+ * @param address The virtual address of cacheline to invalidate
+ * @return None
+ */
+void metal_dcache_l1_flush(int hartid, uintptr_t address);
+
+/*!
+ * @brief Discard dcache for L1 on the requested core with no write back
+ * @param hartid  The core to discard
+ * @param address The virtual address of cacheline to invalidate
+ * @return None
+ */
+void metal_dcache_l1_discard(int hartid, uintptr_t address);
+
+/*!
+ * @brief Check if icache is supported on the core
+ * @param hartid The core to check
+ * @return 1 if icache is present
+ */
+int metal_icache_l1_available(int hartid);
+
+#endif

--- a/metal/cache.h
+++ b/metal/cache.h
@@ -9,82 +9,33 @@
  *
  * @brief API for configuring caches
  */
+#include <stdbool.h>
 #include <stdint.h>
-
-struct metal_cache;
-
-struct __metal_cache_vtable {
-    void (*init)(struct metal_cache *cache, int ways);
-    int (*get_enabled_ways)(struct metal_cache *cache);
-    int (*set_enabled_ways)(struct metal_cache *cache, int ways);
-};
-
-/*!
- * @brief a handle for a cache
- */
-struct metal_cache {
-    const struct __metal_cache_vtable *vtable;
-};
-
-/*!
- * @brief Initialize a cache
- * @param cache The handle for the cache to initialize
- * @param ways The number of ways to enable
- *
- * Initializes a cache with the requested number of ways enabled.
- */
-__inline__ void metal_cache_init(struct metal_cache *cache, int ways) {
-    cache->vtable->init(cache, ways);
-}
-
-/*!
- * @brief Get the current number of enabled cache ways
- * @param cache The handle for the cache
- * @return The current number of enabled cache ways
- */
-__inline__ int metal_cache_get_enabled_ways(struct metal_cache *cache) {
-    return cache->vtable->get_enabled_ways(cache);
-}
-
-/*!
- * @brief Enable the requested number of cache ways
- * @param cache The handle for the cache
- * @param ways The number of ways to enabled
- * @return 0 if the ways are successfully enabled
- */
-__inline__ int metal_cache_set_enabled_ways(struct metal_cache *cache,
-                                            int ways) {
-    return cache->vtable->set_enabled_ways(cache, ways);
-}
 
 /*!
  * @brief Check if dcache is supported on the core
- * @param hartid The core to check
  * @return 1 if dcache is present
  */
-int metal_dcache_l1_available(int hartid);
+bool metal_dcache_l1_available(void);
 
 /*!
  * @brief Flush dcache for L1 on the requested core with write back
- * @param hartid  The core to flush
  * @param address The virtual address of cacheline to invalidate
  * @return None
  */
-void metal_dcache_l1_flush(int hartid, uintptr_t address);
+void metal_dcache_l1_flush(uintptr_t address);
 
 /*!
  * @brief Discard dcache for L1 on the requested core with no write back
- * @param hartid  The core to discard
  * @param address The virtual address of cacheline to invalidate
  * @return None
  */
-void metal_dcache_l1_discard(int hartid, uintptr_t address);
+void metal_dcache_l1_discard(uintptr_t address);
 
 /*!
  * @brief Check if icache is supported on the core
- * @param hartid The core to check
  * @return 1 if icache is present
  */
-int metal_icache_l1_available(int hartid);
+bool metal_icache_l1_available(void);
 
 #endif

--- a/metal/cache.h
+++ b/metal/cache.h
@@ -19,14 +19,14 @@
 bool metal_dcache_l1_available(void);
 
 /*!
- * @brief Flush dcache for L1 on the requested core with write back
+ * @brief Flush dcache for L1 on the current core with write back
  * @param address The virtual address of cacheline to invalidate
  * @return None
  */
 void metal_dcache_l1_flush(uintptr_t address);
 
 /*!
- * @brief Discard dcache for L1 on the requested core with no write back
+ * @brief Discard dcache for L1 on the current core with no write back
  * @param address The virtual address of cacheline to invalidate
  * @return None
  */

--- a/sifive-blocks/metal/drivers/sifive_ccache0.h
+++ b/sifive-blocks/metal/drivers/sifive_ccache0.h
@@ -1,0 +1,22 @@
+/* Copyright 2019 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef METAL__DRIVERS__SIFIVE_CCACHE0_H
+#define METAL__DRIVERS__SIFIVE_CCACHE0_H
+
+#include <metal/cache.h>
+#include <metal/compiler.h>
+
+struct __metal_driver_vtable_sifive_ccache0 {
+    struct __metal_cache_vtable cache;
+};
+
+struct __metal_driver_sifive_ccache0;
+
+__METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_ccache0)
+
+struct __metal_driver_sifive_ccache0 {
+    struct metal_cache cache;
+};
+
+#endif

--- a/sifive-blocks/metal/drivers/sifive_ccache0.h
+++ b/sifive-blocks/metal/drivers/sifive_ccache0.h
@@ -4,19 +4,24 @@
 #ifndef METAL__DRIVERS__SIFIVE_CCACHE0_H
 #define METAL__DRIVERS__SIFIVE_CCACHE0_H
 
-#include <metal/cache.h>
-#include <metal/compiler.h>
+#include <stdint.h>
 
-struct __metal_driver_vtable_sifive_ccache0 {
-    struct __metal_cache_vtable cache;
-};
+/*!
+ * @brief Initialize the SiFive L2 Cache, enabling the requested number of ways
+ * @param ways The number of ways to enable
+ */
+void sifive_ccache0_init(uint32_t ways);
 
-struct __metal_driver_sifive_ccache0;
+/*!
+ * @brief Get the number of enabled ways of the SiFive L2 Cache
+ * @return The number of enabled ways
+ */
+uint32_t sifive_ccache0_get_enabled_ways(void);
 
-__METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_ccache0)
-
-struct __metal_driver_sifive_ccache0 {
-    struct metal_cache cache;
-};
+/*!
+ * @brief Enable the requested number of ways of the Sifive L2 Cache
+ * @param ways The number of ways to enable
+ */
+uint32_t sifive_ccache0_set_enabled_ways(uint32_t ways);
 
 #endif

--- a/sifive-blocks/src/drivers/sifive_ccache0.c
+++ b/sifive-blocks/src/drivers/sifive_ccache0.c
@@ -1,0 +1,87 @@
+/* Copyright 2019 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include <metal/machine/platform.h>
+
+#ifdef METAL_SIFIVE_CCACHE0
+
+#include <metal/drivers/sifive_ccache0.h>
+#include <metal/init.h>
+#include <metal/io.h>
+#include <metal/machine.h>
+#include <stdint.h>
+
+#define L2_CONFIG_WAYS_SHIFT 8
+#define L2_CONFIG_WAYS_MASK (0xFF << L2_CONFIG_WAYS_SHIFT)
+
+void __metal_driver_sifive_ccache0_init(struct metal_cache *l2, int ways);
+
+METAL_CONSTRUCTOR(metal_driver_sifive_ccache0_init) {
+#ifdef __METAL_DT_SIFIVE_CCACHE0_HANDLE
+    /* Get the handle for the L2 cache controller */
+    struct metal_cache *l2 = __METAL_DT_SIFIVE_CCACHE0_HANDLE;
+    if (!l2) {
+        return;
+    }
+
+    /* Get the number of available ways per bank */
+    unsigned long control_base = __metal_driver_sifive_ccache0_control_base(l2);
+    uint32_t ways = __METAL_ACCESS_ONCE(
+        (__metal_io_u32 *)(control_base + METAL_SIFIVE_CCACHE0_CONFIG));
+    ways = ((ways & L2_CONFIG_WAYS_MASK) >> L2_CONFIG_WAYS_SHIFT);
+
+    /* Enable all the ways */
+    __metal_driver_sifive_ccache0_init(l2, ways);
+#endif
+}
+
+void __metal_driver_sifive_ccache0_init(struct metal_cache *l2, int ways) {
+    metal_cache_set_enabled_ways(l2, ways);
+}
+
+int __metal_driver_sifive_ccache0_get_enabled_ways(struct metal_cache *cache) {
+    unsigned long control_base =
+        __metal_driver_sifive_ccache0_control_base(cache);
+
+    uint32_t way_enable = __METAL_ACCESS_ONCE(
+        (__metal_io_u32 *)(control_base + METAL_SIFIVE_CCACHE0_WAYENABLE));
+
+    /* The stored number is the index, so add one */
+    return (0xFF & way_enable) + 1;
+}
+
+int __metal_driver_sifive_ccache0_set_enabled_ways(struct metal_cache *cache,
+                                                   int ways) {
+    unsigned long control_base =
+        __metal_driver_sifive_ccache0_control_base(cache);
+
+    /* We can't decrease the number of enabled ways */
+    if (metal_cache_get_enabled_ways(cache) > ways) {
+        return -2;
+    }
+
+    /* The stored value is the index, so subtract one */
+    uint32_t value = 0xFF & (ways - 1);
+
+    /* Set the number of enabled ways */
+    __METAL_ACCESS_ONCE(
+        (__metal_io_u32 *)(control_base + METAL_SIFIVE_CCACHE0_WAYENABLE)) =
+        value;
+
+    /* Make sure the number of ways was set correctly */
+    if (metal_cache_get_enabled_ways(cache) != ways) {
+        return -3;
+    }
+
+    return 0;
+}
+
+__METAL_DEFINE_VTABLE(__metal_driver_vtable_sifive_ccache0) = {
+    .cache.init = __metal_driver_sifive_ccache0_init,
+    .cache.get_enabled_ways = __metal_driver_sifive_ccache0_get_enabled_ways,
+    .cache.set_enabled_ways = __metal_driver_sifive_ccache0_set_enabled_ways,
+};
+
+#endif
+
+typedef int no_empty_translation_units;

--- a/sifive-blocks/src/drivers/sifive_ccache0.c
+++ b/sifive-blocks/src/drivers/sifive_ccache0.c
@@ -8,79 +8,48 @@
 #include <metal/drivers/sifive_ccache0.h>
 #include <metal/init.h>
 #include <metal/io.h>
-#include <metal/machine.h>
-#include <stdint.h>
 
 #define L2_CONFIG_WAYS_SHIFT 8
 #define L2_CONFIG_WAYS_MASK (0xFF << L2_CONFIG_WAYS_SHIFT)
 
-void __metal_driver_sifive_ccache0_init(struct metal_cache *l2, int ways);
+#define L2_REGW(offset)                                                        \
+    __METAL_ACCESS_ONCE(                                                       \
+        (__metal_io_u32 *)(METAL_SIFIVE_CCACHE0_0_BASE_ADDRESS + (offset)))
 
-METAL_CONSTRUCTOR(metal_driver_sifive_ccache0_init) {
-#ifdef __METAL_DT_SIFIVE_CCACHE0_HANDLE
-    /* Get the handle for the L2 cache controller */
-    struct metal_cache *l2 = __METAL_DT_SIFIVE_CCACHE0_HANDLE;
-    if (!l2) {
-        return;
-    }
+void sifive_ccache0_init(uint32_t ways) {
+    sifive_ccache0_set_enabled_ways(ways);
+}
 
+METAL_CONSTRUCTOR(init_sifive_ccache0) {
     /* Get the number of available ways per bank */
-    unsigned long control_base = __metal_driver_sifive_ccache0_control_base(l2);
-    uint32_t ways = __METAL_ACCESS_ONCE(
-        (__metal_io_u32 *)(control_base + METAL_SIFIVE_CCACHE0_CONFIG));
-    ways = ((ways & L2_CONFIG_WAYS_MASK) >> L2_CONFIG_WAYS_SHIFT);
+    const uint32_t ways = __METAL_GET_FIELD(
+        L2_REGW(METAL_SIFIVE_CCACHE0_CONFIG), L2_CONFIG_WAYS_MASK);
 
     /* Enable all the ways */
-    __metal_driver_sifive_ccache0_init(l2, ways);
-#endif
+    sifive_ccache0_init(ways);
 }
 
-void __metal_driver_sifive_ccache0_init(struct metal_cache *l2, int ways) {
-    metal_cache_set_enabled_ways(l2, ways);
-}
-
-int __metal_driver_sifive_ccache0_get_enabled_ways(struct metal_cache *cache) {
-    unsigned long control_base =
-        __metal_driver_sifive_ccache0_control_base(cache);
-
-    uint32_t way_enable = __METAL_ACCESS_ONCE(
-        (__metal_io_u32 *)(control_base + METAL_SIFIVE_CCACHE0_WAYENABLE));
+uint32_t sifive_ccache0_get_enabled_ways(void) {
+    const uint32_t way_enable = L2_REGW(METAL_SIFIVE_CCACHE0_WAYENABLE);
 
     /* The stored number is the index, so add one */
     return (0xFF & way_enable) + 1;
 }
 
-int __metal_driver_sifive_ccache0_set_enabled_ways(struct metal_cache *cache,
-                                                   int ways) {
-    unsigned long control_base =
-        __metal_driver_sifive_ccache0_control_base(cache);
-
+uint32_t sifive_ccache0_set_enabled_ways(uint32_t ways) {
     /* We can't decrease the number of enabled ways */
-    if (metal_cache_get_enabled_ways(cache) > ways) {
-        return -2;
+    if (sifive_ccache0_get_enabled_ways() > ways) {
+        return sifive_ccache0_get_enabled_ways();
     }
 
     /* The stored value is the index, so subtract one */
-    uint32_t value = 0xFF & (ways - 1);
+    const uint32_t value = 0xFF & (ways - 1);
 
     /* Set the number of enabled ways */
-    __METAL_ACCESS_ONCE(
-        (__metal_io_u32 *)(control_base + METAL_SIFIVE_CCACHE0_WAYENABLE)) =
-        value;
+    L2_REGW(METAL_SIFIVE_CCACHE0_WAYENABLE) = value;
 
-    /* Make sure the number of ways was set correctly */
-    if (metal_cache_get_enabled_ways(cache) != ways) {
-        return -3;
-    }
-
-    return 0;
+    return sifive_ccache0_get_enabled_ways();
 }
-
-__METAL_DEFINE_VTABLE(__metal_driver_vtable_sifive_ccache0) = {
-    .cache.init = __metal_driver_sifive_ccache0_init,
-    .cache.get_enabled_ways = __metal_driver_sifive_ccache0_get_enabled_ways,
-    .cache.set_enabled_ways = __metal_driver_sifive_ccache0_set_enabled_ways,
-};
 
 #endif
 

--- a/sifive-blocks/templates/MANIFEST.ini
+++ b/sifive-blocks/templates/MANIFEST.ini
@@ -30,3 +30,6 @@ Compatible = sifive,spi0
 
 [i2c]
 Compatible = sifive,i2c0
+
+[sifive_ccache0]
+Compatible = sifive,ccache0 sifive,fu540-c000,l2

--- a/sifive-blocks/templates/metal/machine/sifive_ccache0.h.j2
+++ b/sifive-blocks/templates/metal/machine/sifive_ccache0.h.j2
@@ -1,0 +1,31 @@
+/* Copyright 2020 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef METAL__PLATFORM__SIFIVE_CCACHE0_H
+#define METAL__PLATFORM__SIFIVE_CCACHE0_H
+
+{% if 'sifive,ccache0' in devices %}
+{% set l2_caches = devices['sifive,ccache0'] %}
+
+{% for l2 in l2_caches %}
+    {% if 'reg_names' in l2 %}
+#define METAL_SIFIVE_CCACHE0_{{ loop.index0 }}_BASE_ADDRESS {{ "0x%x" % l2.regs_by_name['control'][0] }}UL
+#define METAL_SIFIVE_CCACHE0_{{ loop.index0 }}_SIZE {{ "0x%x" % l2.regs_by_name['control'][1] }}UL
+#define METAL_SIFIVE_CCACHE0_{{ loop.index0 }}_SIDEBAND_BASE_ADDRESS {{ "0x%x" % l2.regs_by_name['sideband'][0] }}UL
+#define METAL_SIFIVE_CCACHE0_{{ loop.index0 }}_SIDEBAND_SIZE {{ "0x%x" % l2.regs_by_name['sideband'][1] }}UL
+    {% else %}
+#define METAL_SIFIVE_CCACHE0_{{ loop.index0 }}_BASE_ADDRESS {{ "0x%x" % l2.reg[0][0] }}UL
+#define METAL_SIFIVE_CCACHE0_{{ loop.index0 }}_SIZE {{ "0x%x" % l2.reg[0][1] }}UL
+#define METAL_SIFIVE_CCACHE0_{{ loop.index0 }}_SIDEBAND_BASE_ADDRESS {{ "0x%x" % l2.reg[1][0] }}UL
+#define METAL_SIFIVE_CCACHE0_{{ loop.index0 }}_SIDEBAND_SIZE {{ "0x%x" % l2.reg[1][1] }}UL
+    {% endif %}
+{% endfor %}
+
+#define METAL_SIFIVE_CCACHE0
+#define METAL_SIFIVE_CCACHE0_CONFIG    0x0
+#define METAL_SIFIVE_CCACHE0_WAYENABLE 0x8
+
+{% endif %}
+
+#endif
+

--- a/sifive-blocks/templates/metal/machine/sifive_fu540_c000_l2.h.j2
+++ b/sifive-blocks/templates/metal/machine/sifive_fu540_c000_l2.h.j2
@@ -1,0 +1,31 @@
+/* Copyright 2020 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef METAL__PLATFORM__SIFIVE_FU540_C000_L20_H
+#define METAL__PLATFORM__SIFIVE_FU540_C000_L20_H
+
+{% if 'sifive,fu540-c000,l2' in devices %}
+{% set l2_caches = devices['sifive,fu540-c000,l2'] %}
+
+{% for l2 in l2_caches %}
+    {% if 'reg_names' in l2 %}
+#define METAL_SIFIVE_CCACHE0_{{ loop.index0 }}_BASE_ADDRESS {{ "0x%x" % l2.regs_by_name['control'][0] }}UL
+#define METAL_SIFIVE_CCACHE0_{{ loop.index0 }}_SIZE {{ "0x%x" % l2.regs_by_name['control'][1] }}UL
+#define METAL_SIFIVE_CCACHE0_{{ loop.index0 }}_SIDEBAND_BASE_ADDRESS {{ "0x%x" % l2.regs_by_name['sideband'][0] }}UL
+#define METAL_SIFIVE_CCACHE0_{{ loop.index0 }}_SIDEBAND_SIZE {{ "0x%x" % l2.regs_by_name['sideband'][1] }}UL
+    {% else %}
+#define METAL_SIFIVE_CCACHE0_{{ loop.index0 }}_BASE_ADDRESS {{ "0x%x" % l2.reg[0][0] }}UL
+#define METAL_SIFIVE_CCACHE0_{{ loop.index0 }}_SIZE {{ "0x%x" % l2.reg[0][1] }}UL
+#define METAL_SIFIVE_CCACHE0_{{ loop.index0 }}_SIDEBAND_BASE_ADDRESS {{ "0x%x" % l2.reg[1][0] }}UL
+#define METAL_SIFIVE_CCACHE0_{{ loop.index0 }}_SIDEBAND_SIZE {{ "0x%x" % l2.reg[1][1] }}UL
+    {% endif %}
+{% endfor %}
+
+#define METAL_SIFIVE_CCACHE0
+#define METAL_SIFIVE_CCACHE0_CONFIG    0x0
+#define METAL_SIFIVE_CCACHE0_WAYENABLE 0x8
+
+{% endif %}
+
+#endif
+

--- a/src/cache.c
+++ b/src/cache.c
@@ -1,0 +1,190 @@
+/* Copyright 2018 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include <metal/cache.h>
+#include <metal/machine.h>
+
+extern __inline__ void metal_cache_init(struct metal_cache *cache, int ways);
+extern __inline__ int metal_cache_get_enabled_ways(struct metal_cache *cache);
+extern __inline__ int metal_cache_set_enabled_ways(struct metal_cache *cache,
+                                                   int ways);
+
+int metal_dcache_l1_available(int hartid) {
+    switch (hartid) {
+    case 0:
+#ifdef __METAL_CPU_0_DCACHE_HANDLE
+        return __METAL_CPU_0_DCACHE_HANDLE;
+#endif
+        break;
+    case 1:
+#ifdef __METAL_CPU_1_DCACHE_HANDLE
+        return __METAL_CPU_1_DCACHE_HANDLE;
+#endif
+        break;
+    case 2:
+#ifdef __METAL_CPU_2_DCACHE_HANDLE
+        return __METAL_CPU_2_DCACHE_HANDLE;
+#endif
+        break;
+    case 3:
+#ifdef __METAL_CPU_3_DCACHE_HANDLE
+        return __METAL_CPU_3_DCACHE_HANDLE;
+#endif
+        break;
+    case 4:
+#ifdef __METAL_CPU_4_DCACHE_HANDLE
+        return __METAL_CPU_4_DCACHE_HANDLE;
+#endif
+        break;
+    case 5:
+#ifdef __METAL_CPU_5_DCACHE_HANDLE
+        return __METAL_CPU_5_DCACHE_HANDLE;
+#endif
+        break;
+    case 6:
+#ifdef __METAL_CPU_6_DCACHE_HANDLE
+        return __METAL_CPU_6_DCACHE_HANDLE;
+#endif
+        break;
+    case 7:
+#ifdef __METAL_CPU_7_DCACHE_HANDLE
+        return __METAL_CPU_7_DCACHE_HANDLE;
+#endif
+        break;
+    case 8:
+#ifdef __METAL_CPU_8_DCACHE_HANDLE
+        return __METAL_CPU_8_DCACHE_HANDLE;
+#endif
+        break;
+    }
+    return 0;
+}
+
+int metal_icache_l1_available(int hartid) {
+    switch (hartid) {
+    case 0:
+#ifdef __METAL_CPU_0_ICACHE_HANDLE
+        return __METAL_CPU_0_ICACHE_HANDLE;
+#endif
+        break;
+    case 1:
+#ifdef __METAL_CPU_1_ICACHE_HANDLE
+        return __METAL_CPU_1_ICACHE_HANDLE;
+#endif
+        break;
+    case 2:
+#ifdef __METAL_CPU_2_ICACHE_HANDLE
+        return __METAL_CPU_2_ICACHE_HANDLE;
+#endif
+        break;
+    case 3:
+#ifdef __METAL_CPU_3_ICACHE_HANDLE
+        return __METAL_CPU_3_ICACHE_HANDLE;
+#endif
+        break;
+    case 4:
+#ifdef __METAL_CPU_4_ICACHE_HANDLE
+        return __METAL_CPU_4_ICACHE_HANDLE;
+#endif
+        break;
+    case 5:
+#ifdef __METAL_CPU_5_ICACHE_HANDLE
+        return __METAL_CPU_5_ICACHE_HANDLE;
+#endif
+        break;
+    case 6:
+#ifdef __METAL_CPU_6_ICACHE_HANDLE
+        return __METAL_CPU_6_ICACHE_HANDLE;
+#endif
+        break;
+    case 7:
+#ifdef __METAL_CPU_7_ICACHE_HANDLE
+        return __METAL_CPU_7_ICACHE_HANDLE;
+#endif
+        break;
+    case 8:
+#ifdef __METAL_CPU_8_ICACHE_HANDLE
+        return __METAL_CPU_8_ICACHE_HANDLE;
+#endif
+        break;
+    }
+    return 0;
+}
+
+/*!
+ * @brief CFlush.D.L1 instruction is a custom instruction implemented as a
+ * state machine in L1 Data Cache (D$) with funct3=0, (for core with data
+ * caches) It is an I type: .insn i opcode, func3, rd, rs1, simm12(signed
+ * immediate 12bs)
+ *  31     28 27    24 23    20 19   16 15    12 11     8 7      4 3       0
+ * |--------|--------|--------|--------|--------|--------|--------|--------|
+ * +-------------+------------+----------+------+--------+-----------------+
+ * |sign immediate12b (simm12)|   rs1    | func3|    rd  |      opcode     |
+ * |-1-1-1-1 -1-1-0-0 -0-0-0-0|-x-x-x-x-x|0-0-0-|-0-0-0-0|-0-1-1-1 -0-0-1-1|
+ * +--------------------------+----------+------+--------+-----------------+
+ * 31     -0x40              20        15   0 12   x0     7      0x73      0
+ * +--------+--------+--------+----------+------+--------+--------+--------+
+ * where,
+ * rs1 =  x0, CFLUSH.D.L1 writes back and invalidates all lines in the L1 D$
+ * rs1 != x0, CFLUSH.D.L1 writes back and invalidates the L1 D$ line containing
+ *            the virtual address in integer register rs1.
+ */
+void metal_dcache_l1_flush(int hartid, uintptr_t address) {
+    if (metal_dcache_l1_available(hartid)) {
+        if (address) {
+            uintptr_t ms1 = 0, ms2 = 0;
+            __asm__ __volatile__("csrr %0, mtvec \n\t"
+                                 "la %1, 1f \n\t"
+                                 "csrw mtvec, %1 \n\t"
+                                 ".insn i 0x73, 0, x0, %2, -0x40 \n\t"
+                                 ".align 2\n\t"
+                                 "1: \n\t"
+                                 "csrw mtvec, %0 \n\t"
+                                 : "+r"(ms1), "+r"(ms2)
+                                 : "r"(address));
+            // Using ‘.insn’ pseudo directive:
+            //       '.insn i opcode, func3, rd, rs1, simm12'
+        } else {
+            __asm__ __volatile__(".word 0xfc000073" : : : "memory");
+        }
+    }
+}
+
+/*!
+ * @brief CDiscard.D.L1 instruction is a custom instruction implemented as a
+ * state machine in L1 Data Cache (D$) with funct3=0, (for core with data
+ * caches) It is an I type: .insn i opcode, func3, rd, rs1, simm12(signed
+ * immediate 12bs)
+ * 31     28 27    24 23    20 19    16 15    12 11     8 7      4 3       0
+ * |--------|--------|--------|--------|--------|--------|--------|--------|
+ * +-------------+------------+----------+------+--------+-----------------+
+ * |sign immediate12b (simm12)|   rs1    | func3|    rd  |      opcode     |
+ * |-1-1-1-1 -1-1-0-0 -0-0-1-0|-x-x-x-x-x|0-0-0-|-0-0-0-0|-0-1-1-1 -0-0-1-1|
+ * +--------------------------+----------+------+--------+-----------------+
+ * 31     -0x3E              20        15   0 12    x0    7      0x73      0
+ * +--------+--------+--------+----------+------+--------+--------+--------+
+ * where,
+ * rs1 = x0, CDISCARD.D.L1 invalidates all lines in the L1 D$ with no writes
+ * back. rs1 != x0, CDISCARD.D.L1 invalidates the L1 D$ line containing the
+ * virtual address in integer register rs1, with no writes back.
+ */
+void metal_dcache_l1_discard(int hartid, uintptr_t address) {
+    if (metal_dcache_l1_available(hartid)) {
+        if (address) {
+            uintptr_t ms1 = 0, ms2 = 0;
+            __asm__ __volatile__("csrr %0, mtvec \n\t"
+                                 "la %1, 1f \n\t"
+                                 "csrw mtvec, %1 \n\t"
+                                 ".insn i 0x73, 0, x0, %2, -0x3E \n\t"
+                                 ".align 2\n\t"
+                                 "1: \n\t"
+                                 "csrw mtvec, %0 \n\t"
+                                 : "+r"(ms1), "+r"(ms2)
+                                 : "r"(address));
+            // Using ‘.insn’ pseudo directive:
+            //       '.insn i opcode, func3, rd, rs1, simm12'
+        } else {
+            __asm__ __volatile__(".word 0xfc200073" : : : "memory");
+        }
+    }
+}

--- a/src/cache.c
+++ b/src/cache.c
@@ -2,113 +2,15 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 #include <metal/cache.h>
-#include <metal/machine.h>
+#include <metal/cpu.h>
+#include <metal/generated/cache.h>
 
-extern __inline__ void metal_cache_init(struct metal_cache *cache, int ways);
-extern __inline__ int metal_cache_get_enabled_ways(struct metal_cache *cache);
-extern __inline__ int metal_cache_set_enabled_ways(struct metal_cache *cache,
-                                                   int ways);
-
-int metal_dcache_l1_available(int hartid) {
-    switch (hartid) {
-    case 0:
-#ifdef __METAL_CPU_0_DCACHE_HANDLE
-        return __METAL_CPU_0_DCACHE_HANDLE;
-#endif
-        break;
-    case 1:
-#ifdef __METAL_CPU_1_DCACHE_HANDLE
-        return __METAL_CPU_1_DCACHE_HANDLE;
-#endif
-        break;
-    case 2:
-#ifdef __METAL_CPU_2_DCACHE_HANDLE
-        return __METAL_CPU_2_DCACHE_HANDLE;
-#endif
-        break;
-    case 3:
-#ifdef __METAL_CPU_3_DCACHE_HANDLE
-        return __METAL_CPU_3_DCACHE_HANDLE;
-#endif
-        break;
-    case 4:
-#ifdef __METAL_CPU_4_DCACHE_HANDLE
-        return __METAL_CPU_4_DCACHE_HANDLE;
-#endif
-        break;
-    case 5:
-#ifdef __METAL_CPU_5_DCACHE_HANDLE
-        return __METAL_CPU_5_DCACHE_HANDLE;
-#endif
-        break;
-    case 6:
-#ifdef __METAL_CPU_6_DCACHE_HANDLE
-        return __METAL_CPU_6_DCACHE_HANDLE;
-#endif
-        break;
-    case 7:
-#ifdef __METAL_CPU_7_DCACHE_HANDLE
-        return __METAL_CPU_7_DCACHE_HANDLE;
-#endif
-        break;
-    case 8:
-#ifdef __METAL_CPU_8_DCACHE_HANDLE
-        return __METAL_CPU_8_DCACHE_HANDLE;
-#endif
-        break;
-    }
-    return 0;
+bool metal_dcache_l1_available(void) {
+    return HART_HAS_L1_DCACHE(metal_cpu_get_current_hartid());
 }
 
-int metal_icache_l1_available(int hartid) {
-    switch (hartid) {
-    case 0:
-#ifdef __METAL_CPU_0_ICACHE_HANDLE
-        return __METAL_CPU_0_ICACHE_HANDLE;
-#endif
-        break;
-    case 1:
-#ifdef __METAL_CPU_1_ICACHE_HANDLE
-        return __METAL_CPU_1_ICACHE_HANDLE;
-#endif
-        break;
-    case 2:
-#ifdef __METAL_CPU_2_ICACHE_HANDLE
-        return __METAL_CPU_2_ICACHE_HANDLE;
-#endif
-        break;
-    case 3:
-#ifdef __METAL_CPU_3_ICACHE_HANDLE
-        return __METAL_CPU_3_ICACHE_HANDLE;
-#endif
-        break;
-    case 4:
-#ifdef __METAL_CPU_4_ICACHE_HANDLE
-        return __METAL_CPU_4_ICACHE_HANDLE;
-#endif
-        break;
-    case 5:
-#ifdef __METAL_CPU_5_ICACHE_HANDLE
-        return __METAL_CPU_5_ICACHE_HANDLE;
-#endif
-        break;
-    case 6:
-#ifdef __METAL_CPU_6_ICACHE_HANDLE
-        return __METAL_CPU_6_ICACHE_HANDLE;
-#endif
-        break;
-    case 7:
-#ifdef __METAL_CPU_7_ICACHE_HANDLE
-        return __METAL_CPU_7_ICACHE_HANDLE;
-#endif
-        break;
-    case 8:
-#ifdef __METAL_CPU_8_ICACHE_HANDLE
-        return __METAL_CPU_8_ICACHE_HANDLE;
-#endif
-        break;
-    }
-    return 0;
+bool metal_icache_l1_available(void) {
+    return HART_HAS_L1_ICACHE(metal_cpu_get_current_hartid());
 }
 
 /*!
@@ -129,8 +31,8 @@ int metal_icache_l1_available(int hartid) {
  * rs1 != x0, CFLUSH.D.L1 writes back and invalidates the L1 D$ line containing
  *            the virtual address in integer register rs1.
  */
-void metal_dcache_l1_flush(int hartid, uintptr_t address) {
-    if (metal_dcache_l1_available(hartid)) {
+void metal_dcache_l1_flush(uintptr_t address) {
+    if (metal_dcache_l1_available()) {
         if (address) {
             uintptr_t ms1 = 0, ms2 = 0;
             __asm__ __volatile__("csrr %0, mtvec \n\t"
@@ -168,8 +70,8 @@ void metal_dcache_l1_flush(int hartid, uintptr_t address) {
  * back. rs1 != x0, CDISCARD.D.L1 invalidates the L1 D$ line containing the
  * virtual address in integer register rs1, with no writes back.
  */
-void metal_dcache_l1_discard(int hartid, uintptr_t address) {
-    if (metal_dcache_l1_available(hartid)) {
+void metal_dcache_l1_discard(uintptr_t address) {
+    if (metal_dcache_l1_available()) {
         if (address) {
             uintptr_t ms1 = 0, ms2 = 0;
             __asm__ __volatile__("csrr %0, mtvec \n\t"

--- a/templates/metal/generated/cache.h.j2
+++ b/templates/metal/generated/cache.h.j2
@@ -1,0 +1,50 @@
+#ifndef __METAL_DT_CACHE__H
+#define __METAL_DT_CACHE__H
+
+{% include 'template_comment.h.j2' %}
+
+#include <stdbool.h>
+
+{% if harts|length > 1 %}
+
+#include <metal/generated/cpu.h>
+
+static const bool dt_l1_icache[__METAL_DT_NUM_HARTS] = {
+    {% for hart in harts %}
+        {% if 'i_cache_size' in hart %}
+    true,
+        {% else %}
+    false,
+        {% endif %}
+    {% endfor %}
+};
+static const bool dt_l1_dcache[__METAL_DT_NUM_HARTS] = {
+    {% for hart in harts %}
+        {% if 'd_cache_size' in hart %}
+    true,
+        {% else %}
+    false,
+        {% endif %}
+    {% endfor %}
+};
+
+#define HART_HAS_L1_ICACHE(hartid) (dt_l1_icache[(hartid)])
+#define HART_HAS_L1_DCACHE(hartid) (dt_l1_dcache[(hartid)])
+
+{% else %}
+
+{% if 'i_cache_size' in harts[0] %}
+#define HART_HAS_L1_ICACHE(hartid) true
+{% else %}
+#define HART_HAS_L1_ICACHE(hartid) false
+{% endif %}
+{% if 'd_cache_size' in harts[0] %}
+#define HART_HAS_L1_DCACHE(hartid) true
+{% else %}
+#define HART_HAS_L1_DCACHE(hartid) false
+{% endif %}
+
+{% endif %}
+
+#endif /* ! __METAL_DT_CACHE__H */
+


### PR DESCRIPTION
The L1 API remains in metal/cache.h

The SiFive L2 API is now driver-specific because an abstracted public API is unnecessary.