### PR TITLE
Use balign 8 for 8 series, otherwise use align 8.

### DIFF
--- a/gloss/crt0.S
+++ b/gloss/crt0.S
@@ -332,7 +332,11 @@ secondary_main:
 /* This shim allows main() to be passed a set of arguments that can satisfy the
  * requirements of the C API. */
 .section .rodata.libgloss.start
+#ifdef __is_series_8
 .balign 8
+#else
+.align 8
+#endif
 argv:
 .dc.a name
 envp:


### PR DESCRIPTION
The performance numbers drop for e76, and s76 with coremark, and dhrystone due to [freedom-metal PR-374](https://github.com/sifive/freedom-metal/pull/374).
* For coremark: e76: 5.71 -> 5.69 ;s76: 5.72 -> 5.67
* For dhrystone: e76: 3.0 -> 2.97

I understand it is necessary for u84 (5.6 -> 5.77 in dhrystone).
Therefore, I develop a mechanism to use align or balign by recognizing RISCV_SERIES.
This mechanism need [another PR in freedom-e-sdk](https://github.com/sifive/freedom-e-sdk-private/pull/113).
Please review, and merge it as well.