### PR TITLE
Add support for L2 LIM.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -78,6 +78,7 @@ nobase_include_HEADERS += \
 	metal/io.h \
 	metal/itim.h \
 	metal/led.h \
+	metal/lim.h \
 	metal/lock.h \
 	metal/memory.h \
 	metal/pmp.h \

--- a/Makefile.in
+++ b/Makefile.in
@@ -480,10 +480,10 @@ nobase_include_HEADERS = metal/machine.h metal/machine/inline.h \
 	metal/cache.h metal/clock.h metal/compiler.h metal/cpu.h \
 	metal/csr.h metal/gpio.h metal/hpm.h metal/i2c.h metal/init.h \
 	metal/interrupt.h metal/io.h metal/itim.h metal/led.h \
-	metal/lock.h metal/memory.h metal/pmp.h metal/privilege.h \
-	metal/pwm.h metal/rtc.h metal/shutdown.h metal/scrub.h \
-	metal/spi.h metal/switch.h metal/timer.h metal/time.h \
-	metal/tty.h metal/uart.h metal/watchdog.h
+	metal/lim.h metal/lock.h metal/memory.h metal/pmp.h \
+	metal/privilege.h metal/pwm.h metal/rtc.h metal/shutdown.h \
+	metal/scrub.h metal/spi.h metal/switch.h metal/timer.h \
+	metal/time.h metal/tty.h metal/uart.h metal/watchdog.h
 
 # This will generate these sources before the compilation step
 BUILT_SOURCES = \

--- a/gloss/crt0.S
+++ b/gloss/crt0.S
@@ -108,6 +108,36 @@ _start:
      complete */
   fence.i
 
+2:
+
+  /* Copy the LIM section */
+  la t0, metal_segment_lim_source_start
+  la t1, metal_segment_lim_target_start
+  la t2, metal_segment_lim_target_end
+
+  beq t0, t1, 2f
+  bge t1, t2, 2f
+
+1:
+#if __riscv_xlen == 32
+  lw   a0, 0(t0)
+  addi t0, t0, 4
+  sw   a0, 0(t1)
+  addi t1, t1, 4
+  blt  t1, t2, 1b
+#else
+  ld   a0, 0(t0)
+  addi t0, t0, 8
+  sd   a0, 0(t1)
+  addi t1, t1, 8
+  blt  t1, t2, 1b
+#endif
+2:
+
+  /* Fence all subsequent instruction fetches until after the LIM writes
+     complete */
+  fence.i
+
   /* Zero the BSS segment. */
   la t1, metal_segment_bss_target_start
   la t2, metal_segment_bss_target_end

--- a/metal/drivers/sifive_ccache0.h
+++ b/metal/drivers/sifive_ccache0.h
@@ -29,6 +29,7 @@ typedef enum {
 
 /*! @brief Initialize cache controller, enables all available
  *         cache-ways.
+ *         Note: If LIM is in use, corresponding cache ways are not enabled.
  * @param None.
  * @return 0 If no error.*/
 int sifive_ccache0_init(void);

--- a/metal/lim.h
+++ b/metal/lim.h
@@ -1,0 +1,20 @@
+/* Copyright 2020 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef METAL__LIM_H
+#define METAL__LIM_H
+
+/*! @file lim.h
+ *
+ * API for manipulating LIM allocation
+ */
+
+/*! @def METAL_PLACE_IN_LIM
+ * @brief Link a function into the LIM
+ *
+ * Link a function into the LIM (Loosely Integrated
+ * Memory) if the LIM is present on the target device.
+ */
+#define METAL_PLACE_IN_LIM __attribute__((section(".lim")))
+
+#endif


### PR DESCRIPTION
Update cache driver _init() to not enable cache ways corresponding to L2 LIM region in use.