### PR TITLE
[next] Add support for ucb,htif0 for the Spike simulator

### DIFF
--- a/metal/drivers/ucb_htif0.h
+++ b/metal/drivers/ucb_htif0.h
@@ -1,0 +1,22 @@
+/* Copyright 2020 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef METAL__DRIVERS__UCB_HTIF0_H
+#define METAL__DRIVERS__UCB_HTIF0_H
+
+/*!
+ * @brief Print a character over the HTIF interface
+ * @param c The character to print
+ * @return 0 upon success
+ *
+ * If the ucb,htif0 device is selected as the standard out path
+ * in the Devicetree's chosen node, metal_tty_putc() (and therefore
+ * all standard out from libc) is sent out over this function.
+ *
+ * The driver exposes this function itself so that applications can
+ * manually print characters over the HTIF even when another device
+ * is selected as the standard out path.
+ */
+int ucb_htif0_putc(int c);
+
+#endif /* !METAL__DRIVERS_UCB_HTIF0_H */

--- a/src/drivers/ucb_htif0.c
+++ b/src/drivers/ucb_htif0.c
@@ -1,0 +1,128 @@
+/* Copyright 2018 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include <metal/machine/platform.h>
+
+#ifdef METAL_UCB_HTIF0
+
+#include <metal/drivers/ucb_htif0.h>
+#include <metal/io.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#define FINISHER_OFFSET 0
+
+volatile uint64_t fromhost __attribute__((aligned(4096)));
+volatile uint64_t tohost __attribute__((aligned(4096)));
+
+#if __riscv_xlen == 64
+#define TOHOST_CMD(dev, cmd, payload)                                          \
+    (((uint64_t)(dev) << 56) | ((uint64_t)(cmd) << 48) | (uint64_t)(payload))
+#else
+#define TOHOST_CMD(dev, cmd, payload)                                          \
+    ({                                                                         \
+        if ((dev) || (cmd))                                                    \
+            __builtin_trap();                                                  \
+        (payload);                                                             \
+    })
+#endif
+#define FROMHOST_DEV(fromhost_value) ((uint64_t)(fromhost_value) >> 56)
+#define FROMHOST_CMD(fromhost_value) ((uint64_t)(fromhost_value) << 8 >> 56)
+#define FROMHOST_DATA(fromhost_value) ((uint64_t)(fromhost_value) << 16 >> 16)
+
+static void __check_fromhost() {
+    uint64_t fh = fromhost;
+    if (!fh)
+        return;
+    fromhost = 0;
+}
+
+static void __set_tohost(uintptr_t dev, uintptr_t cmd, uintptr_t data) {
+    while (tohost)
+        __check_fromhost();
+    tohost = TOHOST_CMD(dev, cmd, data);
+}
+
+static void do_tohost_fromhost(uintptr_t dev, uintptr_t cmd, uintptr_t data) {
+    __set_tohost(dev, cmd, data);
+
+    while (1) {
+        uint64_t fh = fromhost;
+        if (fh) {
+            if (FROMHOST_DEV(fh) == dev && FROMHOST_CMD(fh) == cmd) {
+                fromhost = 0;
+                break;
+            }
+            __check_fromhost();
+        }
+    }
+}
+
+void __metal_driver_ucb_htif0_init(struct metal_uart *uart, int baud_rate) {}
+
+void __metal_driver_ucb_htif0_exit(const struct __metal_shutdown *sd,
+                                   int code) {
+    volatile uint64_t magic_mem[8];
+    magic_mem[0] = 93; // SYS_exit
+    magic_mem[1] = code;
+    magic_mem[2] = 0;
+    magic_mem[3] = 0;
+
+    do_tohost_fromhost(0, 0, (uintptr_t)magic_mem);
+
+    while (1) {
+        // loop forever
+    }
+}
+
+int __metal_driver_ucb_htif0_putc(struct metal_uart *htif, int c) {
+    volatile uint64_t magic_mem[8];
+    magic_mem[0] = 64; // SYS_write
+    magic_mem[1] = 1;
+    magic_mem[2] = (uintptr_t)&c;
+    magic_mem[3] = 1;
+
+    do_tohost_fromhost(0, 0, (uintptr_t)magic_mem);
+
+    return 0;
+}
+
+int __metal_driver_ucb_htif0_getc(struct metal_uart *htif, int *c) {
+    return -1;
+}
+
+int __metal_driver_ucb_htif0_get_baud_rate(struct metal_uart *guart) {
+    return 0;
+}
+
+int __metal_driver_ucb_htif0_set_baud_rate(struct metal_uart *guart,
+                                           int baud_rate) {
+    return 0;
+}
+
+struct metal_interrupt *
+__metal_driver_ucb_htif0_interrupt_controller(struct metal_uart *uart) {
+    return NULL;
+}
+
+int __metal_driver_ucb_htif0_get_interrupt_id(struct metal_uart *uart) {
+    return -1;
+}
+
+__METAL_DEFINE_VTABLE(__metal_driver_vtable_ucb_htif0_shutdown) = {
+    .shutdown.exit = &__metal_driver_ucb_htif0_exit,
+};
+
+__METAL_DEFINE_VTABLE(__metal_driver_vtable_ucb_htif0_uart) = {
+    .uart.init = __metal_driver_ucb_htif0_init,
+    .uart.putc = __metal_driver_ucb_htif0_putc,
+    .uart.getc = __metal_driver_ucb_htif0_getc,
+    .uart.get_baud_rate = __metal_driver_ucb_htif0_get_baud_rate,
+    .uart.set_baud_rate = __metal_driver_ucb_htif0_set_baud_rate,
+    .uart.controller_interrupt = __metal_driver_ucb_htif0_interrupt_controller,
+    .uart.get_interrupt_id = __metal_driver_ucb_htif0_get_interrupt_id,
+};
+
+#endif /* METAL_UCB_HTIF0 */
+
+typedef int no_empty_translation_units;

--- a/src/drivers/ucb_htif0.c
+++ b/src/drivers/ucb_htif0.c
@@ -1,12 +1,13 @@
 /* Copyright 2018 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 
-#include <metal/machine/platform.h>
+#include <metal/platform.h>
 
 #ifdef METAL_UCB_HTIF0
 
 #include <metal/drivers/ucb_htif0.h>
-#include <metal/io.h>
+#include <metal/private/metal_private_ucb_htif0.h>
+#include <metal/tty.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -30,7 +31,7 @@ volatile uint64_t tohost __attribute__((aligned(4096)));
 #define FROMHOST_CMD(fromhost_value) ((uint64_t)(fromhost_value) << 8 >> 56)
 #define FROMHOST_DATA(fromhost_value) ((uint64_t)(fromhost_value) << 16 >> 16)
 
-static void __check_fromhost() {
+static void __check_fromhost(void) {
     uint64_t fh = fromhost;
     if (!fh)
         return;
@@ -58,10 +59,23 @@ static void do_tohost_fromhost(uintptr_t dev, uintptr_t cmd, uintptr_t data) {
     }
 }
 
-void __metal_driver_ucb_htif0_init(struct metal_uart *uart, int baud_rate) {}
+int ucb_htif0_putc(int c) {
+    volatile uint64_t magic_mem[8];
+    magic_mem[0] = 64; // SYS_write
+    magic_mem[1] = 1;
+    magic_mem[2] = (uintptr_t)&c;
+    magic_mem[3] = 1;
 
-void __metal_driver_ucb_htif0_exit(const struct __metal_shutdown *sd,
-                                   int code) {
+    do_tohost_fromhost(0, 0, (uintptr_t)magic_mem);
+
+    return 0;
+}
+
+#ifdef METAL_STDOUT_UCB_HTIF0
+int metal_tty_putc(int c) __attribute__((alias("ucb_htif0_putc")));
+#endif /* METAL_STDOUT_UCB_HTIF0 */
+
+void metal_shutdown(int code) {
     volatile uint64_t magic_mem[8];
     magic_mem[0] = 93; // SYS_exit
     magic_mem[1] = code;
@@ -74,54 +88,6 @@ void __metal_driver_ucb_htif0_exit(const struct __metal_shutdown *sd,
         // loop forever
     }
 }
-
-int __metal_driver_ucb_htif0_putc(struct metal_uart *htif, int c) {
-    volatile uint64_t magic_mem[8];
-    magic_mem[0] = 64; // SYS_write
-    magic_mem[1] = 1;
-    magic_mem[2] = (uintptr_t)&c;
-    magic_mem[3] = 1;
-
-    do_tohost_fromhost(0, 0, (uintptr_t)magic_mem);
-
-    return 0;
-}
-
-int __metal_driver_ucb_htif0_getc(struct metal_uart *htif, int *c) {
-    return -1;
-}
-
-int __metal_driver_ucb_htif0_get_baud_rate(struct metal_uart *guart) {
-    return 0;
-}
-
-int __metal_driver_ucb_htif0_set_baud_rate(struct metal_uart *guart,
-                                           int baud_rate) {
-    return 0;
-}
-
-struct metal_interrupt *
-__metal_driver_ucb_htif0_interrupt_controller(struct metal_uart *uart) {
-    return NULL;
-}
-
-int __metal_driver_ucb_htif0_get_interrupt_id(struct metal_uart *uart) {
-    return -1;
-}
-
-__METAL_DEFINE_VTABLE(__metal_driver_vtable_ucb_htif0_shutdown) = {
-    .shutdown.exit = &__metal_driver_ucb_htif0_exit,
-};
-
-__METAL_DEFINE_VTABLE(__metal_driver_vtable_ucb_htif0_uart) = {
-    .uart.init = __metal_driver_ucb_htif0_init,
-    .uart.putc = __metal_driver_ucb_htif0_putc,
-    .uart.getc = __metal_driver_ucb_htif0_getc,
-    .uart.get_baud_rate = __metal_driver_ucb_htif0_get_baud_rate,
-    .uart.set_baud_rate = __metal_driver_ucb_htif0_set_baud_rate,
-    .uart.controller_interrupt = __metal_driver_ucb_htif0_interrupt_controller,
-    .uart.get_interrupt_id = __metal_driver_ucb_htif0_get_interrupt_id,
-};
 
 #endif /* METAL_UCB_HTIF0 */
 

--- a/src/tty.c
+++ b/src/tty.c
@@ -22,4 +22,7 @@ int nop_putc(int c) {
     return -1;
 }
 
+int nop_getc(int *c) { return -1; }
+
 int metal_tty_putc(int c) __attribute__((weak, alias("nop_putc")));
+int metal_tty_getc(int *c) __attribute__((weak, alias("nop_getc")));

--- a/templates/MANIFEST.ini
+++ b/templates/MANIFEST.ini
@@ -6,3 +6,6 @@ Compatible = fixed-clock fixed-factor-clock
 
 [interrupt]
 Compatible = riscv,cpu-intc riscv,plic0
+
+[shutdown]
+Compatible = ucb,htif0

--- a/templates/metal/platform/metal_platform_ucb_htif0.h.j2
+++ b/templates/metal/platform/metal_platform_ucb_htif0.h.j2
@@ -1,0 +1,14 @@
+/* Copyright 2020 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef METAL__PLATFORM__UCB_HTIF0_H
+#define METAL__PLATFORM__UCB_HTIF0_H
+
+{% if 'ucb,htif0' in devices %}
+
+#define METAL_UCB_HTIF0
+#define __METAL_HAS_SHUTDOWN
+
+{% endif %}
+
+#endif

--- a/templates/metal/private/metal_private_ucb_htif0.h.j2
+++ b/templates/metal/private/metal_private_ucb_htif0.h.j2
@@ -1,0 +1,23 @@
+/* Copyright 2020 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef METAL__PRIVATE__UCB_HTIF0_H
+#define METAL__PRIVATE__UCB_HTIF0_H
+
+{% include 'template_comment.h.j2' %}
+
+{% if 'ucb,htif0' in devices %}
+
+{% if chosen.stdout_path is defined %}
+{% if chosen.stdout_path[0].compatible[0] == "ucb,htif0" %}
+
+/* ucb,htif0 has been selected by the Devicetree to provide
+ * standard out for the Freedom Metal program
+ */
+#define METAL_STDOUT_UCB_HTIF0
+{% endif %}
+{% endif %}
+
+{% endif %}
+
+#endif


### PR DESCRIPTION
In addition to adding back the HTIF driver, we also add a weak alias for metal_tty_getc() so that targets without stdio can build with picolibc.