### PR TITLE
build.wake: Ensure output directory is created before installing.

### DIFF
--- a/build.wake
+++ b/build.wake
@@ -61,9 +61,10 @@ global def runFreedomMetalInstall options =
   def metalInstallDir = outputDir
 
   def installedFreedomMetal =
-    def inputs =
+    def sourceFiles =
       sources freedomMetalRoot `.*`
       | filter (!matches (freedomMetalRoot.quote, `/doc/.*`, Nil).regExpCat _.getPathName)
+    def inputs = mkdir outputDir, sourceFiles
     def cmdline =
       "rsync",
       "-r",


### PR DESCRIPTION
Wake's directory handling is a bit flawed, and you can run into situations where sometimes a build rule won't run correctly when an output directory is not passed in as a visible file to the `Plan`. The way to avoid any issues is to always call `mkdir` on the directory in Wake to produce a `Path` corresponding to the directory, and then passing that into the visible file list to a `Plan`.

I did this for the `runFreedomMetalInstall` function, since I was hitting issues trying to bump freedom-metal in api-generator-sifive.