### PR TITLE
Refactor sifive,buserror0 driver

### DIFF
--- a/metal/cpu.h
+++ b/metal/cpu.h
@@ -215,18 +215,4 @@ uintptr_t metal_cpu_get_exception_pc(struct metal_cpu cpu);
  */
 int metal_cpu_set_exception_pc(struct metal_cpu cpu, uintptr_t epc);
 
-/* I ripped out the buserror driver but I'd rather not delete the code
- * unnecessarily */
-struct metal_buserror {
-    uint32_t __buserror_index;
-};
-
-/*!
- * @brief Get the handle for the hart's bus error unit
- *
- * @param cpu The CPU device handle
- * @return A pointer to the bus error unit handle
- */
-struct metal_buserror metal_cpu_get_buserror(struct metal_cpu cpu);
-
 #endif

--- a/sifive-blocks/metal/drivers/sifive_buserror0.h
+++ b/sifive-blocks/metal/drivers/sifive_buserror0.h
@@ -1,0 +1,184 @@
+/* Copyright 2020 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef METAL__DRIVERS__SIFIVE_BUSERROR0_H
+#define METAL__DRIVERS__SIFIVE_BUSERROR0_H
+
+/*!
+ * @file sifive_buserror0.h
+ *
+ * @brief API for configuring the SiFive Bus Error Unit
+ */
+
+#include <metal/compiler.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+/*!
+ * @brief The set of possible events handled by a SiFive Bus Error Unit
+ */
+typedef enum {
+    /*! @brief No event or error has been detected */
+    METAL_BUSERROR_EVENT_NONE = 0,
+
+    /*! @brief A correctable ECC error has occurred in the I$ or ITIM */
+    METAL_BUSERROR_EVENT_INST_CORRECTABLE_ECC_ERROR = (1 << 2),
+    /*! @brief An uncorrectable ECC error has occurred in the I$ or ITIM */
+    METAL_BUSERROR_EVENT_INST_UNCORRECTABLE_ECC_ERROR = (1 << 3),
+    /*! @brief A TileLink load or store bus error has occurred */
+    METAL_BUSERROR_EVENT_LOAD_STORE_ERROR = (1 << 5),
+    /*! @brief A correctable ECC error has occurred in the D$ or DTIM */
+    METAL_BUSERROR_EVENT_DATA_CORRECTABLE_ECC_ERROR = (1 << 6),
+    /*! @brief An uncorrectable ECC error has occurred in the D$ or DTIM */
+    METAL_BUSERROR_EVENT_DATA_UNCORRECTABLE_ECC_ERROR = (1 << 7),
+
+    /*! @brief Used to set/clear all interrupts or query/clear all accrued
+       events */
+    METAL_BUSERROR_EVENT_ALL =
+        METAL_BUSERROR_EVENT_INST_CORRECTABLE_ECC_ERROR |
+        METAL_BUSERROR_EVENT_INST_UNCORRECTABLE_ECC_ERROR |
+        METAL_BUSERROR_EVENT_LOAD_STORE_ERROR |
+        METAL_BUSERROR_EVENT_DATA_CORRECTABLE_ECC_ERROR |
+        METAL_BUSERROR_EVENT_DATA_UNCORRECTABLE_ECC_ERROR,
+    /*! @brief A synonym of METAL_BUSERROR_EVENT_ALL */
+    METAL_BUSERROR_EVENT_ANY = METAL_BUSERROR_EVENT_ALL,
+
+    /*! @brief A value which is impossible for the bus error unit to report.
+     * Indicates an error has occurred if provided as a return value. */
+    METAL_BUSERROR_EVENT_INVALID = (1 << 8),
+} metal_buserror_event_t;
+
+/*!
+ * @brief The handle for a bus error unit
+ */
+struct metal_buserror {
+    uint8_t __no_empty_structs;
+};
+
+/*!
+ * @brief Enable bus error events
+ *
+ * Enabling bus error events causes them to be registered as accrued and,
+ * if the corresponding interrupt is inabled, trigger interrupts.
+ *
+ * @param beu The bus error unit handle
+ * @param events A mask of error events to enable
+ * @param enabled True if the mask should be enabled, false if they should be
+ * disabled
+ * @return 0 upon success
+ */
+int metal_buserror_set_event_enabled(struct metal_buserror *beu,
+                                     metal_buserror_event_t events,
+                                     bool enabled);
+
+/*!
+ * @brief Get enabled bus error events
+ * @param beu The bus error unit handle
+ * @return A mask of all enabled events
+ */
+metal_buserror_event_t
+metal_buserror_get_event_enabled(struct metal_buserror *beu);
+
+/*!
+ * @brief Enable or disable the platform interrupt
+ *
+ * @param beu The bus error unit handle
+ * @param event The error event which would trigger the interrupt
+ * @param enabled True if the interrupt should be enabled
+ * @return 0 upon success
+ */
+int metal_buserror_set_platform_interrupt(struct metal_buserror *beu,
+                                          metal_buserror_event_t events,
+                                          bool enabled);
+
+/*!
+ * @brief Enable or disable the hart-local interrupt
+ *
+ * @param beu The bus error unit handle
+ * @param event The error event which would trigger the interrupt
+ * @param enabled True if the interrupt should be enabled
+ * @return 0 upon success
+ */
+int metal_buserror_set_local_interrupt(struct metal_buserror *beu,
+                                       metal_buserror_event_t events,
+                                       bool enabled);
+
+/*!
+ * @brief Get the error event which caused the most recent interrupt
+ *
+ * This method should be called from within the interrupt handler for the bus
+ * error unit interrupt
+ *
+ * @param beu The bus error unit handle
+ * @return The event which caused the interrupt
+ */
+metal_buserror_event_t metal_buserror_get_cause(struct metal_buserror *beu);
+
+/*!
+ * @brief Clear the cause register for the bus error unit
+ *
+ * This method should be called from within the interrupt handler for the bus
+ * error unit to un-latch the cause register for the next event
+ *
+ * @param beu The bus error unit handle
+ * @return 0 upon success
+ */
+int metal_buserror_clear_cause(struct metal_buserror *beu);
+
+/*!
+ * @brief Get the physical address of the error event
+ *
+ * This method should be called from within the interrupt handler for the bus
+ * error unit.
+ *
+ * @param beu The bus error unit handle
+ * @return The address of the error event
+ */
+uintptr_t metal_buserror_get_event_address(struct metal_buserror *beu);
+
+/*!
+ * @brief Returns true if the event is set in the accrued register
+ *
+ * @param beu The bus error unit handle
+ * @param event The event to query
+ * @return True if the event is set in the accrued register
+ */
+bool metal_buserror_is_event_accrued(struct metal_buserror *beu,
+                                     metal_buserror_event_t events);
+
+/*!
+ * @brief Clear the given event from the accrued register
+ *
+ * @param beu The bus error unit handle
+ * @param event The event to clear
+ * @return 0 upon success
+ */
+int metal_buserror_clear_event_accrued(struct metal_buserror *beu,
+                                       metal_buserror_event_t events);
+
+/*!
+ * @brief get the platform-level interrupt parent of the bus error unit
+ *
+ * @param beu The bus error unit handle
+ * @return A pointer to the interrupt parent
+ */
+struct metal_interrupt *
+metal_buserror_get_platform_interrupt_parent(struct metal_buserror *beu);
+
+/*!
+ * @brief Get the platform-level interrupt id for the bus error unit interrupt
+ *
+ * @param beu The bus error unit handle
+ * @return The interrupt id
+ */
+int metal_buserror_get_platform_interrupt_id(struct metal_buserror *beu);
+
+/*!
+ * @brief Get the hart-local interrupt id for the bus error unit interrupt
+ *
+ * @param beu The bus error unit handle
+ * @return The interrupt id
+ */
+int metal_buserror_get_local_interrupt_id(struct metal_buserror *beu);
+
+#endif

--- a/sifive-blocks/metal/drivers/sifive_buserror0.h
+++ b/sifive-blocks/metal/drivers/sifive_buserror0.h
@@ -10,7 +10,7 @@
  * @brief API for configuring the SiFive Bus Error Unit
  */
 
-#include <metal/compiler.h>
+#include <metal/cpu.h>
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -46,14 +46,7 @@ typedef enum {
     /*! @brief A value which is impossible for the bus error unit to report.
      * Indicates an error has occurred if provided as a return value. */
     METAL_BUSERROR_EVENT_INVALID = (1 << 8),
-} metal_buserror_event_t;
-
-/*!
- * @brief The handle for a bus error unit
- */
-struct metal_buserror {
-    uint8_t __no_empty_structs;
-};
+} sifive_buserror_event_t;
 
 /*!
  * @brief Enable bus error events
@@ -61,47 +54,29 @@ struct metal_buserror {
  * Enabling bus error events causes them to be registered as accrued and,
  * if the corresponding interrupt is inabled, trigger interrupts.
  *
- * @param beu The bus error unit handle
+ * @param cpu The CPU handle corresponding to the hart to configure
  * @param events A mask of error events to enable
- * @param enabled True if the mask should be enabled, false if they should be
- * disabled
  * @return 0 upon success
  */
-int metal_buserror_set_event_enabled(struct metal_buserror *beu,
-                                     metal_buserror_event_t events,
-                                     bool enabled);
+int sifive_buserror_enable_events(struct metal_cpu cpu,
+                                  sifive_buserror_event_t events);
+
+/*!
+ * @brief Disable bus error events
+ *
+ * @param cpu The CPU handle corresponding to the hart to configure
+ * @param events A mask of error events to enable
+ * @return 0 upon success
+ */
+int sifive_buserror_disable_events(struct metal_cpu cpu,
+                                   sifive_buserror_event_t events);
 
 /*!
  * @brief Get enabled bus error events
- * @param beu The bus error unit handle
+ * @param cpu The CPU handle corresponding to the hart to query
  * @return A mask of all enabled events
  */
-metal_buserror_event_t
-metal_buserror_get_event_enabled(struct metal_buserror *beu);
-
-/*!
- * @brief Enable or disable the platform interrupt
- *
- * @param beu The bus error unit handle
- * @param event The error event which would trigger the interrupt
- * @param enabled True if the interrupt should be enabled
- * @return 0 upon success
- */
-int metal_buserror_set_platform_interrupt(struct metal_buserror *beu,
-                                          metal_buserror_event_t events,
-                                          bool enabled);
-
-/*!
- * @brief Enable or disable the hart-local interrupt
- *
- * @param beu The bus error unit handle
- * @param event The error event which would trigger the interrupt
- * @param enabled True if the interrupt should be enabled
- * @return 0 upon success
- */
-int metal_buserror_set_local_interrupt(struct metal_buserror *beu,
-                                       metal_buserror_event_t events,
-                                       bool enabled);
+sifive_buserror_event_t sifive_buserror_get_event_enabled(struct metal_cpu cpu);
 
 /*!
  * @brief Get the error event which caused the most recent interrupt
@@ -112,7 +87,7 @@ int metal_buserror_set_local_interrupt(struct metal_buserror *beu,
  * @param beu The bus error unit handle
  * @return The event which caused the interrupt
  */
-metal_buserror_event_t metal_buserror_get_cause(struct metal_buserror *beu);
+sifive_buserror_event_t sifive_buserror_get_cause(struct metal_cpu cpu);
 
 /*!
  * @brief Clear the cause register for the bus error unit
@@ -120,10 +95,10 @@ metal_buserror_event_t metal_buserror_get_cause(struct metal_buserror *beu);
  * This method should be called from within the interrupt handler for the bus
  * error unit to un-latch the cause register for the next event
  *
- * @param beu The bus error unit handle
+ * @param cpu The CPU handle corresponding to the hart to configure
  * @return 0 upon success
  */
-int metal_buserror_clear_cause(struct metal_buserror *beu);
+int sifive_buserror_clear_cause(struct metal_cpu cpu);
 
 /*!
  * @brief Get the physical address of the error event
@@ -134,51 +109,62 @@ int metal_buserror_clear_cause(struct metal_buserror *beu);
  * @param beu The bus error unit handle
  * @return The address of the error event
  */
-uintptr_t metal_buserror_get_event_address(struct metal_buserror *beu);
+uintptr_t sifive_buserror_get_event_address(struct metal_cpu cpu);
 
 /*!
  * @brief Returns true if the event is set in the accrued register
  *
- * @param beu The bus error unit handle
+ * @param cpu The CPU handle corresponding to the hart to configure
  * @param event The event to query
  * @return True if the event is set in the accrued register
  */
-bool metal_buserror_is_event_accrued(struct metal_buserror *beu,
-                                     metal_buserror_event_t events);
+bool sifive_buserror_is_event_accrued(struct metal_cpu cpu,
+                                      sifive_buserror_event_t events);
 
 /*!
  * @brief Clear the given event from the accrued register
  *
- * @param beu The bus error unit handle
+ * @param cpu The CPU handle corresponding to the hart to configure
  * @param event The event to clear
  * @return 0 upon success
  */
-int metal_buserror_clear_event_accrued(struct metal_buserror *beu,
-                                       metal_buserror_event_t events);
+int sifive_buserror_clear_event_accrued(struct metal_cpu cpu,
+                                        sifive_buserror_event_t events);
 
 /*!
- * @brief get the platform-level interrupt parent of the bus error unit
+ * @brief Enable the platform-level buserror unit interrupt
  *
- * @param beu The bus error unit handle
- * @return A pointer to the interrupt parent
+ * @param cpu The CPU handle corresponding to the hart to configure
+ * @return 0 upon success
  */
-struct metal_interrupt *
-metal_buserror_get_platform_interrupt_parent(struct metal_buserror *beu);
+int sifive_buserror_enable_platform_interrupt(struct metal_cpu cpu,
+                                              sifive_buserror_event_t events);
 
 /*!
- * @brief Get the platform-level interrupt id for the bus error unit interrupt
+ * @brief Disable the platform-level buserror unit interrupt
  *
- * @param beu The bus error unit handle
- * @return The interrupt id
+ * @param cpu The CPU handle corresponding to the hart to configure
+ * @return 0 upon success
  */
-int metal_buserror_get_platform_interrupt_id(struct metal_buserror *beu);
+int sifive_buserror_disable_platform_interrupt(struct metal_cpu cpu,
+                                               sifive_buserror_event_t events);
 
 /*!
- * @brief Get the hart-local interrupt id for the bus error unit interrupt
+ * @brief Enable the hart-local buserror unit interrupt
  *
- * @param beu The bus error unit handle
- * @return The interrupt id
+ * @param cpu The CPU handle corresponding to the hart to configure
+ * @return 0 upon success
  */
-int metal_buserror_get_local_interrupt_id(struct metal_buserror *beu);
+int sifive_buserror_enable_local_interrupt(struct metal_cpu cpu,
+                                           sifive_buserror_event_t events);
+
+/*!
+ * @brief Disable the hart-local buserror unit interrupt
+ *
+ * @param cpu The CPU handle corresponding to the hart to configure
+ * @return 0 upon success
+ */
+int sifive_buserror_disable_local_interrupt(struct metal_cpu cpu,
+                                            sifive_buserror_event_t events);
 
 #endif

--- a/sifive-blocks/src/drivers/sifive_buserror0.c
+++ b/sifive-blocks/src/drivers/sifive_buserror0.c
@@ -1,0 +1,257 @@
+/* Copyright 2020 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include <metal/drivers/sifive_buserror0.h>
+#include <metal/machine/platform.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef METAL_SIFIVE_BUSERROR0
+
+#include <metal/cpu.h>
+#include <metal/init.h>
+#include <metal/io.h>
+#include <metal/machine.h>
+
+/* Enable all events on all hart bus error units */
+METAL_CONSTRUCTOR(metal_driver_sifive_buserror_init) {
+    for (int hart = 0; hart < metal_cpu_get_num_harts(); hart++) {
+        struct metal_cpu *cpu = metal_cpu_get(hart);
+        if (cpu != NULL) {
+            struct metal_buserror *beu = metal_cpu_get_buserror(cpu);
+            if (beu != NULL) {
+                metal_buserror_set_event_enabled(beu, METAL_BUSERROR_EVENT_ALL,
+                                                 true);
+            }
+        }
+    }
+}
+
+int metal_buserror_set_event_enabled(struct metal_buserror *beu,
+                                     metal_buserror_event_t events,
+                                     bool enabled) {
+    uintptr_t base = __metal_driver_sifive_buserror0_control_base(beu);
+    if (base == (uintptr_t)NULL) {
+        return 1;
+    }
+    if (!(events & METAL_BUSERROR_EVENT_ANY)) {
+        return 2;
+    }
+
+    uintptr_t reg_enable = base + METAL_SIFIVE_BUSERROR0_ENABLE;
+
+    if (enabled) {
+        __METAL_ACCESS_ONCE((__metal_io_u8 *)reg_enable) |= events;
+    } else {
+        __METAL_ACCESS_ONCE((__metal_io_u8 *)reg_enable) &= ~events;
+    }
+
+    if (!(events & __METAL_ACCESS_ONCE((__metal_io_u8 *)reg_enable))) {
+        return __METAL_ACCESS_ONCE((__metal_io_u8 *)reg_enable);
+    }
+
+    return 0;
+}
+
+metal_buserror_event_t
+metal_buserror_get_event_enabled(struct metal_buserror *beu) {
+    uintptr_t base = __metal_driver_sifive_buserror0_control_base(beu);
+    if (base == (uintptr_t)NULL) {
+        return 1;
+    }
+
+    uintptr_t reg_enable = base + METAL_SIFIVE_BUSERROR0_ENABLE;
+
+    return __METAL_ACCESS_ONCE((__metal_io_u8 *)reg_enable);
+}
+
+int metal_buserror_set_platform_interrupt(struct metal_buserror *beu,
+                                          metal_buserror_event_t events,
+                                          bool enabled) {
+    uintptr_t base = __metal_driver_sifive_buserror0_control_base(beu);
+    if (base == (uintptr_t)NULL) {
+        return 1;
+    }
+    if (!(events & METAL_BUSERROR_EVENT_ANY)) {
+        return 2;
+    }
+
+    uintptr_t platform_interrupt =
+        base + METAL_SIFIVE_BUSERROR0_PLATFORM_INTERRUPT;
+
+    if (enabled) {
+        __METAL_ACCESS_ONCE((__metal_io_u8 *)platform_interrupt) |= events;
+    } else {
+        __METAL_ACCESS_ONCE((__metal_io_u8 *)platform_interrupt) &= ~events;
+    }
+
+    return 0;
+}
+
+int metal_buserror_set_local_interrupt(struct metal_buserror *beu,
+                                       metal_buserror_event_t events,
+                                       bool enabled) {
+    uintptr_t base = __metal_driver_sifive_buserror0_control_base(beu);
+    if (base == (uintptr_t)NULL) {
+        return 1;
+    }
+    if (!(events & METAL_BUSERROR_EVENT_ANY)) {
+        return 2;
+    }
+
+    uintptr_t local_interrupt = base + METAL_SIFIVE_BUSERROR0_LOCAL_INTERRUPT;
+
+    if (enabled) {
+        __METAL_ACCESS_ONCE((__metal_io_u8 *)local_interrupt) |= events;
+    } else {
+        __METAL_ACCESS_ONCE((__metal_io_u8 *)local_interrupt) &= ~events;
+    }
+
+    return 0;
+}
+
+metal_buserror_event_t metal_buserror_get_cause(struct metal_buserror *beu) {
+    uintptr_t base = __metal_driver_sifive_buserror0_control_base(beu);
+    if (base == (uintptr_t)NULL) {
+        return METAL_BUSERROR_EVENT_INVALID;
+    }
+
+    uintptr_t cause = base + METAL_SIFIVE_BUSERROR0_CAUSE;
+
+    return (metal_buserror_event_t)(
+        1 << __METAL_ACCESS_ONCE((__metal_io_u8 *)cause));
+}
+
+int metal_buserror_clear_cause(struct metal_buserror *beu) {
+    uintptr_t base = __metal_driver_sifive_buserror0_control_base(beu);
+    if (base == (uintptr_t)NULL) {
+        /* We return (1 << 8) because the value of the cause register
+         * can never equal that value */
+        return (1 << 8);
+    }
+
+    uintptr_t cause = base + METAL_SIFIVE_BUSERROR0_CAUSE;
+    __METAL_ACCESS_ONCE((__metal_io_u8 *)cause) = METAL_BUSERROR_EVENT_NONE;
+
+    return __METAL_ACCESS_ONCE((__metal_io_u8 *)cause);
+}
+
+uintptr_t metal_buserror_get_event_address(struct metal_buserror *beu) {
+    uintptr_t base = __metal_driver_sifive_buserror0_control_base(beu);
+    if (base == (uintptr_t)NULL) {
+        return 0;
+    }
+
+    uintptr_t value = base + METAL_SIFIVE_BUSERROR0_VALUE;
+
+    return __METAL_ACCESS_ONCE((__metal_io_u8 *)value);
+}
+
+bool metal_buserror_is_event_accrued(struct metal_buserror *beu,
+                                     metal_buserror_event_t events) {
+    uintptr_t base = __metal_driver_sifive_buserror0_control_base(beu);
+    if (base == (uintptr_t)NULL) {
+        return false;
+    }
+
+    uintptr_t accrued = base + METAL_SIFIVE_BUSERROR0_ACCRUED;
+
+    if (!(events & METAL_BUSERROR_EVENT_ANY)) {
+        return false;
+    }
+
+    return !!(events & __METAL_ACCESS_ONCE((__metal_io_u8 *)accrued));
+}
+
+int metal_buserror_clear_event_accrued(struct metal_buserror *beu,
+                                       metal_buserror_event_t events) {
+    uintptr_t base = __metal_driver_sifive_buserror0_control_base(beu);
+    if (base == (uintptr_t)NULL) {
+        /* We return (1 << 8) because the value of the accrued register
+         * can never equal that value */
+        return (1 << 8);
+    }
+
+    uintptr_t accrued = base + METAL_SIFIVE_BUSERROR0_ACCRUED;
+
+    if (!(events & METAL_BUSERROR_EVENT_ANY)) {
+        /* We return (1 << 9) because the value of the accrued register
+         * can never equal that value */
+        return (1 << 9);
+    } else {
+        __METAL_ACCESS_ONCE((__metal_io_u8 *)accrued) &= ~events;
+        if (events & __METAL_ACCESS_ONCE((__metal_io_u8 *)accrued)) {
+            return __METAL_ACCESS_ONCE((__metal_io_u8 *)accrued);
+        }
+    }
+
+    return 0;
+}
+
+struct metal_interrupt *
+metal_buserror_get_platform_interrupt_parent(struct metal_buserror *beu) {
+    return __metal_driver_sifive_buserror0_interrupt_parent(beu);
+}
+
+int metal_buserror_get_platform_interrupt_id(struct metal_buserror *beu) {
+    return __metal_driver_sifive_buserror0_interrupt_id(beu);
+}
+
+int metal_buserror_get_local_interrupt_id(struct metal_buserror *beu) {
+    return 128;
+}
+
+#else
+
+int metal_buserror_set_event_enabled(struct metal_buserror *beu,
+                                     metal_buserror_event_t event,
+                                     bool enabled) {
+    return 1;
+}
+
+int metal_buserror_set_platform_interrupt(struct metal_buserror *beu,
+                                          metal_buserror_event_t event,
+                                          bool enabled) {
+    return 1;
+}
+
+int metal_buserror_set_local_interrupt(struct metal_buserror *beu,
+                                       metal_buserror_event_t event,
+                                       bool enabled) {
+    return 1;
+}
+
+metal_buserror_event_t metal_buserror_get_cause(struct metal_buserror *beu) {
+    return METAL_BUSERROR_EVENT_INVALID;
+}
+
+int metal_buserror_clear_cause(struct metal_buserror *beu) { return (1 << 9); }
+
+uintptr_t metal_buserror_get_event_address(struct metal_buserror *beu) {
+    return 0;
+}
+
+bool metal_buserror_is_event_accrued(struct metal_buserror *beu,
+                                     metal_buserror_event_t event) {
+    return false;
+}
+
+int metal_buserror_clear_event_accrued(struct metal_buserror *beu,
+                                       metal_buserror_event_t event) {
+    return (1 << 8);
+}
+
+struct metal_interrupt *
+metal_buserror_get_platform_interrupt_parent(struct metal_buserror *beu) {
+    return NULL;
+}
+
+int metal_buserror_get_platform_interrupt_id(struct metal_buserror *beu) {
+    return 0;
+}
+
+int metal_buserror_get_local_interrupt_id(struct metal_buserror *beu) {
+    return 0;
+}
+
+#endif

--- a/sifive-blocks/src/drivers/sifive_buserror0.c
+++ b/sifive-blocks/src/drivers/sifive_buserror0.c
@@ -4,254 +4,166 @@
 #include <metal/drivers/sifive_buserror0.h>
 #include <metal/machine/platform.h>
 #include <stddef.h>
-#include <stdint.h>
 
 #ifdef METAL_SIFIVE_BUSERROR0
 
 #include <metal/cpu.h>
 #include <metal/init.h>
 #include <metal/io.h>
-#include <metal/machine.h>
+
+#define HARTID(cpu) ((cpu).__hartid)
+#define CPU_HAS_BEU(cpu) HART_HAS_BEU(HARTID(cpu))
+#define BEU_REGB(cpu, offset)                                                  \
+    __METAL_ACCESS_ONCE(                                                       \
+        (__metal_io_u8 *)(BEU_BASE_ADDR(HARTID(cpu)) + (offset)))
 
 /* Enable all events on all hart bus error units */
 METAL_CONSTRUCTOR(metal_driver_sifive_buserror_init) {
     for (int hart = 0; hart < metal_cpu_get_num_harts(); hart++) {
-        struct metal_cpu *cpu = metal_cpu_get(hart);
-        if (cpu != NULL) {
-            struct metal_buserror *beu = metal_cpu_get_buserror(cpu);
-            if (beu != NULL) {
-                metal_buserror_set_event_enabled(beu, METAL_BUSERROR_EVENT_ALL,
-                                                 true);
-            }
-        }
+        struct metal_cpu cpu = metal_cpu_get(hart);
+        sifive_buserror_enable_events(cpu, METAL_BUSERROR_EVENT_ALL)
     }
 }
 
-int metal_buserror_set_event_enabled(struct metal_buserror *beu,
-                                     metal_buserror_event_t events,
-                                     bool enabled) {
-    uintptr_t base = __metal_driver_sifive_buserror0_control_base(beu);
-    if (base == (uintptr_t)NULL) {
-        return 1;
-    }
-    if (!(events & METAL_BUSERROR_EVENT_ANY)) {
-        return 2;
+int sifive_buserror_enable_events(struct metal_cpu cpu,
+                                  sifive_buserror_event_t events) {
+    if (!CPU_HAS_BEU(cpu)) {
+        return -1;
     }
 
-    uintptr_t reg_enable = base + METAL_SIFIVE_BUSERROR0_ENABLE;
-
-    if (enabled) {
-        __METAL_ACCESS_ONCE((__metal_io_u8 *)reg_enable) |= events;
-    } else {
-        __METAL_ACCESS_ONCE((__metal_io_u8 *)reg_enable) &= ~events;
-    }
-
-    if (!(events & __METAL_ACCESS_ONCE((__metal_io_u8 *)reg_enable))) {
-        return __METAL_ACCESS_ONCE((__metal_io_u8 *)reg_enable);
-    }
+    BEU_REGB(cpu, METAL_SIFIVE_BUSERROR0_ENABLE) |= events;
 
     return 0;
 }
 
-metal_buserror_event_t
-metal_buserror_get_event_enabled(struct metal_buserror *beu) {
-    uintptr_t base = __metal_driver_sifive_buserror0_control_base(beu);
-    if (base == (uintptr_t)NULL) {
-        return 1;
+int sifive_buserror_disable_events(struct metal_cpu cpu,
+                                   sifive_buserror_event_t events) {
+    if (!CPU_HAS_BEU(cpu)) {
+        return -1;
     }
 
-    uintptr_t reg_enable = base + METAL_SIFIVE_BUSERROR0_ENABLE;
-
-    return __METAL_ACCESS_ONCE((__metal_io_u8 *)reg_enable);
-}
-
-int metal_buserror_set_platform_interrupt(struct metal_buserror *beu,
-                                          metal_buserror_event_t events,
-                                          bool enabled) {
-    uintptr_t base = __metal_driver_sifive_buserror0_control_base(beu);
-    if (base == (uintptr_t)NULL) {
-        return 1;
-    }
-    if (!(events & METAL_BUSERROR_EVENT_ANY)) {
-        return 2;
-    }
-
-    uintptr_t platform_interrupt =
-        base + METAL_SIFIVE_BUSERROR0_PLATFORM_INTERRUPT;
-
-    if (enabled) {
-        __METAL_ACCESS_ONCE((__metal_io_u8 *)platform_interrupt) |= events;
-    } else {
-        __METAL_ACCESS_ONCE((__metal_io_u8 *)platform_interrupt) &= ~events;
-    }
+    BEU_REGB(cpu, METAL_SIFIVE_BUSERROR0_ENABLE) &= ~events;
 
     return 0;
 }
 
-int metal_buserror_set_local_interrupt(struct metal_buserror *beu,
-                                       metal_buserror_event_t events,
-                                       bool enabled) {
-    uintptr_t base = __metal_driver_sifive_buserror0_control_base(beu);
-    if (base == (uintptr_t)NULL) {
-        return 1;
-    }
-    if (!(events & METAL_BUSERROR_EVENT_ANY)) {
-        return 2;
-    }
-
-    uintptr_t local_interrupt = base + METAL_SIFIVE_BUSERROR0_LOCAL_INTERRUPT;
-
-    if (enabled) {
-        __METAL_ACCESS_ONCE((__metal_io_u8 *)local_interrupt) |= events;
-    } else {
-        __METAL_ACCESS_ONCE((__metal_io_u8 *)local_interrupt) &= ~events;
-    }
-
-    return 0;
-}
-
-metal_buserror_event_t metal_buserror_get_cause(struct metal_buserror *beu) {
-    uintptr_t base = __metal_driver_sifive_buserror0_control_base(beu);
-    if (base == (uintptr_t)NULL) {
+sifive_buserror_event_t
+sifive_buserror_get_event_enabled(struct metal_cpu cpu) {
+    if (!CPU_HAS_BEU(cpu)) {
         return METAL_BUSERROR_EVENT_INVALID;
     }
 
-    uintptr_t cause = base + METAL_SIFIVE_BUSERROR0_CAUSE;
-
-    return (metal_buserror_event_t)(
-        1 << __METAL_ACCESS_ONCE((__metal_io_u8 *)cause));
+    return BEU_REGB(cpu, METAL_SIFIVE_BUSERROR0_ENABLE);
 }
 
-int metal_buserror_clear_cause(struct metal_buserror *beu) {
-    uintptr_t base = __metal_driver_sifive_buserror0_control_base(beu);
-    if (base == (uintptr_t)NULL) {
-        /* We return (1 << 8) because the value of the cause register
-         * can never equal that value */
-        return (1 << 8);
+sifive_buserror_event_t sifive_buserror_get_cause(struct metal_cpu cpu) {
+    if (!CPU_HAS_BEU(cpu)) {
+        return METAL_BUSERROR_EVENT_INVALID;
     }
 
-    uintptr_t cause = base + METAL_SIFIVE_BUSERROR0_CAUSE;
-    __METAL_ACCESS_ONCE((__metal_io_u8 *)cause) = METAL_BUSERROR_EVENT_NONE;
-
-    return __METAL_ACCESS_ONCE((__metal_io_u8 *)cause);
+    return (1 << BEU_REGB(cpu, METAL_SIFIVE_BUSERROR0_CAUSE))
 }
 
-uintptr_t metal_buserror_get_event_address(struct metal_buserror *beu) {
-    uintptr_t base = __metal_driver_sifive_buserror0_control_base(beu);
-    if (base == (uintptr_t)NULL) {
-        return 0;
+int sifive_buserror_clear_cause(struct metal_cpu cpu) {
+    if (!CPU_HAS_BEU(cpu)) {
+        return -1;
     }
 
-    uintptr_t value = base + METAL_SIFIVE_BUSERROR0_VALUE;
+    BEU_REGB(cpu, METAL_SIFIVE_BUSERROR0_CAUSE) = METAL_BUSERROR_EVENT_NONE;
 
-    return __METAL_ACCESS_ONCE((__metal_io_u8 *)value);
+    return 0;
 }
 
-bool metal_buserror_is_event_accrued(struct metal_buserror *beu,
-                                     metal_buserror_event_t events) {
-    uintptr_t base = __metal_driver_sifive_buserror0_control_base(beu);
-    if (base == (uintptr_t)NULL) {
-        return false;
+uintptr_t sifive_buserror_get_event_address(struct metal_cpu cpu) {
+    if (!CPU_HAS_BEU(cpu)) {
+        return -1;
     }
 
-    uintptr_t accrued = base + METAL_SIFIVE_BUSERROR0_ACCRUED;
+    return BEU_REGB(cpu, METAL_SIFIVE_BUSERROR0_VALUE);
+}
 
+bool sifive_buserror_is_event_accrued(struct metal_cpu cpu,
+                                      sifive_buserror_event_t events) {
+    if (!CPU_HAS_BEU(cpu)) {
+        return -1;
+    }
     if (!(events & METAL_BUSERROR_EVENT_ANY)) {
         return false;
     }
 
-    return !!(events & __METAL_ACCESS_ONCE((__metal_io_u8 *)accrued));
+    return !!(events & BEU_REGB(cpu, METAL_SIFIVE_BUSERROR0_ACCRUED));
 }
 
-int metal_buserror_clear_event_accrued(struct metal_buserror *beu,
-                                       metal_buserror_event_t events) {
-    uintptr_t base = __metal_driver_sifive_buserror0_control_base(beu);
-    if (base == (uintptr_t)NULL) {
-        /* We return (1 << 8) because the value of the accrued register
-         * can never equal that value */
-        return (1 << 8);
+int sifive_buserror_clear_event_accrued(struct metal_cpu cpu,
+                                        sifive_buserror_event_t events) {
+    if (!CPU_HAS_BEU(cpu)) {
+        return -1;
     }
-
-    uintptr_t accrued = base + METAL_SIFIVE_BUSERROR0_ACCRUED;
-
     if (!(events & METAL_BUSERROR_EVENT_ANY)) {
-        /* We return (1 << 9) because the value of the accrued register
-         * can never equal that value */
-        return (1 << 9);
-    } else {
-        __METAL_ACCESS_ONCE((__metal_io_u8 *)accrued) &= ~events;
-        if (events & __METAL_ACCESS_ONCE((__metal_io_u8 *)accrued)) {
-            return __METAL_ACCESS_ONCE((__metal_io_u8 *)accrued);
-        }
+        return -2;
     }
 
+    BEU_REGB(cpu, METAL_SIFIVE_BUSERROR0_ACCRUED) = 0;
+
     return 0;
 }
 
-struct metal_interrupt *
-metal_buserror_get_platform_interrupt_parent(struct metal_buserror *beu) {
-    return __metal_driver_sifive_buserror0_interrupt_parent(beu);
-}
+int sifive_buserror_enable_platform_interrupt(struct metal_cpu cpu,
+                                              sifive_buserror_event_t events) {
+    if (!CPU_HAS_BEU(cpu)) {
+        return -1;
+    }
+    if (!(events & METAL_BUSERROR_EVENT_ANY)) {
+        return -2;
+    }
 
-int metal_buserror_get_platform_interrupt_id(struct metal_buserror *beu) {
-    return __metal_driver_sifive_buserror0_interrupt_id(beu);
-}
+    BEU_REGB(cpu, METAL_SIFIVE_BUSERROR0_PLATFORM_INTERRUPT) |= events;
 
-int metal_buserror_get_local_interrupt_id(struct metal_buserror *beu) {
-    return 128;
-}
-
-#else
-
-int metal_buserror_set_event_enabled(struct metal_buserror *beu,
-                                     metal_buserror_event_t event,
-                                     bool enabled) {
-    return 1;
-}
-
-int metal_buserror_set_platform_interrupt(struct metal_buserror *beu,
-                                          metal_buserror_event_t event,
-                                          bool enabled) {
-    return 1;
-}
-
-int metal_buserror_set_local_interrupt(struct metal_buserror *beu,
-                                       metal_buserror_event_t event,
-                                       bool enabled) {
-    return 1;
-}
-
-metal_buserror_event_t metal_buserror_get_cause(struct metal_buserror *beu) {
-    return METAL_BUSERROR_EVENT_INVALID;
-}
-
-int metal_buserror_clear_cause(struct metal_buserror *beu) { return (1 << 9); }
-
-uintptr_t metal_buserror_get_event_address(struct metal_buserror *beu) {
     return 0;
 }
 
-bool metal_buserror_is_event_accrued(struct metal_buserror *beu,
-                                     metal_buserror_event_t event) {
-    return false;
-}
+int sifive_buserror_disable_platform_interrupt(struct metal_cpu cpu,
+                                               sifive_buserror_event_t events) {
+    if (!CPU_HAS_BEU(cpu)) {
+        return -1;
+    }
+    if (!(events & METAL_BUSERROR_EVENT_ANY)) {
+        return -2;
+    }
 
-int metal_buserror_clear_event_accrued(struct metal_buserror *beu,
-                                       metal_buserror_event_t event) {
-    return (1 << 8);
-}
+    BEU_REGB(cpu, METAL_SIFIVE_BUSERROR0_PLATFORM_INTERRUPT) &= ~events;
 
-struct metal_interrupt *
-metal_buserror_get_platform_interrupt_parent(struct metal_buserror *beu) {
-    return NULL;
-}
-
-int metal_buserror_get_platform_interrupt_id(struct metal_buserror *beu) {
     return 0;
 }
 
-int metal_buserror_get_local_interrupt_id(struct metal_buserror *beu) {
+int sifive_buserror_enable_local_interrupt(struct metal_cpu cpu,
+                                           sifive_buserror_event_t events) {
+    if (!CPU_HAS_BEU(cpu)) {
+        return -1;
+    }
+    if (!(events & METAL_BUSERROR_EVENT_ANY)) {
+        return -2;
+    }
+
+    BEU_REGB(cpu, METAL_SIFIVE_BUSERROR0_LOCAL_INTERRUPT) |= events;
+
+    return 0;
+}
+
+int sifive_buserror_disable_local_interrupt(struct metal_cpu cpu,
+                                            sifive_buserror_event_t events) {
+    if (!CPU_HAS_BEU(cpu)) {
+        return -1;
+    }
+    if (!(events & METAL_BUSERROR_EVENT_ANY)) {
+        return -2;
+    }
+
+    BEU_REGB(cpu, METAL_SIFIVE_BUSERROR0_LOCAL_INTERRUPT) &= ~events;
+
     return 0;
 }
 
 #endif
+
+typedef int no_empty_translation_units;

--- a/sifive-blocks/templates/metal/generated/sifive_buserror0.h.j2
+++ b/sifive-blocks/templates/metal/generated/sifive_buserror0.h.j2
@@ -1,0 +1,45 @@
+/* Copyright 2020 SiFive Inc. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef __METAL__GENERATED__SIFIVE_BUSERROR0__H
+#define __METAL__GENERATED__SIFIVE_BUSERROR0__H
+
+{% include 'template_comment.h.j2' %}
+
+{% if 'sifive,buserror0' in devices %}
+
+#include <metal/generated/cpu.h>
+#include <metal/machine/platform.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+{% if harts|length > 1 %}
+
+static const uintptr_t dt_beu_base_addrs[__METAL_DT_NUM_HARTS] = {
+    {% for hart in harts %}
+        {% if 'sifive_buserror' in hart %}
+    METAL_SIFIVE_BUSERROR0_{{ hart['sifive_buserror'].id }}_BASE_ADDRESS,
+        {% else %}
+    0UL,
+        {% endif %}
+    {% endfor %}
+};
+
+#define BEU_BASE_ADDR(hartid) (dt_beu_base_addrs[(hartid)])
+#define HART_HAS_BEU(hartid) (BEU_BASE_ADDR(hartid) != 0UL)
+
+{% else %}
+
+    {% if 'sifive_buserror' in hart %}
+#define BEU_BASE_ADDR(hartid) METAL_SIFIVE_BUSERROR0_0_BASE_ADDRESS
+#define HART_HAS_BEU(hartid) (BEU_BASE_ADDR(hartid) != 0UL)
+    {% else %}
+#define BEU_BASE_ADDR(hartid) 0UL
+#define HART_HAS_BEU(hartid) false
+    {% endif %}
+
+{% endif %}
+
+{% endif %}
+
+#endif

--- a/sifive-blocks/templates/metal/machine/sifive_buserror0.h.j2
+++ b/sifive-blocks/templates/metal/machine/sifive_buserror0.h.j2
@@ -1,0 +1,20 @@
+/* Copyright 2020 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef METAL__PLATFORM__SIFIVE_BUSERROR0_H
+#define METAL__PLATFORM__SIFIVE_BUSERROR0_H
+
+{% if 'sifive,buserror0' in devices %}
+
+{% for buserror in devices['sifive,buserror0'] %}
+#define METAL_SIFIVE_BUSERROR0_{{ loop.index0 }}_BASE_ADDRESS {{ "0x%x" % buserror.reg[0][0] }}UL
+#define METAL_SIFIVE_BUSERROR0_{{ loop.index0 }}_SIZE {{ "0x%x" % buserror.reg[0][1] }}UL
+{% endfor %}
+
+#define METAL_SIFIVE_BUSERROR0
+#define METAL_SIFIVE_BUSERROR0_LFROSCCFG 0x70UL
+#define METAL_SIFIVE_BUSERROR0_LFCLKMUX  0x7CUL
+
+{% endif %}
+
+#endif

--- a/src/drivers/riscv_cpu.c
+++ b/src/drivers/riscv_cpu.c
@@ -112,8 +112,3 @@ int metal_cpu_set_exception_pc(struct metal_cpu cpu, uintptr_t mepc) {
     __asm__ volatile("csrw mepc, %0" ::"r"(mepc));
     return 0;
 }
-
-struct metal_buserror metal_cpu_get_buserror(struct metal_cpu cpu) {
-    assert(dt_cpu_data[get_hartid(cpu)].has_buserror);
-    return dt_cpu_data[get_hartid(cpu)].buserror;
-}

--- a/src/exception.c
+++ b/src/exception.c
@@ -29,6 +29,14 @@ void __metal_trap_vector(void) {
 void __metal_exception_handler(riscv_xlen_t mcause) {
     const int id = RISCV_MCAUSE_ID(mcause);
     const struct metal_cpu cpu = metal_cpu_get(metal_cpu_get_current_hartid());
+
+#ifdef METAL_SIFIVE_BUSERROR0
+    /* The SiFive Bus Error Unit has a hard-coded local interrupt id of 128 */
+    if (id == 128) {
+        metal_sifive_buserror0_source_0_handler();
+    }
+#endif
+
     __metal_exception_table[id](cpu, id);
 }
 

--- a/templates/metal/generated/riscv_cpu.h.j2
+++ b/templates/metal/generated/riscv_cpu.h.j2
@@ -14,19 +14,11 @@
 
 static const struct dt_cpu_data {
     uint64_t timebase;
-    bool has_buserror;
-    struct metal_buserror buserror;
 } dt_cpu_data[__METAL_DT_NUM_HARTS] = {
     {% for hart in harts %}
     {
     {% if hart.timebase_frequency is defined %}
         .timebase = {{ hart.timebase_frequency[0] }},
-    {% endif %}
-    {% if hart.sifive_buserror is defined %}
-        .has_buserror = true,
-        .buserror = (struct metal_buserror) { {{ hart.sifive_buserror[0].id }} }
-    {% else %}
-        .has_buserror = false,
     {% endif %}
     },
     {% endfor %}

--- a/templates/metal/interrupt_handlers.h.j2
+++ b/templates/metal/interrupt_handlers.h.j2
@@ -73,6 +73,9 @@ void metal_riscv_plic0_source_0_handler() __attribute__((interrupt));
 {% else %}
 void metal_riscv_cpu_intc_meip_handler() __attribute__((interrupt));
 {% endif %}
+{% if 'sifive,buserror0' in devices %}
+void metal_sifive_buserror0_source_0_handler() __attribute__((interrupt));
+{% endif %}
 {% if local_interrupts is defined %}
     {% for irq in local_interrupts.irqs|unique_irqs %}
         {% if irq.source.compatible != None %}
@@ -94,6 +97,9 @@ void metal_riscv_cpu_intc_seip_handler();
 void metal_riscv_plic0_source_0_handler();
 {% else %}
 void metal_riscv_cpu_intc_meip_handler();
+{% endif %}
+{% if 'sifive,buserror0' in devices %}
+void metal_sifive_buserror0_handler();
 {% endif %}
 {% if local_interrupts is defined %}
     {% for irq in local_interrupts.irqs|unique_irqs %}

--- a/templates/src/interrupt_handlers.c.j2
+++ b/templates/src/interrupt_handlers.c.j2
@@ -57,6 +57,9 @@ void metal_riscv_plic0_source_0_handler() __attribute((interrupt, weak, alias("_
 {% else %}
 void metal_riscv_cpu_intc_meip_handler() __attribute__((interrupt, weak, alias("_metal_local_interrupt_handler_nop")));
 {% endif %}
+{% if 'sifive,buserror0' in devices %}
+void metal_sifive_buserror0_source_0_handler() __attribute__((interrupt, weak, alias("_metal_local_interrupt_handler_nop")));
+{% endif %}
 {% if local_interrupts is defined %}
     {% for irq in local_interrupts.irqs|unique_irqs %}
         {% if irq.source.compatible != None %}

--- a/templates/src/jump_table.S.j2
+++ b/templates/src/jump_table.S.j2
@@ -50,11 +50,28 @@ IRQ_15:
         j metal_riscv_cpu_intc_default_handler
 {% if local_interrupts is defined %}
   {% for irq in local_interrupts.irqs %}
-IRQ_LOCAL_{{ irq.id }}:
+IRQ_{{ irq.id }}:
     {% if irq.source is defined %}
-      j metal_{{ to_snakecase(irq.source.compatible) }}_source_{{ irq.source.id }}_handler
+        j metal_{{ to_snakecase(irq.source.compatible) }}_source_{{ irq.source.id }}_handler
     {% else %}
-      j metal_{{ local_interrupts.controller }}_{{ irq.id }}_handler
+        j metal_{{ local_interrupts.controller }}_{{ irq.id }}_handler
     {% endif %}
   {% endfor %}
+{% endif %}
+{% if 'sifive,buserror0' in devices %}
+#ifdef METAL_HLIC_VECTORED
+/*
+ * The Bus Error Unit has a hard-coded local interrupt id of 128. Therefore,
+ * when hardware-vectored local interrupts are enabled, we need to pad out
+ * the jump table to put the BEU interrupt handler at the appropriate offset.
+ * This wastes a ton of space, so this should only happen when HLIC-vectored
+ * interrupts are requested at compile-time.
+ */
+{% for i in range(16 + local_interrupts.irqs|length, 128) %}
+IRQ_{{ i }}:
+        j metal_riscv_cpu_intc_default_handler
+{% endfor %}
+IRQ_128:
+        j metal_sifive_buserror0_handler
+#endif
 {% endif %}


### PR DESCRIPTION
Among other things, this refactor also makes it so that the bus error unit local interrupt is properly vectored by HLIC hardware vectoring.