### PR TITLE
Fix comparator_count and compare_width fields in dt_pwm_data for PWM

### DIFF
--- a/sifive-blocks/templates/metal/private/metal_private_sifive_pwm0.h.j2
+++ b/sifive-blocks/templates/metal/private/metal_private_sifive_pwm0.h.j2
@@ -54,11 +54,11 @@ static const struct dt_pwm_data {
 		.interrupt_parent = { {{ pwm.interrupt_parent[0].id }} },
 		.interrupt_id = {{ pwm.interrupts[0] }},
 	{% endif %}
-	{% if pwm.ncomparators is defined %}
-		.comparator_count = {{ pwm.ncomparators }},
+	{% if pwm.sifive_ncomparators is defined %}
+		.comparator_count = {{ pwm.sifive_ncomparators[0] }},
 	{% endif %}
-	{% if pwm.comparator_widthbits is defined %}
-		.compare_width = {{ pwm.comparator_widthbits }},
+	{% if pwm.sifive_comparator_widthbits is defined %}
+		.compare_width = {{ pwm.sifive_comparator_widthbits[0] }},
 	{% endif %}
 	},
 	{% endfor %}


### PR DESCRIPTION
**Issue Description**
PWM doesn't work well with example-pwm in freedom-metal-next branch.
There are missing comparator_count and compare_width fields in dt_pwm_data for PWM.

**Root Cause**
In core.dts, pwm node has following properties.
sifive,ncomparators
sifive,comparator-widthbits
But, j2 file includes the wrong item name. It needs to fix.

**Test**
example-pwm works well on sesame with vcu-118 fpga.

**Question**
I have another issue.
I'd like to test PWM interrupt, too. But it has only one interrupt_id in dt_pwm_data, though interrupts property in pwm node in core.dts file has 4 interrupt ids. Also, in sifive_pwm0.c, there is no API to get which interrupt index to enable/disable PWM interrupt.
I think it should also fix. Can I add the code for these issues?