### PR TITLE
Fix old-style function declarations/definitions

### DIFF
--- a/gloss/sys_fork.c
+++ b/gloss/sys_fork.c
@@ -1,6 +1,6 @@
 #include <errno.h>
 
-int _fork() {
+int _fork(void) {
     errno = ENOSYS;
     return -1;
 }

--- a/metal/cpu.h
+++ b/metal/cpu.h
@@ -51,7 +51,7 @@ static __inline__ struct metal_cpu metal_cpu_get_current_hart(void) {
 /*! @brief Get the number of CPU harts
  *
  * @return The number of CPU harts */
-static __inline__ int metal_cpu_get_num_harts() { return __METAL_DT_NUM_HARTS; }
+static __inline__ int metal_cpu_get_num_harts(void) { return __METAL_DT_NUM_HARTS; }
 
 /*!
  * @brief Enables the global interrupt enable for the hart

--- a/sifive-blocks/templates/metal/private/metal_private_sifive_fe310_g000_pll.h.j2
+++ b/sifive-blocks/templates/metal/private/metal_private_sifive_fe310_g000_pll.h.j2
@@ -72,7 +72,7 @@ void _{{ to_snakecase(devices[compat][0].compatible[0]) }}_post_rate_change_call
     {% endif %}
 {% endfor %}
 
-static __inline__ void pre_rate_change_callbacks() {
+static __inline__ void pre_rate_change_callbacks(void) {
 {% if sifive_fe310_g000_plls|length == 1 %}
     {% for compat in devices %}
 	{% for device in devices[compat] %}
@@ -86,7 +86,7 @@ static __inline__ void pre_rate_change_callbacks() {
 {% endif %}
 }
 
-static __inline__ void post_rate_change_callbacks() {
+static __inline__ void post_rate_change_callbacks(void) {
 {% if sifive_fe310_g000_plls|length == 1 %}
     {% for compat in devices %}
 	{% for device in devices[compat] %}

--- a/src/drivers/riscv_plic0.c
+++ b/src/drivers/riscv_plic0.c
@@ -94,7 +94,7 @@ static __inline__ int __metal_plic0_disable(int hartid, int id) {
 /* This is the interrupt handler for the machine external interrupt, which is
  * automatically named metal_riscv_plic0_source_0_handler() when a PLIC exists.
  */
-void metal_riscv_plic0_source_0_handler() {
+void metal_riscv_plic0_source_0_handler(void) {
     uint32_t hartid = metal_cpu_get_current_hartid();
 
     unsigned int idx = __metal_plic0_claim_interrupt(hartid);

--- a/src/pmp.c
+++ b/src/pmp.c
@@ -61,11 +61,11 @@ static uintptr_t _get_pmpaddr_granularity(uintptr_t address) {
 int metal_pmp_num_regions(int hartid) { return PMP_REGIONS(hartid); }
 
 /* Get the number of pmp regions for the current hart */
-static unsigned int _pmp_regions() {
+static unsigned int _pmp_regions(void) {
     return metal_pmp_num_regions(metal_cpu_get_current_hartid());
 }
 
-void metal_pmp_init() {
+void metal_pmp_init(void) {
     struct metal_pmp_config init_config = {
         .L = METAL_PMP_UNLOCKED,
         .A = METAL_PMP_OFF,

--- a/src/synchronize_harts.c
+++ b/src/synchronize_harts.c
@@ -8,7 +8,7 @@
  * hart 0 to finish copying the datat section, zeroing the BSS, and running
  * the libc contstructors.
  */
-__attribute__((section(".init"))) void __metal_synchronize_harts() {
+__attribute__((section(".init"))) void __metal_synchronize_harts(void) {
 #if __METAL_DT_NUM_HARTS > 1
     uint32_t hartid = metal_cpu_get_current_hartid();
 

--- a/templates/metal/interrupt_handlers.h.j2
+++ b/templates/metal/interrupt_handlers.h.j2
@@ -5,6 +5,7 @@
 
 #include <metal/cpu.h>
 #include <metal/interrupt.h>
+#include <metal/riscv.h>
 
 {% if harts|length > 1 and 'mmu_type' in harts[1] %}
 #define __METAL_NUM_EXCEPTIONS 16
@@ -29,7 +30,7 @@
 /*!
  * @brief Function signature for interrupt callback handlers
  */
-typedef void (*metal_interrupt_handler_t)();
+typedef void (*metal_interrupt_handler_t)(void);
 
 /*!
  * @brief Function signature for exception handlers
@@ -40,7 +41,7 @@ typedef void (*metal_exception_handler_t)(struct metal_cpu cpu, int ecode);
 extern const metal_exception_handler_t __metal_exception_table[__METAL_NUM_EXCEPTIONS];
 extern const metal_interrupt_handler_t __metal_local_interrupt_table[__METAL_NUM_LOCAL_INTERRUPTS];
 
-void __metal_exception_handler();
+void __metal_exception_handler(riscv_xlen_t mcause);
 
 void metal_exception_instruction_address_misaligned_handler(struct metal_cpu cpu, int ecode);
 void metal_exception_instruction_address_fault_handler(struct metal_cpu cpu, int ecode);
@@ -59,38 +60,38 @@ void metal_exception_load_page_fault_handler(struct metal_cpu cpu, int ecode);
 void metal_exception_store_amo_page_fault_handler(struct metal_cpu cpu, int ecode);
 
 
-void metal_riscv_cpu_intc_default_handler() __attribute__((interrupt));
+void metal_riscv_cpu_intc_default_handler(void) __attribute__((interrupt));
 
-void metal_riscv_cpu_intc_usip_handler(){% if local_interrupts['irqs'][0]['hwvectored'] %} __attribute__((interrupt)){% endif %};
-void metal_riscv_cpu_intc_ssip_handler(){% if local_interrupts['irqs'][1]['hwvectored'] %} __attribute__((interrupt)){% endif %};
-void metal_riscv_cpu_intc_msip_handler(){% if local_interrupts['irqs'][3]['hwvectored'] %} __attribute__((interrupt)){% endif %};
+void metal_riscv_cpu_intc_usip_handler(void){% if local_interrupts['irqs'][0]['hwvectored'] %} __attribute__((interrupt)){% endif %};
+void metal_riscv_cpu_intc_ssip_handler(void){% if local_interrupts['irqs'][1]['hwvectored'] %} __attribute__((interrupt)){% endif %};
+void metal_riscv_cpu_intc_msip_handler(void){% if local_interrupts['irqs'][3]['hwvectored'] %} __attribute__((interrupt)){% endif %};
 
-void metal_riscv_cpu_intc_utip_handler(){% if local_interrupts['irqs'][4]['hwvectored'] %} __attribute__((interrupt)){% endif %};
-void metal_riscv_cpu_intc_stip_handler(){% if local_interrupts['irqs'][5]['hwvectored'] %} __attribute__((interrupt)){% endif %};
-void metal_riscv_cpu_intc_mtip_handler(){% if local_interrupts['irqs'][7]['hwvectored'] %} __attribute__((interrupt)){% endif %};
+void metal_riscv_cpu_intc_utip_handler(void){% if local_interrupts['irqs'][4]['hwvectored'] %} __attribute__((interrupt)){% endif %};
+void metal_riscv_cpu_intc_stip_handler(void){% if local_interrupts['irqs'][5]['hwvectored'] %} __attribute__((interrupt)){% endif %};
+void metal_riscv_cpu_intc_mtip_handler(void){% if local_interrupts['irqs'][7]['hwvectored'] %} __attribute__((interrupt)){% endif %};
 
-void metal_riscv_cpu_intc_ueip_handler(){% if local_interrupts['irqs'][8]['hwvectored'] %} __attribute__((interrupt)){% endif %};
-void metal_riscv_cpu_intc_seip_handler(){% if local_interrupts['irqs'][9]['hwvectored'] %} __attribute__((interrupt)){% endif %};
+void metal_riscv_cpu_intc_ueip_handler(void){% if local_interrupts['irqs'][8]['hwvectored'] %} __attribute__((interrupt)){% endif %};
+void metal_riscv_cpu_intc_seip_handler(void){% if local_interrupts['irqs'][9]['hwvectored'] %} __attribute__((interrupt)){% endif %};
 {% if global_interrupts is defined %}
-void metal_riscv_plic0_source_0_handler(){% if local_interrupts['irqs'][11]['hwvectored'] %} __attribute__((interrupt)){% endif %};
+void metal_riscv_plic0_source_0_handler(void){% if local_interrupts['irqs'][11]['hwvectored'] %} __attribute__((interrupt)){% endif %};
 {% else %}
-void metal_riscv_cpu_intc_meip_handler(){% if local_interrupts['irqs'][11]['hwvectored'] %} __attribute__((interrupt)){% endif %};
+void metal_riscv_cpu_intc_meip_handler(void){% if local_interrupts['irqs'][11]['hwvectored'] %} __attribute__((interrupt)){% endif %};
 {% endif %}
 
 {% if 'sifive,clic0' in devices %}
-void metal_sifive_clic0_csip_handler(){% if local_interrupts['irqs'][12]['hwvectored'] %} __attribute__((interrupt)){% endif %};
+void metal_sifive_clic0_csip_handler(void){% if local_interrupts['irqs'][12]['hwvectored'] %} __attribute__((interrupt)){% endif %};
 {% endif %}
 
 {% if 'sifive,buserror0' in devices %}
   {% if local_interrupts['irqs']|length >= 128 %}
-void metal_sifive_buserror0_source_0_handler(){% if local_interrupts['irqs'][128]['hwvectored'] %} __attribute__((interrupt)){% endif %};
+void metal_sifive_buserror0_source_0_handler(void){% if local_interrupts['irqs'][128]['hwvectored'] %} __attribute__((interrupt)){% endif %};
   {% endif %}
 {% endif %}
 
 {% if local_interrupts is defined %}
     {% for irq in local_interrupts.irqs|unique_irqs %}
        {% if irq.id >= 16 and irq.source.compatible != None %}
-void metal_{{ to_snakecase(irq.source.compatible) }}_source_{{ irq.source.id }}_handler(){% if local_interrupts['irqs'][irq.id]['hwvectored'] %} __attribute__((interrupt)){% endif %};
+void metal_{{ to_snakecase(irq.source.compatible) }}_source_{{ irq.source.id }}_handler(void){% if local_interrupts['irqs'][irq.id]['hwvectored'] %} __attribute__((interrupt)){% endif %};
         {% endif %}
     {% endfor %}
 {% endif %}
@@ -98,7 +99,7 @@ void metal_{{ to_snakecase(irq.source.compatible) }}_source_{{ irq.source.id }}_
 {% if global_interrupts is defined %}
     {% for irq in global_interrupts.irqs|unique_irqs %}
        {% if irq.source.compatible != None %}
-void metal_{{ to_snakecase(irq.source.compatible) }}_source_{{ irq.source.id }}_handler();
+void metal_{{ to_snakecase(irq.source.compatible) }}_source_{{ irq.source.id }}_handler(void);
         {% endif %}
     {% endfor %}
 {% endif %}

--- a/templates/src/interrupt_handlers.c.j2
+++ b/templates/src/interrupt_handlers.c.j2
@@ -16,16 +16,16 @@ void _metal_exception_handler_nop(struct metal_cpu cpu, int ecode) {
     metal_shutdown(100);
 }
 
-void _metal_local_interrupt_handler_nop() __attribute((interrupt));
-void _metal_local_interrupt_handler_nop() {
+void _metal_local_interrupt_handler_nop(void) __attribute((interrupt));
+void _metal_local_interrupt_handler_nop(void) {
     metal_shutdown(200);
 }
 
-void _metal_global_interrupt_handler_nop() {
+void _metal_global_interrupt_handler_nop(void) {
     metal_shutdown(300);
 }
 
-/* Alias default exception handlers to _metal_exception_handler_nop() */
+/* Alias default exception handlers to _metal_exception_handler_nop(void) */
 void metal_exception_instruction_address_misaligned_handler(struct metal_cpu cpu, int ecode) __attribute__((weak, alias("_metal_exception_handler_nop")));
 void metal_exception_instruction_address_fault_handler(struct metal_cpu cpu, int ecode) __attribute__((weak, alias("_metal_exception_handler_nop")));
 void metal_exception_illegal_instruction_handler(struct metal_cpu cpu, int ecode) __attribute__((weak, alias("_metal_exception_handler_nop")));
@@ -42,40 +42,40 @@ void metal_exception_instruction_page_fault_handler(struct metal_cpu cpu, int ec
 void metal_exception_load_page_fault_handler(struct metal_cpu cpu, int ecode) __attribute__((weak, alias("_metal_exception_handler_nop")));
 void metal_exception_store_amo_page_fault_handler(struct metal_cpu cpu, int ecode) __attribute__((weak, alias("_metal_exception_handler_nop")));
 
-/* Alias default local interrupt handlers to _metal_local_interrupt_handler_nop() */
-void metal_riscv_cpu_intc_default_handler() __attribute__((weak, alias("_metal_local_interrupt_handler_nop"))); 
-void metal_riscv_cpu_intc_usip_handler() __attribute__((weak, alias("_metal_local_interrupt_handler_nop")));
-void metal_riscv_cpu_intc_ssip_handler() __attribute__((weak, alias("_metal_local_interrupt_handler_nop")));
-void metal_riscv_cpu_intc_msip_handler() __attribute__((weak, alias("_metal_local_interrupt_handler_nop")));
-void metal_riscv_cpu_intc_utip_handler() __attribute__((weak, alias("_metal_local_interrupt_handler_nop")));
-void metal_riscv_cpu_intc_stip_handler() __attribute__((weak, alias("_metal_local_interrupt_handler_nop")));
-void metal_riscv_cpu_intc_mtip_handler() __attribute__((weak, alias("_metal_local_interrupt_handler_nop")));
-void metal_riscv_cpu_intc_ueip_handler() __attribute__((weak, alias("_metal_local_interrupt_handler_nop")));
-void metal_riscv_cpu_intc_seip_handler() __attribute__((weak, alias("_metal_local_interrupt_handler_nop")));
+/* Alias default local interrupt handlers to _metal_local_interrupt_handler_nop(void) */
+void metal_riscv_cpu_intc_default_handler(void) __attribute__((weak, alias("_metal_local_interrupt_handler_nop"))); 
+void metal_riscv_cpu_intc_usip_handler(void) __attribute__((weak, alias("_metal_local_interrupt_handler_nop")));
+void metal_riscv_cpu_intc_ssip_handler(void) __attribute__((weak, alias("_metal_local_interrupt_handler_nop")));
+void metal_riscv_cpu_intc_msip_handler(void) __attribute__((weak, alias("_metal_local_interrupt_handler_nop")));
+void metal_riscv_cpu_intc_utip_handler(void) __attribute__((weak, alias("_metal_local_interrupt_handler_nop")));
+void metal_riscv_cpu_intc_stip_handler(void) __attribute__((weak, alias("_metal_local_interrupt_handler_nop")));
+void metal_riscv_cpu_intc_mtip_handler(void) __attribute__((weak, alias("_metal_local_interrupt_handler_nop")));
+void metal_riscv_cpu_intc_ueip_handler(void) __attribute__((weak, alias("_metal_local_interrupt_handler_nop")));
+void metal_riscv_cpu_intc_seip_handler(void) __attribute__((weak, alias("_metal_local_interrupt_handler_nop")));
 {% if global_interrupts is defined %}
-void metal_riscv_plic0_source_0_handler() __attribute__((weak, alias("_metal_local_interrupt_handler_nop")));
+void metal_riscv_plic0_source_0_handler(void) __attribute__((weak, alias("_metal_local_interrupt_handler_nop")));
 {% else %}
-void metal_riscv_cpu_intc_meip_handler() __attribute__((weak, alias("_metal_local_interrupt_handler_nop")));
+void metal_riscv_cpu_intc_meip_handler(void) __attribute__((weak, alias("_metal_local_interrupt_handler_nop")));
 {% endif %}
 {% if 'sifive,clic0' in devices %}
-void metal_sifive_clic0_csip_handler() __attribute__((weak, alias("_metal_local_interrupt_handler_nop")));
+void metal_sifive_clic0_csip_handler(void) __attribute__((weak, alias("_metal_local_interrupt_handler_nop")));
 {% endif %}
 {% if 'sifive,buserror0' in devices %}
-void metal_sifive_buserror0_source_0_handler() __attribute__((weak, alias("_metal_local_interrupt_handler_nop")));
+void metal_sifive_buserror0_source_0_handler(void) __attribute__((weak, alias("_metal_local_interrupt_handler_nop")));
 {% endif %}
 {% if local_interrupts is defined %}
     {% for irq in local_interrupts.irqs|unique_irqs %}
         {% if irq.id >= 16 and irq.source.compatible != None %}
-void metal_{{ to_snakecase(irq.source.compatible) }}_source_{{ irq.source.id }}_handler() __attribute__((weak, alias("_metal_local_interrupt_handler_nop")));
+void metal_{{ to_snakecase(irq.source.compatible) }}_source_{{ irq.source.id }}_handler(void) __attribute__((weak, alias("_metal_local_interrupt_handler_nop")));
         {% endif %}
     {% endfor %}
 {% endif %}
 
-/* Alias default global interrupt handlers to _metal_global_interrupt_handler_nop() */
+/* Alias default global interrupt handlers to _metal_global_interrupt_handler_nop(void) */
 {% if global_interrupts is defined %}
     {% for irq in global_interrupts.irqs|unique_irqs %}
         {% if irq.source.compatible != None %}
-void metal_{{ to_snakecase(irq.source.compatible) }}_source_{{ irq.source.id }}_handler() __attribute__((weak, alias ("_metal_global_interrupt_handler_nop")));
+void metal_{{ to_snakecase(irq.source.compatible) }}_source_{{ irq.source.id }}_handler(void) __attribute__((weak, alias ("_metal_global_interrupt_handler_nop")));
         {% endif %}
     {% endfor %}
 {% endif %}


### PR DESCRIPTION
Functions taking no arguments should be defined using (void) instead
of () as the latter means 'unknown arguments' instead of 'no arguments'.

There was only one function declared using () which took a parameter,
__metal_exception_handler, which is defined to take 'riscv_xlen_t
mcause' but declared using ().

Signed-off-by: Keith Packard <keithp@keithp.com>