### PR TITLE
Support Handling each PLIC interrupt on each hart on multi-core

### DIFF
--- a/src/drivers/riscv_cpu.c
+++ b/src/drivers/riscv_cpu.c
@@ -466,21 +466,21 @@ void __metal_driver_riscv_cpu_controller_interrupt_init(
             intc->metal_exception_table[i] = __metal_default_exception_handler;
         }
 
-        /*
-         * Set the real trap handler if the value of mtvec is equal to
-         * early_trap_vector. If mtvec is not equal to early_trap_vector,
-         * that means user has own trap handler, then we don't overwrite it.
-         */
-        uintptr_t mtvec;
-        __asm__ volatile("csrr %0, mtvec" : "=r"(mtvec));
-        if (mtvec == (uintptr_t)&early_trap_vector) {
-            __metal_controller_interrupt_vector(
-                METAL_DIRECT_MODE,
-                (void *)(uintptr_t)&__metal_exception_handler);
-        }
         intc->init_done = 1;
     }
-}
+    /*
+     * Set the real trap handler if the value of mtvec is equal to
+     * early_trap_vector. If mtvec is not equal to early_trap_vector,
+     * that means user has own trap handler, then we don't overwrite it.
+     */
+    uintptr_t mtvec;
+    __asm__ volatile("csrr %0, mtvec" : "=r"(mtvec));
+    if (mtvec == (uintptr_t)&early_trap_vector) {
+        __metal_controller_interrupt_vector(
+            METAL_DIRECT_MODE,
+            (void *)(uintptr_t)&__metal_exception_handler);
+    }
+} 
 
 int __metal_driver_riscv_cpu_controller_interrupt_register(
     struct metal_interrupt *controller, int id, metal_interrupt_handler_t isr,

--- a/src/drivers/riscv_plic0.c
+++ b/src/drivers/riscv_plic0.c
@@ -187,10 +187,15 @@ int __metal_driver_riscv_plic0_register(struct metal_interrupt *controller,
 int __metal_driver_riscv_plic0_enable(struct metal_interrupt *controller,
                                       int id) {
     struct __metal_driver_riscv_plic0 *plic = (void *)(controller);
+    struct metal_interrupt *intc;
+    struct __metal_driver_cpu *cpu = __metal_cpu_table[__metal_myhart_id()];
 
     if (id >= __metal_driver_sifive_plic0_num_interrupts(controller)) {
         return -1;
     }
+
+    intc = (struct __metal_driver_riscv_cpu_intc *)__metal_driver_cpu_interrupt_controller(cpu);
+    intc->vtable->interrupt_enable(intc, METAL_INTERRUPT_ID_EXT);
 
     __metal_plic0_enable(plic, __metal_myhart_id(), id, METAL_ENABLE);
     return 0;
@@ -199,10 +204,15 @@ int __metal_driver_riscv_plic0_enable(struct metal_interrupt *controller,
 int __metal_driver_riscv_plic0_disable(struct metal_interrupt *controller,
                                        int id) {
     struct __metal_driver_riscv_plic0 *plic = (void *)(controller);
+    struct metal_interrupt *intc;
+    struct __metal_driver_cpu *cpu = __metal_cpu_table[__metal_myhart_id()];
 
     if (id >= __metal_driver_sifive_plic0_num_interrupts(controller)) {
         return -1;
     }
+    intc = (struct __metal_driver_riscv_cpu_intc *)__metal_driver_cpu_interrupt_controller(cpu);
+    intc->vtable->interrupt_disable(intc, METAL_INTERRUPT_ID_EXT);
+
     __metal_plic0_enable(plic, __metal_myhart_id(), id, METAL_DISABLE);
     return 0;
 }


### PR DESCRIPTION
Hi,
I have an issue.

The implementation of freedom-metal should be considered about PLIC interrupt handling on multi-core. But, currently, PLIC can be handled on only 1 core that registers an interrupt at first among several cores. For example, when the PLIC interrupt of BTN0 is registered on hart0 and PLIC of BTN1 is registered on hart1, only BTN0 works on hart0 and BTN1 doesn't work. Because mtvec and mie of only one core are enabled normally and other cores keep initial value - early_trap_vector (mtvec) and NULL (mie) instead of the address of __metal_exception_handler() (mtvec) and 0x800 (MEIE in mie).

So. I modified 2 files for this problem.
The modification in riscv_cpu.c is to enable mtvec on each core.
The modification in riscv_plic0.c is to set mie to 0x800 (MEIE) on each core.

Please refer [IPOBHD-176]( https://sifive.atlassian.net/servicedesk/customer/portal/64/IPOBHD-176) for detail.

Thanks,
Aiden.