### PR TITLE
Support compact code model for freedom-metal.

### DIFF
--- a/gloss/crt0.S
+++ b/gloss/crt0.S
@@ -41,7 +41,15 @@ _start:
    * to just "addi gp, gp, 0". */
 .option push
 .option norelax
+#ifdef __riscv_cmodel_compact
+1:
+  auipc a0, %pcrel_hi(__global_pointer__)
+  addi a0, a0, %pcrel_lo(1b)
+  ld   gp, 0(a0)
+  add  gp, gp, a0
+#else
   la gp, __global_pointer$
+#endif
 .option pop
 
   /* Stack pointer is expected to be initialized before _start */
@@ -57,9 +65,15 @@ _start:
    * is optional: if the METAL provides an environment in which this relocation
    * is not necessary then it must simply set metal_segment_data_source_start to
    * be equal to metal_segment_data_target_start. */
+#ifdef __riscv_cmodel_compact
+  la.got.gprel t0, metal_segment_data_source_start
+  lla.gprel t1, metal_segment_data_target_start
+  lla.gprel t2, metal_segment_data_target_end
+#else
   la t0, metal_segment_data_source_start
   la t1, metal_segment_data_target_start
   la t2, metal_segment_data_target_end
+#endif
 
   beq t0, t1, 2f
   bge t1, t2, 2f
@@ -81,9 +95,15 @@ _start:
 2:
 
   /* Copy the ITIM section */
+#ifdef __riscv_cmodel_compact
+  la.got.gprel t0, metal_segment_itim_source_start
+  la.got.gprel t1, metal_segment_itim_target_start
+  la.got.gprel t2, metal_segment_itim_target_end
+#else
   la t0, metal_segment_itim_source_start
   la t1, metal_segment_itim_target_start
   la t2, metal_segment_itim_target_end
+#endif
 
   beq t0, t1, 2f
   bge t1, t2, 2f
@@ -111,9 +131,15 @@ _start:
 2:
 
   /* Copy the LIM section */
+#ifdef __riscv_cmodel_compact
+  la.got.gprel t0, metal_segment_lim_source_start
+  lla.gprel t1, metal_segment_lim_target_start
+  lla.gprel t2, metal_segment_lim_target_end
+#else
   la t0, metal_segment_lim_source_start
   la t1, metal_segment_lim_target_start
   la t2, metal_segment_lim_target_end
+#endif
 
   beq t0, t1, 2f
   bge t1, t2, 2f
@@ -139,8 +165,13 @@ _start:
   fence.i
 
   /* Zero the BSS segment. */
+#ifdef __riscv_cmodel_compact
+  lla.gprel t1, metal_segment_bss_target_start
+  lla.gprel t2, metal_segment_bss_target_end
+#else
   la t1, metal_segment_bss_target_start
   la t2, metal_segment_bss_target_end
+#endif
 
   bge t1, t2, 2f
 
@@ -158,7 +189,11 @@ _start:
 
   /* Set TLS pointer */
   .weak __tls_base	
+#ifdef __riscv_cmodel_compact
+  lla.gprel tp, __tls_base
+#else
   la tp, __tls_base
+#endif
 
   /* At this point we're in an environment that can execute C code.  The first
    * thing to do is to make the callback to the parent environment if it's been
@@ -300,3 +335,12 @@ envp:
 name:
 .asciz "libgloss"
 
+#ifdef __riscv_cmodel_compact
+/* Compact stub.  */
+  .section .text.__global_pointer__, "aMG",@progbits, 8, __global_pointer__, comdat
+  .align 3
+  .global __global_pointer__
+  .type   __global_pointer__, object
+__global_pointer__:
+  .quad   __global_pointer$ -.
+#endif

--- a/src/entry.S
+++ b/src/entry.S
@@ -21,7 +21,15 @@ _enter:
      * that's safe as it's a fixed register. */
 .option push
 .option norelax
+#ifdef __riscv_cmodel_compact
+1:
+    auipc a0, %pcrel_hi(__global_pointer__)
+    addi a0, a0, %pcrel_lo(1b)
+    ld   gp, 0(a0)
+    add  gp, gp, a0
+#else
     la gp, __global_pointer$
+#endif
 .option pop
 
     /* trap over the chicken bit register clearing, aloe & fe310 dont have it */
@@ -53,7 +61,11 @@ _enter:
     * stack alignment. */
 
     bne sp, zero, 1f
+#ifdef __riscv_cmodel_compact
+    lla.gprel sp, _sp
+#else
     la sp, _sp
+#endif
 1:
     /* Increment by hartid number of stack sizes */
     csrr a0, mhartid

--- a/src/scrub.S
+++ b/src/scrub.S
@@ -112,14 +112,24 @@ __metal_before_start:
     bne     a5, t0, skip_scrub
 
     /* Zero out data segment */
+#ifdef __riscv_cmodel_compact
+    lla.gprel t1, metal_segment_data_target_start
+    lla.gprel t2, metal_segment_data_target_end
+#else
     la      t1, metal_segment_data_target_start
     la      t2, metal_segment_data_target_end
+#endif
     beq     t1, t2, 1f
     jal     __metal_memory_scrub
 1:
     /* Zero out itim memory */
+#ifdef __riscv_cmodel_compact
+    la.got.gprel t1, metal_segment_itim_target_start
+    la.got.gprel t2, metal_segment_itim_target_end
+#else
     la      t1, metal_segment_itim_target_start
     la      t2, metal_segment_itim_target_end
+#endif
     beq     t1, t2, skip_scrub
     jal     __metal_memory_scrub
 


### PR DESCRIPTION
Hi Guys,

I got the request recently that our freedom-e-sdk cannot build compact code model for coremark and dhrystone.  If we use the following configuration in metal.customer.lds,

MEMORY
{
    itim (airwx) : ORIGIN = 0x1801000, LENGTH = 0x1000
    ram (arw!xi) : ORIGIN = 0x1000000000, LENGTH = 0x1000000000
    rom (irx!wa) : ORIGIN = 0x200000000, LENGTH = 0x1fffffff
}

Then we will get a lot of ld truncated fails for R_RISCV_GPREL relocation.  There are two issues need to be fixed as follows,

1. The parts of .LCx and .Lx labels are actually ROdata, once we move the RWdata (gp is also there) far away from text and Rodata, then the gprel range may be not enough to use.  But if we move the ROdata and RWdata together, then gprel access should be fine.  Unfortunately gcc cannot know the section configurations until the linker have parsed the linker script, so probably always use got_gprel for those cases should be the safest method.  This is toolchain's issue rather than freedom-e-sdk, so just for reference only.

2. We need to support compact patterns in freedom-metal, just like what we did in the newlib.  This PR adds those compact cases, when RISCV_CMODEL sets to `compact`.

* When to use GPREL?  Only RWdata which are placed nearly gp.
* When to use GOT_GPREL?  ROdata, since they can be placed anywhere.  Sometimes they are near to text, but sometimes they are near to RWdata, depends on which linker script is used.
* When to use pcrel?  Symbols defined in the text section. 

Thanks
Nelson
