### PR TITLE
fix gpio interrupt clear bit control

### DIFF
--- a/sifive-blocks/src/drivers/sifive_gpio0.c
+++ b/sifive-blocks/src/drivers/sifive_gpio0.c
@@ -154,30 +154,30 @@ int sifive_gpio0_clear_interrupt(struct metal_gpio gpio, int pin,
 
     switch (int_type) {
     case METAL_GPIO_INT_RISING:
-        GPIO_REGW(METAL_SIFIVE_GPIO0_RISE_IP) |= (1 << pin);
+        GPIO_REGW(METAL_SIFIVE_GPIO0_RISE_IP) = (1 << pin);
         break;
     case METAL_GPIO_INT_FALLING:
-        GPIO_REGW(METAL_SIFIVE_GPIO0_FALL_IP) |= (1 << pin);
+        GPIO_REGW(METAL_SIFIVE_GPIO0_FALL_IP) = (1 << pin);
         break;
     case METAL_GPIO_INT_BOTH_EDGE:
-        GPIO_REGW(METAL_SIFIVE_GPIO0_RISE_IP) |= (1 << pin);
-        GPIO_REGW(METAL_SIFIVE_GPIO0_FALL_IP) |= (1 << pin);
+        GPIO_REGW(METAL_SIFIVE_GPIO0_RISE_IP) = (1 << pin);
+        GPIO_REGW(METAL_SIFIVE_GPIO0_FALL_IP) = (1 << pin);
         break;
     case METAL_GPIO_INT_HIGH:
-        GPIO_REGW(METAL_SIFIVE_GPIO0_HIGH_IP) |= (1 << pin);
+        GPIO_REGW(METAL_SIFIVE_GPIO0_HIGH_IP) = (1 << pin);
         break;
     case METAL_GPIO_INT_LOW:
-        GPIO_REGW(METAL_SIFIVE_GPIO0_LOW_IP) |= (1 << pin);
+        GPIO_REGW(METAL_SIFIVE_GPIO0_LOW_IP) = (1 << pin);
         break;
     case METAL_GPIO_INT_BOTH_LEVEL:
-        GPIO_REGW(METAL_SIFIVE_GPIO0_HIGH_IP) |= (1 << pin);
-        GPIO_REGW(METAL_SIFIVE_GPIO0_LOW_IP) |= (1 << pin);
+        GPIO_REGW(METAL_SIFIVE_GPIO0_HIGH_IP) = (1 << pin);
+        GPIO_REGW(METAL_SIFIVE_GPIO0_LOW_IP) = (1 << pin);
         break;
     case METAL_GPIO_INT_MAX:
-        GPIO_REGW(METAL_SIFIVE_GPIO0_RISE_IP) |= (1 << pin);
-        GPIO_REGW(METAL_SIFIVE_GPIO0_FALL_IP) |= (1 << pin);
-        GPIO_REGW(METAL_SIFIVE_GPIO0_HIGH_IP) |= (1 << pin);
-        GPIO_REGW(METAL_SIFIVE_GPIO0_LOW_IP) |= (1 << pin);
+        GPIO_REGW(METAL_SIFIVE_GPIO0_RISE_IP) = (1 << pin);
+        GPIO_REGW(METAL_SIFIVE_GPIO0_FALL_IP) = (1 << pin);
+        GPIO_REGW(METAL_SIFIVE_GPIO0_HIGH_IP) = (1 << pin);
+        GPIO_REGW(METAL_SIFIVE_GPIO0_LOW_IP) = (1 << pin);
         break;
     default:
         return -1;


### PR DESCRIPTION
**Issue Description**

I try to clear only one bit of the interrupt pending register.
But all the bits in register is cleared.

**Root Cause**

I checked "sifive_gpio0_clear_interrupt()" in sifive_gpio.c 
To clear a pending bit, there was "|= OR" operation like 

    case METAL_GPIO_INT_RISING:
        GPIO_REGW(METAL_SIFIVE_GPIO0_RISE_IP) |= (1 << pin);
    break;

**Test**

After i  replaced  "|=" operation with "=" ,  this problem is cleared on fpga vcu118

Refer to : https://sifive.atlassian.net/servicedesk/customer/portal/64/IPOBHD-308