### PR TITLE
Initialize V-extension CSRs

### DIFF
--- a/gloss/crt0.S
+++ b/gloss/crt0.S
@@ -260,6 +260,9 @@ _skip_init:
   csrr a5, mstatus
   ori a5, a5, 0x200
   csrw mstatus, a5
+  csrwi vstart, 0
+  csrwi vxrm, 0
+  csrwi vxsat, 0
 1:
 
   /* This is a C runtime, so main() is defined to have some arguments.  Since

--- a/gloss/crt0.S
+++ b/gloss/crt0.S
@@ -252,7 +252,9 @@ _skip_init:
   csrwi fcsr, 0
 1:
 
-  /* Check for vector extension support and enable it if found */
+  /* Check for vector extension support and enable it if found.
+   * Omit if toolchain doesn't support the vector extension. */
+#ifdef __riscv_v
   csrr a5, misa
   li a4, 0x200000
   and a5, a5, a4
@@ -263,6 +265,7 @@ _skip_init:
   vsetivli x0, 0, e8, m1, ta, ma
   csrwi vcsr, 0
 1:
+#endif
 
   /* This is a C runtime, so main() is defined to have some arguments.  Since
    * there's nothing sane the METAL can pass we don't bother with that but

--- a/gloss/crt0.S
+++ b/gloss/crt0.S
@@ -261,8 +261,7 @@ _skip_init:
   ori a5, a5, 0x200
   csrw mstatus, a5
   vsetivli x0, 0, e8, m1, ta, ma
-  csrwi vxrm, 0
-  csrwi vxsat, 0
+  csrwi vcsr, 0
 1:
 
   /* This is a C runtime, so main() is defined to have some arguments.  Since

--- a/gloss/crt0.S
+++ b/gloss/crt0.S
@@ -260,7 +260,7 @@ _skip_init:
   csrr a5, mstatus
   ori a5, a5, 0x200
   csrw mstatus, a5
-  csrwi vstart, 0
+  vsetivli x0, 0, e8, m1, ta, ma
   csrwi vxrm, 0
   csrwi vxsat, 0
 1:


### PR DESCRIPTION
When initializing the vector unit (when present), boot code should also initialize `vstart`, `vxrm`, and `vxsat`; see [spec](https://github.com/riscv/riscv-v-spec/blob/master/v-spec.adoc#state-of-vector-extension-at-reset).

Closes #375, which concerns a particular problem that may arise when this is not done.