### PR TITLE
Add Wake API for Freedom Metal code generation and installation

### DIFF
--- a/.github/workflows/wake.yml
+++ b/.github/workflows/wake.yml
@@ -1,0 +1,27 @@
+name: wake-api-test
+
+on:
+  push:
+    path-ignore:
+      - 'doc/*'
+      - 'LICENSE*'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Init workspace
+        uses: sifive/wit/actions/init@v0.13.2
+        with:
+          additional_packages: git@github.com:sifive/environment-blockci-sifive.git::0.7.1
+
+      - name: Run Wake API Test
+        uses: sifive/environment-blockci-sifive/actions/shell@0.7.1
+        with:
+          command: freedom-metal/tests/test-wake-api.sh
+
+      - name: Run library install test
+        uses: sifive/environment-blockci-sifive/actions/shell@0.7.1
+        with:
+          command: freedom-metal/tests/test-wake-install.sh

--- a/build.wake
+++ b/build.wake
@@ -1,0 +1,93 @@
+# Copyright (c) 2020 SiFive Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+package freedom_metal
+
+from wake import _
+
+export tuple FreedomMetalCodeGenerationOptions =
+  export TopDTSFile: Path
+  export OtherDTSFiles: List Path
+  export OutputDirectory: String
+  export ApplicationConfig: Option Path
+
+# The freedomMetalSources topic allows users of Freedom Metal to
+# add out-of-tree drivers to Freedom Metal, including code
+# generation from Devicetree content.
+#
+# To add an out-of-tree source directory to Freedom Metal, simply:
+#
+#    publish freedomMetalSources = "path/to/out-of-tree/sources", Nil
+#
+export topic freedomMetalSources : String
+
+# Add the default in-tree sources and SiFive blocks sources to the
+# freedomMetalSources topic
+publish freedomMetalSources = here, "{here}/sifive-blocks", Nil
+
+#######################################################################
+# makeFreedomMetalCodeGenerationOptions takes the following parameters:
+#   - topDTSFile: The top-level Devicetree source file
+#   - otherDTSFiles: any other Devicetree source files included in the
+#                    hierarchy of Devicetree source files
+#   - outputDirectory: The path to output generated Freedom Metal code
+#   - applicationConfig: An .ini file used to customize Freedom Metal
+#                        for a given application
+#######################################################################
+export def makeFreedomMetalCodeGenerationOptions topDTSFile otherDTSFiles outputDirectory =
+  FreedomMetalCodeGenerationOptions topDTSFile otherDTSFiles outputDirectory None
+
+export def runFreedomMetalCodeGeneration sdkDir options =
+  def topDTSFile = options.getFreedomMetalCodeGenerationOptionsTopDTSFile
+  def otherDTSFiles = options.getFreedomMetalCodeGenerationOptionsOtherDTSFiles
+  def outputDirectory = options.getFreedomMetalCodeGenerationOptionsOutputDirectory
+  def appConfig = options.getFreedomMetalCodeGenerationOptionsApplicationConfig
+
+  def inputs =
+    def outDir = mkdir (simplify outputDirectory)
+    def generatorSource = source "{here}/scripts/codegen.py"
+    def dtsSources = topDTSFile, otherDTSFiles
+    def metalSources = installFreedomMetal sdkDir
+    outDir, generatorSource, dtsSources ++ metalSources
+
+  def expectedOutputs _ =
+    subscribe freedomMetalSources
+    | mapFlat (\d sources d `.*\.j2`)
+    | map getPathName
+    | map (\f replace `\.j2` "" f)
+    | map (\f replace `.*/templates` outputDirectory f)
+
+  def args =
+    def base =
+      "--dts", relative sdkDir topDTSFile.getPathName,
+      "--output-dir", relative sdkDir outputDirectory,
+      "--source-paths", subscribe freedomMetalSources
+    match appConfig
+      None = base
+      Some p = "--application-config", p.getPathName, base
+
+  makePlan (pythonCommand (relative sdkDir "{here}/scripts/codegen.py") args) inputs
+  | setPlanDirectory sdkDir
+  | addPlanRelativePath "PYTHONPATH" here
+  | addPythonRequirementsEnv here
+  | setPlanFnOutputs expectedOutputs
+  | runJob
+
+# Install the python virtualenv for the code generator as part of the preinstall topic.
+publish preinstall = (pythonRequirementsInstaller here), Nil
+
+#######################################################################
+# installFreedomMetal installs the Freedom Metal sources appropriate
+#   for a customer deliverable and excludes the testing and internal
+#   infrastructure like Wake sources, CI configuration, etc.
+# It takes the following parameter:
+#   - install Path: the path to install Freedom Metal in
+#######################################################################
+export target installFreedomMetal installPath =
+  def metalSources =
+    (subscribe freedomMetalSources | mapFlat (\d sources d `.*\.(c|h|S|j2|ini)`)) ++
+    sources here `.*\.make` ++
+    sources here `LICENSE.*`
+
+  mkdir installPath,
+  map (installIn installPath) metalSources

--- a/scripts/codegen.py
+++ b/scripts/codegen.py
@@ -340,9 +340,12 @@ def get_templates(template_paths, strip_dir=True):
 def get_c_sources(args):
     sources = []
     for d in args.source_paths:
-        sources += [g for g in glob.glob("{}/src/**/*.c".format(d), recursive=True)]
+        sources += [
+            "$(ROOT_DIR)/" + g
+            for g in glob.glob("{}/src/**/*.c".format(d), recursive=True)
+        ]
     sources += [
-        os.path.join(args.output_dir, t.replace(".j2", ""))
+        "$(ROOT_DIR)/" + args.output_dir + "/" + t.replace(".j2", "")
         for t in get_templates(args.template_paths)
         if ".c" in t
     ]
@@ -353,9 +356,12 @@ def get_c_sources(args):
 def get_asm_sources(args):
     sources = []
     for d in args.source_paths:
-        sources += [g for g in glob.glob("{}/src/**/*.S".format(d), recursive=True)]
+        sources += [
+            "$(ROOT_DIR)/" + g
+            for g in glob.glob("{}/src/**/*.S".format(d), recursive=True)
+        ]
     sources += [
-        os.path.join(args.output_dir, t.replace(".j2", ""))
+        "$(ROOT_DIR)/" + args.output_dir + "/" + t.replace(".j2", "")
         for t in get_templates(args.template_paths)
         if ".S" in t
     ]
@@ -474,6 +480,7 @@ def main():
         "devices": dict(),
         "default_drivers": dict(),
         "devicetree_path": args.dts,
+        "output_dir": args.output_dir,
         "c_sources": get_c_sources(args),
         "asm_sources": get_asm_sources(args),
         "source_dirs": get_source_dirs(args),

--- a/templates/metal.mk.j2
+++ b/templates/metal.mk.j2
@@ -1,14 +1,17 @@
 METAL_SRC = \
-        {{ c_sources|join(' \\\n        ') }} \
+	{{ c_sources|join(' \\\n        ') }} \
 	{{ asm_sources|join(' \\\n        ') }}
 
-METAL_CFLAGS = {% for path in source_paths %} -I{{ path }} {% endfor %}
-
+METAL_CFLAGS = \
+{% for path in source_paths %}
+	-I$(ROOT_DIR)/{{ path }} \
+{% endfor %}
 
 METAL_MK_DEPEND = \
-	{{ devicetree_path }} \
-	{{ templates|join(' \\\n        ') }}
-
+	$(ROOT_DIR)/{{ devicetree_path }} \
+{% for template in templates %}
+	$(ROOT_DIR)/{{ template }} \
+{% endfor %}
 
 METAL_SRC_PATH = {{ source_dirs|join(':') }}
 

--- a/tests/spike/core.dts
+++ b/tests/spike/core.dts
@@ -1,0 +1,45 @@
+/dts-v1/;
+
+/ {
+  #address-cells = <2>;
+  #size-cells = <2>;
+  compatible = "ucbbar,spike-bare-dev";
+  model = "ucbbar,spike-bare";
+  cpus {
+    #address-cells = <1>;
+    #size-cells = <0>;
+    timebase-frequency = <10000000>;
+    CPU0: cpu@0 {
+      device_type = "cpu";
+      reg = <0>;
+      status = "okay";
+      compatible = "riscv";
+      riscv,isa = "rv64imafdc";
+      mmu-type = "riscv,sv48";
+      clock-frequency = <1000000000>;
+      CPU0_intc: interrupt-controller {
+        #interrupt-cells = <1>;
+        interrupt-controller;
+        compatible = "riscv,cpu-intc";
+      };
+    };
+  };
+  memory@80000000 {
+    device_type = "memory";
+    reg = <0x0 0x80000000 0x0 0x80000000>;
+  };
+  soc {
+    #address-cells = <2>;
+    #size-cells = <2>;
+    compatible = "ucbbar,spike-bare-soc", "simple-bus";
+    ranges;
+    clint@2000000 {
+      compatible = "riscv,clint0";
+      interrupts-extended = <&CPU0_intc 3 &CPU0_intc 7 >;
+      reg = <0x0 0x2000000 0x0 0xc0000>;
+    };
+  };
+  htif {
+    compatible = "ucb,htif0";
+  };
+};

--- a/tests/spike/design.dts
+++ b/tests/spike/design.dts
@@ -1,0 +1,10 @@
+/include/ "core.dts"
+/ {
+	chosen {
+		metal,entry = <&{/memory@80000000} 0 0>;
+		metal,boothart = <&CPU0>;
+		stdout-path = "/htif:115200";
+		metal,itim = <&{/memory@80000000} 0 0>;
+		metal,ram = <&{/memory@80000000} 0 0>;
+	};
+};

--- a/tests/test-wake-api.sh
+++ b/tests/test-wake-api.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR=$(dirname $0)
+SPIKE_DTS_DIR=${SCRIPT_DIR}/spike
+
+OUTPUT_PATH="build/freedom-metal/generated"
+
+wake --init .
+
+wake -v --in freedom_metal -x "runFreedomMetalCodeGeneration \"build\" (makeFreedomMetalCodeGenerationOptions (source \"${SPIKE_DTS_DIR}/design.dts\") (sources \"${SPIKE_DTS_DIR}\" \`core.dts\`) \"${OUTPUT_PATH}\")"
+
+OUTPUTS=("${OUTPUT_PATH}/metal.mk" )
+for file in ${OUTPUTS[@]}; do
+        >&2 echo "$0: Checking for ${file}"
+        if [ ! -f ${file} ] ; then
+                >&2 echo "$0: ERROR Failed to produce ${file}"
+                exit 1
+        fi
+done

--- a/tests/test-wake-install.sh
+++ b/tests/test-wake-install.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR=$(dirname $0)
+
+OUTPUT_PATH="build/freedom-metal/install"
+
+wake --init .
+
+wake -v --in freedom_metal -x "installFreedomMetal \"${OUTPUT_PATH}\""
+
+OUTPUTS=("${OUTPUT_PATH}/freedom-metal/LICENSE" )
+for file in ${OUTPUTS[@]}; do
+        >&2 echo "$0: Checking for ${file}"
+        if [ ! -f ${file} ] ; then
+                >&2 echo "$0: ERROR Failed to produce ${file}"
+                exit 1
+        fi
+done

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -1,0 +1,8 @@
+[
+    {
+        "//": "v0.2.2",
+        "commit": "29770efe2cf4e72edfb05da1baa1a08c5638f839",
+        "name": "api-languages-sifive",
+        "source": "git@github.com:sifive/api-languages-sifive.git"
+    }
+]

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -1,7 +1,7 @@
 [
     {
-        "//": "v0.2.2",
-        "commit": "29770efe2cf4e72edfb05da1baa1a08c5638f839",
+        "//": "Commit on master with wake 0.18+ support",
+        "commit": "e135f6a013d830f34aeb1a9542f42c0aabc80813",
         "name": "api-languages-sifive",
         "source": "git@github.com:sifive/api-languages-sifive.git"
     }


### PR DESCRIPTION
This series adds support for running Freedom Metal code generation in a wit/wake build environment.

In order to make this work, generated paths in metal.mk are now relative to the `ROOT_DIR` Make variable. This allows the delivered make fragment to be reusable outside of the Wake build environment.