### PR TITLE
Add CI check for Wake 0.19 syntax.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,12 @@ install:
   - docker exec -t host bash -c "yes | apt-get update"
   - docker exec -t host bash -c "yes | apt-get upgrade"
   - docker exec -t host bash -c "yes | apt-get install git clang-format-6.0"
+  - sudo curl -L -o /tmp/wake.deb https://github.com/sifive/wake/releases/download/v0.19.0/ubuntu-16-04-wake_0.19.0-1_amd64.deb
+  - sudo apt install /tmp/wake.deb
 
 # Here's where we actually run the test.
 script:
 # Check source code formatting
   - docker exec -t host bash -c "cd /travis && ./scripts/check-format"
+# Run dummy Wake program in order to run Wake type cehcker.
+  - wake --init . && wake -x Unit

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,5 +31,5 @@ install:
 script:
 # Check source code formatting
   - docker exec -t host bash -c "cd /travis && ./scripts/check-format"
-# Run dummy Wake program in order to run Wake type cehcker.
+# Run dummy Wake program in order to run Wake type checker.
   - wake --init . && wake -x Unit


### PR DESCRIPTION
We've been adding some CI to all Git repos with Wake installed so that we can get type checking.

I opted against doing the more sophisticated setup we have in some other repos because 1) this repo just has Pull Request CI set up with Travis CI and 2) this repo has no wit dependencies, so we don't necessarily need that boilerplate.

I hope you don't mind me just taking this on to the end of your Travis CI configuration. I'd be more than happy to port this to GitHub Actions.