### PR TITLE
Fix clang build due to declare a symbol with both .weak and .global

### DIFF
--- a/gloss/crt0.S
+++ b/gloss/crt0.S
@@ -264,7 +264,6 @@ _fini:
 /* By default, secondary_main will cause secondary harts to spin forever.
  * Users can redefine secondary_main themselves to run code on secondary harts */
 .weak   secondary_main
-.global secondary_main
 .type   secondary_main, @function
 
 secondary_main:

--- a/src/entry.S
+++ b/src/entry.S
@@ -110,7 +110,6 @@ _enter:
  * but to deal with what I think is probably a bug in the linker script I'm
  * going to leave this in for now.  At least it's fairly cheap :) */
 .weak __register_frame_info
-.global __register_frame_info
 .section .text.metal.init.__register_frame_info
 __register_frame_info:
     .cfi_startproc

--- a/src/scrub.S
+++ b/src/scrub.S
@@ -87,7 +87,6 @@ __metal_memory_scrub:
  */
 .weak __metal_eccscrub_bit
 .weak __metal_before_start
-.global __metal_before_start
 .type __metal_before_start, @function
 __metal_before_start:
     /* Save caller ra */

--- a/src/vector.S
+++ b/src/vector.S
@@ -4,85 +4,65 @@
 /*
  * Jump table for CLINT vectored mode
  */
+.balign 4, 0
 .weak metal_interrupt_vector_handler
-.balign 4, 0
-.global metal_interrupt_vector_handler
 
+.balign 4, 0
 .weak metal_software_interrupt_vector_handler
-.balign 4, 0
-.global metal_software_interrupt_vector_handler
 
+.balign 4, 0
 .weak metal_timer_interrupt_vector_handler
-.balign 4, 0
-.global metal_timer_interrupt_vector_handler
 
+.balign 4, 0
 .weak metal_external_interrupt_vector_handler
-.balign 4, 0
-.global metal_external_interrupt_vector_handler
 
+.balign 4, 0
 .weak metal_lc0_interrupt_vector_handler
-.balign 4, 0
-.global metal_lc0_interrupt_vector_handler
 
+.balign 4, 0
 .weak metal_lc1_interrupt_vector_handler
-.balign 4, 0
-.global metal_lc1_interrupt_vector_handler
 
+.balign 4, 0
 .weak metal_lc2_interrupt_vector_handler
-.balign 4, 0
-.global metal_lc2_interrupt_vector_handler
 
+.balign 4, 0
 .weak metal_lc3_interrupt_vector_handler
-.balign 4, 0
-.global metal_lc3_interrupt_vector_handler
 
+.balign 4, 0
 .weak metal_lc4_interrupt_vector_handler
-.balign 4, 0
-.global metal_lc4_interrupt_vector_handler
 
+.balign 4, 0
 .weak metal_lc5_interrupt_vector_handler
-.balign 4, 0
-.global metal_lc5_interrupt_vector_handler
 
+.balign 4, 0
 .weak metal_lc6_interrupt_vector_handler
-.balign 4, 0
-.global metal_lc6_interrupt_vector_handler
 
+.balign 4, 0
 .weak metal_lc7_interrupt_vector_handler
-.balign 4, 0
-.global metal_lc7_interrupt_vector_handler
 
+.balign 4, 0
 .weak metal_lc8_interrupt_vector_handler
-.balign 4, 0
-.global metal_lc8_interrupt_vector_handler
 
+.balign 4, 0
 .weak metal_lc9_interrupt_vector_handler
-.balign 4, 0
-.global metal_lc9_interrupt_vector_handler
 
+.balign 4, 0
 .weak metal_lc10_interrupt_vector_handler
-.balign 4, 0
-.global metal_lc10_interrupt_vector_handler
 
+.balign 4, 0
 .weak metal_lc11_interrupt_vector_handler
-.balign 4, 0
-.global metal_lc11_interrupt_vector_handler
 
+.balign 4, 0
 .weak metal_lc12_interrupt_vector_handler
-.balign 4, 0
-.global metal_lc12_interrupt_vector_handler
 
+.balign 4, 0
 .weak metal_lc13_interrupt_vector_handler
-.balign 4, 0
-.global metal_lc13_interrupt_vector_handler
 
+.balign 4, 0
 .weak metal_lc14_interrupt_vector_handler
-.balign 4, 0
-.global metal_lc14_interrupt_vector_handler
 
-.weak metal_lc15_interrupt_vector_handler
 .balign 4, 0
-.global metal_lc15_interrupt_vector_handler
+.weak metal_lc15_interrupt_vector_handler
 
 #if __riscv_xlen == 32
 .balign 128, 0


### PR DESCRIPTION
 - A symbol is either weak and global bind, declare a symbol with .weak
   and .global will result weak binding only in binutils.

 - But in LLVM, such kind of legacy usage is forbidden.

Ref: https://reviews.llvm.org/D90108