### PR TITLE
configure.ac: Fix typo in help messages.

### DIFF
--- a/configure
+++ b/configure
@@ -1364,10 +1364,10 @@ Optional Features:
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
   --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
-  --with-bultin-libgloss  Build libgloss along with Metal
-  --with-bultin-libmetal-pico
+  --with-builtin-libgloss Build libgloss along with Metal
+  --with-builtin-libmetal-pico
                           Build libmetal-pico along with Metal
-  --with-bultin-libmetal-segger
+  --with-builtin-libmetal-segger
                           Build libmetal-segger along with Metal
   --with-machine-header=PATH
                           Path to the machine header file

--- a/configure.ac
+++ b/configure.ac
@@ -31,19 +31,19 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([],[
 ########################################################
 
 AC_ARG_WITH([builtin-libgloss],
-    [AS_HELP_STRING([--with-bultin-libgloss], [Build libgloss along with Metal])],
+    [AS_HELP_STRING([--with-builtin-libgloss], [Build libgloss along with Metal])],
     [with_builtin_libgloss="yes"],
     [with_builtin_libgloss="no"]
 )
 
 AC_ARG_WITH([builtin-libmetal-pico],
-    [AS_HELP_STRING([--with-bultin-libmetal-pico], [Build libmetal-pico along with Metal])],
+    [AS_HELP_STRING([--with-builtin-libmetal-pico], [Build libmetal-pico along with Metal])],
     [with_builtin_libmetal_pico="yes"],
     [with_builtin_libmetal_pico="no"]
 )
 
 AC_ARG_WITH([builtin-libmetal-segger],
-    [AS_HELP_STRING([--with-bultin-libmetal-segger], [Build libmetal-segger along with Metal])],
+    [AS_HELP_STRING([--with-builtin-libmetal-segger], [Build libmetal-segger along with Metal])],
     [with_builtin_libmetal_segger="yes"],
     [with_builtin_libmetal_segger="no"]
 )


### PR DESCRIPTION
Help messsages for the following commands contained a typo:
- `--with-builtin-libgloss`
- `--with-builtin-libmetal-pico`
- `--with-builtin-libmetal-segger`

This commit fixes those.

configure.ac has been regenerated using autoconf 2.69.