### PR TITLE
Support to enable parent interrupt of PWM channel ID in metal_pwm_cfg_interrupt

### DIFF
--- a/metal/pwm.h
+++ b/metal/pwm.h
@@ -93,8 +93,10 @@ int metal_pwm_stop(struct metal_pwm pwm, uint32_t idx);
 /*! @brief Enable or Disable PWM interrupts.
  * @param pwm PWM device handle.
  * @param flag PWM interrupt enable flag.
+ * @param idx PWM channel id.
  * @return 0 If no error.*/
-int metal_pwm_cfg_interrupt(struct metal_pwm pwm, metal_pwm_interrupt_t flag);
+int metal_pwm_cfg_interrupt(struct metal_pwm pwm, metal_pwm_interrupt_t flag,
+                            uint32_t idx);
 
 /*! @brief Clears pending interrupt flags.
  * @param pwm PWM device handle.

--- a/sifive-blocks/src/drivers/sifive_pwm0.c
+++ b/sifive-blocks/src/drivers/sifive_pwm0.c
@@ -249,17 +249,21 @@ int sifive_pwm0_stop(struct metal_pwm pwm, uint32_t idx) {
     return ret;
 }
 
-int sifive_pwm0_cfg_interrupt(struct metal_pwm pwm,
-                              metal_pwm_interrupt_t flag) {
+int sifive_pwm0_cfg_interrupt(struct metal_pwm pwm, metal_pwm_interrupt_t flag,
+                              uint32_t idx) {
     uintptr_t base = dt_pwm_data[get_index(pwm)].base_addr;
+    struct metal_interrupt intc = dt_pwm_data[get_index(pwm)].interrupt_parent;
+    int id = dt_pwm_data[get_index(pwm)].interrupt_id[idx];
     int ret = METAL_PWM_RET_ERR;
 
     if (base != 0) {
         if (flag == METAL_PWM_INTERRUPT_ENABLE) {
             /* Enable sticky bit, to make sure interrupts are not forgotten */
             METAL_PWM_REGW(METAL_SIFIVE_PWM0_PWMCFG) |= METAL_PWMCFG_STICKY;
+            metal_interrupt_enable(intc, id);
         } else {
             METAL_PWM_REGW(METAL_SIFIVE_PWM0_PWMCFG) &= ~METAL_PWMCFG_STICKY;
+            metal_interrupt_disable(intc, id);
         }
         ret = METAL_PWM_RET_OK;
     }

--- a/sifive-blocks/templates/metal/private/metal_private_sifive_pwm0.h.j2
+++ b/sifive-blocks/templates/metal/private/metal_private_sifive_pwm0.h.j2
@@ -26,7 +26,7 @@ static const struct dt_pwm_data {
 	uint32_t pinmux_output_selector;
 	uint32_t pinmux_source_selector;
 	struct metal_interrupt interrupt_parent;
-	uint32_t interrupt_id;
+	uint32_t interrupt_id[4];
 	uint8_t comparator_count;
 	uint8_t	compare_width;
 } dt_pwm_data[__METAL_DT_NUM_PWMS] = {
@@ -52,7 +52,9 @@ static const struct dt_pwm_data {
 	{% if pwm.interrupt_parent is defined %}
 	    /* {{ pwm.interrupt_parent[0].compatible[0] }} */
 		.interrupt_parent = { {{ pwm.interrupt_parent[0].id }} },
-		.interrupt_id = {{ pwm.interrupts[0] }},
+		.interrupt_id = {
+			{{ pwm.interrupts[0] }},{{ pwm.interrupts[1] }},{{ pwm.interrupts[2] }},{{ pwm.interrupts[3] }},
+		},
 	{% endif %}
 	{% if pwm.sifive_ncomparators is defined %}
 		.comparator_count = {{ pwm.sifive_ncomparators[0] }},

--- a/sifive-blocks/templates/metal/private/metal_private_sifive_pwm0.h.j2
+++ b/sifive-blocks/templates/metal/private/metal_private_sifive_pwm0.h.j2
@@ -26,7 +26,7 @@ static const struct dt_pwm_data {
 	uint32_t pinmux_output_selector;
 	uint32_t pinmux_source_selector;
 	struct metal_interrupt interrupt_parent;
-	uint32_t interrupt_id[4];
+	uint32_t interrupt_id[{{sifive_pwm0s[0].interrupts|length}}];
 	uint8_t comparator_count;
 	uint8_t	compare_width;
 } dt_pwm_data[__METAL_DT_NUM_PWMS] = {
@@ -52,9 +52,7 @@ static const struct dt_pwm_data {
 	{% if pwm.interrupt_parent is defined %}
 	    /* {{ pwm.interrupt_parent[0].compatible[0] }} */
 		.interrupt_parent = { {{ pwm.interrupt_parent[0].id }} },
-		.interrupt_id = {
-			{{ pwm.interrupts[0] }},{{ pwm.interrupts[1] }},{{ pwm.interrupts[2] }},{{ pwm.interrupts[3] }},
-		},
+		.interrupt_id = { {% for interrupt in pwm.interrupts %} {{ interrupt }}, {% endfor %} },
 	{% endif %}
 	{% if pwm.sifive_ncomparators is defined %}
 		.comparator_count = {{ pwm.sifive_ncomparators[0] }},


### PR DESCRIPTION
**Issue Description**
PWM Interrupt doesn't work well with example-pwm in freedom-metal-next branch on [sesame.](url)

**Root Cause**
In sesame core.dts, the number of pwm interrupt channel ID is 4. pwm0 : 35, 36, 37, 38, pwm1 : 39, 40, 41, 42
```
		L43: pwm@10020000 {
			clocks = <&L39>;
			compatible = "sifive,pwm0";
			interrupt-parent = <&L3>;
			interrupts = <35 36 37 38>;
			reg = <0x0 0x10020000 0x0 0x1000>;
			reg-names = "control";
			sifive,comparator-widthbits = <16>;
			sifive,ncomparators = <4>;
		};
		L44: pwm@10021000 {
			clocks = <&L39>;
			compatible = "sifive,pwm0";
			interrupt-parent = <&L3>;
			interrupts = <39 40 41 42>;
			reg = <0x0 0x10021000 0x0 0x1000>;
			reg-names = "control";
			sifive,comparator-widthbits = <16>;
			sifive,ncomparators = <4>;
		};
```
But, the implement in j2 file considered the index only for the first one instead of all indexes. So there is no API to get which index in PLIC to enable/disable interrupt.
Also, there is no code to enable parent interrupt (PLIC) of PWM.

**Test**
example-pwm works well with ENABLE_INTERRUPTS on sesame with vcu-118 fpga.
all index interrupts of pwm work well.
I checked it with clang-formater.

Additionally, to test this PR, it should change example-pwm code too as below.
```
--- a/software/example-pwm/example-pwm.c
+++ b/software/example-pwm/example-pwm.c
@@ -31,7 +31,7 @@
 
 #ifdef ENABLE_INTERRUPTS
 
-void metal_sifive_pwm0_source0_handler(void)
+void metal_sifive_pwm0_source_0_handler(void)
{
     static unsigned int i = 0;
 
@@ -73,7 +63,8 @@ int main(void) {
     metal_pwm_trigger(pwm, 0, METAL_PWM_CONTINUOUS);
 
 #ifdef ENABLE_INTERRUPTS
-    metal_pwm_cfg_interrupt(pwm, METAL_PWM_INTERRUPT_ENABLE);
+    metal_pwm_cfg_interrupt(pwm, METAL_PWM_INTERRUPT_ENABLE, 0);
+    metal_cpu_enable_interrupts();
#else
     metal_pwm_set_duty(pwm, 2, 90, METAL_PWM_PHASE_CORRECT_DISABLE);
     metal_pwm_set_duty(pwm, 3, 20, METAL_PWM_PHASE_CORRECT_DISABLE);
```
