### PR TITLE
Fix integer truncation on abs() call

### DIFF
--- a/src/drivers/sifive_fe310-g000_pll.c
+++ b/src/drivers/sifive_fe310-g000_pll.c
@@ -260,7 +260,13 @@ static int find_closest_config(long ref_hz, long rate) {
          i--) {
         long config_freq = get_pll_config_freq(ref_hz, &(pll_configs[i]));
         if (config_freq != PLL_CONFIG_NOT_VALID) {
-            long freq_diff = abs(config_freq - rate);
+            long freq_diff;
+            if (config_freq > rate) {
+                freq_diff = config_freq - rate;
+            } else {
+                freq_diff = rate - config_freq;
+            }
+
             if (freq_diff < closest_diff) {
                 closest_index = i;
                 closest_diff = freq_diff;


### PR DESCRIPTION
GCC 10 complains about possible integer truncation when passing a long int to abs().