### PR TITLE
fix template file for metal_private_gpio.h

### DIFF
--- a/templates/metal/private/metal_private_gpio.h.j2
+++ b/templates/metal/private/metal_private_gpio.h.j2
@@ -14,8 +14,8 @@
 #define metal_gpio_enable_output {{ driver_string }}_enable_output
 #define metal_gpio_disable_output {{ driver_string }}_disable_output
 #define metal_gpio_set_pin {{ driver_string }}_set_pin
-#define metal_gpio_input_pin {{ driver_string }}_input_pin
-#define metal_gpio_output_pin {{ driver_string }}_output_pin
+#define metal_gpio_get_input_pin {{ driver_string }}_get_input_pin
+#define metal_gpio_get_output_pin {{ driver_string }}_get_output_pin
 #define metal_gpio_clear_pin {{ driver_string }}_clear_pin
 #define metal_gpio_toggle_pin {{ driver_string }}_toggle_pin
 #define metal_gpio_enable_pinmux {{ driver_string }}_enable_pinmux


### PR DESCRIPTION
**Description**
In metal_private_gpio.h.j2,  template variable needs "_get_" for  get_intput/output_pin.