### PR TITLE
Fix for PLIC interrupt issue on multiple core

### DIFF
--- a/src/drivers/riscv_plic0.c
+++ b/src/drivers/riscv_plic0.c
@@ -187,35 +187,42 @@ int __metal_driver_riscv_plic0_register(struct metal_interrupt *controller,
 int __metal_driver_riscv_plic0_enable(struct metal_interrupt *controller,
                                       int id) {
     struct __metal_driver_riscv_plic0 *plic = (void *)(controller);
-
+    int contextid =
+        __metal_driver_sifive_plic0_context_ids(__metal_myhart_id());
+ 
     if (id >= __metal_driver_sifive_plic0_num_interrupts(controller)) {
         return -1;
     }
 
-    __metal_plic0_enable(plic, __metal_myhart_id(), id, METAL_ENABLE);
+    __metal_plic0_enable(plic, contextid, id, METAL_ENABLE);
     return 0;
 }
 
 int __metal_driver_riscv_plic0_disable(struct metal_interrupt *controller,
                                        int id) {
     struct __metal_driver_riscv_plic0 *plic = (void *)(controller);
-
+    int contextid =
+        __metal_driver_sifive_plic0_context_ids(__metal_myhart_id());
+ 
     if (id >= __metal_driver_sifive_plic0_num_interrupts(controller)) {
         return -1;
     }
-    __metal_plic0_enable(plic, __metal_myhart_id(), id, METAL_DISABLE);
+    __metal_plic0_enable(plic, contextid, id, METAL_DISABLE);
     return 0;
 }
 
 int __metal_driver_riscv_plic0_set_threshold(struct metal_interrupt *controller,
                                              unsigned int threshold) {
-    return __metal_plic0_set_threshold(controller, __metal_myhart_id(),
-                                       threshold);
+    int contextid =
+        __metal_driver_sifive_plic0_context_ids(__metal_myhart_id());
+    return __metal_plic0_set_threshold(controller, contextid, threshold);
 }
 
 unsigned int
 __metal_driver_riscv_plic0_get_threshold(struct metal_interrupt *controller) {
-    return __metal_plic0_get_threshold(controller, __metal_myhart_id());
+     int contextid =
+        __metal_driver_sifive_plic0_context_ids(__metal_myhart_id());
+     return __metal_plic0_get_threshold(controller, contextid);
 }
 
 metal_affinity


### PR DESCRIPTION
#### Issue Description
Related ticket: https://sifive.atlassian.net/servicedesk/customer/portal/64/IPOBHD-190

On U74 MC, there are 4 U74 Cores.
The external interrupt on PLIC was correctly working for hart 0.
And the PLIC interrupt for the other harts are not working at all

#### Root Cause
Wrong interrupt enable PLIC register offset was given on enabling interrupts for all hart except hart 0.
it gives the hard id on`__metal_plic0_enable` but this should be context id.

#### Bench Test
- [x] : External interrupt for all hart worked well with sesame and standard package(U74 MC) on vcu118