### PR TITLE
crt0: make argv 8-byte aligned

### DIFF
--- a/gloss/crt0.S
+++ b/gloss/crt0.S
@@ -327,7 +327,7 @@ secondary_main:
 /* This shim allows main() to be passed a set of arguments that can satisfy the
  * requirements of the C API. */
 .section .rodata.libgloss.start
-.align 8
+.balign 8
 argv:
 .dc.a name
 envp:


### PR DESCRIPTION
backport commit 79d0422c03d9828f8d083e160a556ffc71b35759