### PR TITLE
Fix crt0 passes unaligned argv to main()

### DIFF
--- a/gloss/crt0.S
+++ b/gloss/crt0.S
@@ -293,6 +293,7 @@ secondary_main:
 /* This shim allows main() to be passed a set of arguments that can satisfy the
  * requirements of the C API. */
 .section .rodata.libgloss.start
+.align 8
 argv:
 .dc.a name
 envp:


### PR DESCRIPTION
argv may be unaligned depend on the context of rodata, then causes application occurs unaligned fault when paring argv