### PR TITLE
Ignore clock rate changes before init in SPI/UART

### DIFF
--- a/sifive-blocks/src/drivers/sifive_spi0.c
+++ b/sifive-blocks/src/drivers/sifive_spi0.c
@@ -360,6 +360,9 @@ int sifive_spi0_set_baud_rate(struct metal_spi spi, int baud_rate) {
 }
 
 void _sifive_spi0_pre_rate_change_callback(uint32_t id) {
+    if (!spi_state[id].baud_rate)
+        return;
+
     struct metal_spi spi = (struct metal_spi){id};
     uintptr_t control_base = dt_spi_data[get_index(spi)].base_addr;
 
@@ -374,6 +377,9 @@ void _sifive_spi0_pre_rate_change_callback(uint32_t id) {
 }
 
 void _sifive_spi0_post_rate_change_callback(uint32_t id) {
+    if (!spi_state[id].baud_rate)
+        return;
+
     struct metal_spi spi = (struct metal_spi){id};
     uint32_t baud_rate = spi_state[get_index(spi)].baud_rate;
     sifive_spi0_set_baud_rate(spi, baud_rate);


### PR DESCRIPTION
The clock rate change callbacks may happen before the drivers have
been initialized. In this case they need to be ignored. Check for this
case by looking for an uninitialized baud_rate.

Signed-off-by: Keith Packard <keithp@keithp.com>