### PR TITLE
driver: fix maximum number of interrupts supported by CLIC

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -38,6 +38,7 @@ nobase_include_HEADERS += \
 	metal/drivers/riscv_clint0.h \
 	metal/drivers/riscv_cpu.h \
 	metal/drivers/riscv_plic0.h \
+	metal/drivers/sifive_remapper2.h \
 	metal/drivers/sifive_buserror0.h \
 	metal/drivers/sifive_ccache0.h \
 	metal/drivers/sifive_clic0.h \
@@ -63,6 +64,7 @@ nobase_include_HEADERS += \
 	metal/drivers/sifive_simuart0.h \
 	metal/drivers/sifive_wdog0.h \
 	metal/drivers/ucb_htif0.h \
+	metal/remapper.h \
 	metal/atomic.h \
 	metal/button.h \
 	metal/cache.h \
@@ -109,6 +111,7 @@ libmetal_a_SOURCES = \
 	src/drivers/riscv_clint0.c \
 	src/drivers/riscv_cpu.c \
 	src/drivers/riscv_plic0.c \
+	src/drivers/sifive_remapper2.c \
 	src/drivers/sifive_buserror0.c \
 	src/drivers/sifive_ccache0.c \
 	src/drivers/sifive_clic0.c \
@@ -134,6 +137,7 @@ libmetal_a_SOURCES = \
 	src/drivers/sifive_simuart0.c \
 	src/drivers/sifive_wdog0.c \
 	src/drivers/ucb_htif0.c \
+	src/remapper.c \
 	src/atomic.c \
 	src/button.c \
 	src/cache.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -81,6 +81,7 @@ nobase_include_HEADERS += \
 	metal/lim.h \
 	metal/lock.h \
 	metal/memory.h \
+	metal/nmi.h \
 	metal/pmp.h \
 	metal/privilege.h \
 	metal/pwm.h\

--- a/Makefile.am
+++ b/Makefile.am
@@ -54,6 +54,7 @@ nobase_include_HEADERS += \
 	metal/drivers/sifive_gpio0.h \
 	metal/drivers/sifive_i2c0.h \
 	metal/drivers/sifive_l2pf0.h \
+	metal/drivers/sifive_l2pf1.h \
 	metal/drivers/sifive_local-external-interrupts0.h \
 	metal/drivers/sifive_pwm0.h \
 	metal/drivers/sifive_rtc0.h \
@@ -127,6 +128,7 @@ libmetal_a_SOURCES = \
 	src/drivers/sifive_gpio0.c \
 	src/drivers/sifive_i2c0.c \
 	src/drivers/sifive_l2pf0.c \
+	src/drivers/sifive_l2pf1.c \
 	src/drivers/sifive_local-external-interrupts0.c \
 	src/drivers/sifive_pwm0.c \
 	src/drivers/sifive_rtc0.c \

--- a/Makefile.in
+++ b/Makefile.in
@@ -481,7 +481,7 @@ nobase_include_HEADERS = metal/machine.h metal/machine/inline.h \
 	metal/cache.h metal/clock.h metal/compiler.h metal/cpu.h \
 	metal/csr.h metal/gpio.h metal/hpm.h metal/i2c.h metal/init.h \
 	metal/interrupt.h metal/io.h metal/itim.h metal/led.h \
-	metal/lim.h metal/lock.h metal/memory.h metal/pmp.h \
+	metal/lim.h metal/lock.h metal/memory.h metal/nmi.h metal/pmp.h \
 	metal/privilege.h metal/pwm.h metal/rtc.h metal/shutdown.h \
 	metal/scrub.h metal/spi.h metal/switch.h metal/timer.h \
 	metal/time.h metal/tty.h metal/uart.h metal/watchdog.h

--- a/Makefile.in
+++ b/Makefile.in
@@ -242,6 +242,7 @@ am_libmetal_a_OBJECTS = src/drivers/fixed-clock.$(OBJEXT) \
 	src/drivers/sifive_gpio0.$(OBJEXT) \
 	src/drivers/sifive_i2c0.$(OBJEXT) \
 	src/drivers/sifive_l2pf0.$(OBJEXT) \
+	src/drivers/sifive_l2pf1.$(OBJEXT) \
 	src/drivers/sifive_local-external-interrupts0.$(OBJEXT) \
 	src/drivers/sifive_pwm0.$(OBJEXT) \
 	src/drivers/sifive_rtc0.$(OBJEXT) \
@@ -473,6 +474,7 @@ nobase_include_HEADERS = metal/machine.h metal/machine/inline.h \
 	metal/drivers/sifive_gpio-switches.h \
 	metal/drivers/sifive_gpio0.h metal/drivers/sifive_i2c0.h \
 	metal/drivers/sifive_l2pf0.h \
+	metal/drivers/sifive_l2pf1.h \
 	metal/drivers/sifive_local-external-interrupts0.h \
 	metal/drivers/sifive_pwm0.h metal/drivers/sifive_rtc0.h \
 	metal/drivers/sifive_spi0.h metal/drivers/sifive_test0.h \
@@ -523,6 +525,7 @@ libmetal_a_SOURCES = \
 	src/drivers/sifive_gpio0.c \
 	src/drivers/sifive_i2c0.c \
 	src/drivers/sifive_l2pf0.c \
+	src/drivers/sifive_l2pf1.c \
 	src/drivers/sifive_local-external-interrupts0.c \
 	src/drivers/sifive_pwm0.c \
 	src/drivers/sifive_rtc0.c \
@@ -825,6 +828,8 @@ src/drivers/sifive_i2c0.$(OBJEXT): src/drivers/$(am__dirstamp) \
 	src/drivers/$(DEPDIR)/$(am__dirstamp)
 src/drivers/sifive_l2pf0.$(OBJEXT): src/drivers/$(am__dirstamp) \
 	src/drivers/$(DEPDIR)/$(am__dirstamp)
+src/drivers/sifive_l2pf1.$(OBJEXT): src/drivers/$(am__dirstamp) \
+	src/drivers/$(DEPDIR)/$(am__dirstamp)
 src/drivers/sifive_local-external-interrupts0.$(OBJEXT):  \
 	src/drivers/$(am__dirstamp) \
 	src/drivers/$(DEPDIR)/$(am__dirstamp)
@@ -998,6 +1003,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@src/drivers/$(DEPDIR)/sifive_gpio0.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/drivers/$(DEPDIR)/sifive_i2c0.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/drivers/$(DEPDIR)/sifive_l2pf0.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/drivers/$(DEPDIR)/sifive_l2pf1.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/drivers/$(DEPDIR)/sifive_local-external-interrupts0.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/drivers/$(DEPDIR)/sifive_pwm0.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/drivers/$(DEPDIR)/sifive_rtc0.Po@am__quote@

--- a/Makefile.in
+++ b/Makefile.in
@@ -226,6 +226,7 @@ am_libmetal_a_OBJECTS = src/drivers/fixed-clock.$(OBJEXT) \
 	src/drivers/riscv_clint0.$(OBJEXT) \
 	src/drivers/riscv_cpu.$(OBJEXT) \
 	src/drivers/riscv_plic0.$(OBJEXT) \
+	src/drivers/sifive_remapper2.$(OBJEXT) \
 	src/drivers/sifive_buserror0.$(OBJEXT) \
 	src/drivers/sifive_ccache0.$(OBJEXT) \
 	src/drivers/sifive_clic0.$(OBJEXT) \
@@ -261,7 +262,7 @@ am_libmetal_a_OBJECTS = src/drivers/fixed-clock.$(OBJEXT) \
 	src/switch.$(OBJEXT) src/synchronize_harts.$(OBJEXT) \
 	src/timer.$(OBJEXT) src/time.$(OBJEXT) src/trap.$(OBJEXT) \
 	src/tty.$(OBJEXT) src/uart.$(OBJEXT) src/vector.$(OBJEXT) \
-	src/watchdog.$(OBJEXT)
+	src/watchdog.$(OBJEXT) src/remapper.$(OBJEXT)
 libmetal_a_OBJECTS = $(am_libmetal_a_OBJECTS)
 AM_V_P = $(am__v_P_@AM_V@)
 am__v_P_ = $(am__v_P_@AM_DEFAULT_V@)
@@ -458,6 +459,7 @@ nobase_include_HEADERS = metal/machine.h metal/machine/inline.h \
 	metal/machine/platform.h metal/drivers/fixed-clock.h \
 	metal/drivers/fixed-factor-clock.h \
 	metal/drivers/riscv_clint0.h metal/drivers/riscv_cpu.h \
+	metal/drivers/sifive_remapper2.h \
 	metal/drivers/riscv_plic0.h metal/drivers/sifive_buserror0.h \
 	metal/drivers/sifive_ccache0.h metal/drivers/sifive_clic0.h \
 	metal/drivers/sifive_fe310-g000_hfrosc.h \
@@ -484,7 +486,8 @@ nobase_include_HEADERS = metal/machine.h metal/machine/inline.h \
 	metal/lim.h metal/lock.h metal/memory.h metal/nmi.h metal/pmp.h \
 	metal/privilege.h metal/pwm.h metal/rtc.h metal/shutdown.h \
 	metal/scrub.h metal/spi.h metal/switch.h metal/timer.h \
-	metal/time.h metal/tty.h metal/uart.h metal/watchdog.h
+	metal/time.h metal/tty.h metal/uart.h metal/watchdog.h \
+	metal/remapper.h
 
 # This will generate these sources before the compilation step
 BUILT_SOURCES = \
@@ -504,6 +507,7 @@ libmetal_a_SOURCES = \
 	src/drivers/riscv_clint0.c \
 	src/drivers/riscv_cpu.c \
 	src/drivers/riscv_plic0.c \
+	src/drivers/sifive_remapper2.c \
 	src/drivers/sifive_buserror0.c \
 	src/drivers/sifive_ccache0.c \
 	src/drivers/sifive_clic0.c \
@@ -529,6 +533,7 @@ libmetal_a_SOURCES = \
 	src/drivers/sifive_simuart0.c \
 	src/drivers/sifive_wdog0.c \
 	src/drivers/ucb_htif0.c \
+	src/remapper.c \
 	src/atomic.c \
 	src/button.c \
 	src/cache.c \
@@ -780,6 +785,8 @@ src/drivers/riscv_cpu.$(OBJEXT): src/drivers/$(am__dirstamp) \
 	src/drivers/$(DEPDIR)/$(am__dirstamp)
 src/drivers/riscv_plic0.$(OBJEXT): src/drivers/$(am__dirstamp) \
 	src/drivers/$(DEPDIR)/$(am__dirstamp)
+src/drivers/sifive_remapper2.$(OBJEXT): src/drivers/$(am__dirstamp) \
+	src/drivers/$(DEPDIR)/$(am__dirstamp)
 src/drivers/sifive_buserror0.$(OBJEXT): src/drivers/$(am__dirstamp) \
 	src/drivers/$(DEPDIR)/$(am__dirstamp)
 src/drivers/sifive_ccache0.$(OBJEXT): src/drivers/$(am__dirstamp) \
@@ -845,6 +852,8 @@ src/$(am__dirstamp):
 src/$(DEPDIR)/$(am__dirstamp):
 	@$(MKDIR_P) src/$(DEPDIR)
 	@: > src/$(DEPDIR)/$(am__dirstamp)
+src/remapper.$(OBJEXT): src/$(am__dirstamp) \
+	src/$(DEPDIR)/$(am__dirstamp)
 src/atomic.$(OBJEXT): src/$(am__dirstamp) \
 	src/$(DEPDIR)/$(am__dirstamp)
 src/button.$(OBJEXT): src/$(am__dirstamp) \
@@ -936,6 +945,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@gloss/$(DEPDIR)/sys_wait.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@gloss/$(DEPDIR)/sys_write.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@segger/$(DEPDIR)/SEGGER_target_metal.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/remapper.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/atomic.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/button.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/cache.Po@am__quote@
@@ -972,6 +982,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@src/drivers/$(DEPDIR)/riscv_clint0.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/drivers/$(DEPDIR)/riscv_cpu.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/drivers/$(DEPDIR)/riscv_plic0.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/drivers/$(DEPDIR)/sifive_remapper2.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/drivers/$(DEPDIR)/sifive_buserror0.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/drivers/$(DEPDIR)/sifive_ccache0.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/drivers/$(DEPDIR)/sifive_clic0.Po@am__quote@

--- a/metal/drivers/sifive_l2pf1.h
+++ b/metal/drivers/sifive_l2pf1.h
@@ -1,0 +1,94 @@
+/* Copyright 2021 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef METAL__DRIVERS__SIFIVE_L2PF1_H
+#define METAL__DRIVERS__SIFIVE_L2PF1_H
+
+/*!
+ * @file sifive_l2pf1.h
+ *
+ * @brief API for configuring the SiFive L2 stride prefetcher.
+ */
+
+#include <stdint.h>
+
+/*! @brief L2 stride prefetcher configuration. */
+typedef struct {
+    /* Enable hardware prefetcher support for scalar Loads. */
+    uint8_t ScalarLoadSupportEn;
+
+    /* Initial prefetch distance. */
+    uint8_t Dist;
+
+    /* Maximum allowed prefetch Distance. */
+    uint32_t MaxAllowedDist;
+
+    /*
+     * Threshold when SPF distance increase changes
+     * from linear (+1) to exponential (*2).
+     */
+    uint8_t LinToExpThrd;
+
+    /* Enable prefetches to cross pages. */
+    uint8_t CrossPageEn;
+
+    /*
+     * Threshold for forgiving loads with
+     * mismatching strides when SPF is in trained state.
+     */
+    uint8_t ForgiveThrd;
+
+    /*
+     * Threshold no. of Fullness (L2 MSHRs used/ total available) to stop
+     * sending hits.
+     */
+    uint8_t QFullnessThrd;
+
+    /* No. of CacheHits for evicting SPF entry. */
+    uint8_t HitCacheThrd;
+
+    /* Threshold no. of MSHR hits for increasing SPF distance. */
+    uint8_t HitMSHRThrd;
+
+    /* Size of the comparison window for address matching. */
+    uint8_t Window;
+
+    /* Prefetch-enable for Scalar Stores. */
+    uint8_t ScalarStoreSupportEn;
+
+    /* Prefetch-enable for Vector Loads (Gets). */
+    uint8_t VectorLoadSupportEn;
+
+    /* Prefetch-enable for Vector Stores (Puts). */
+    uint8_t VectorStoreSupportEn;
+} sifive_l2pf1_config;
+
+/*
+ * ! @brief Disable L2 hardware stride prefetcher unit.
+ * @param None.
+ * @return None.
+ */
+void sifive_l2pf1_disable(void);
+
+/*
+ * ! @brief Get currently active L2 stride prefetcher configuration.
+ * @param config Pointer to user specified configuration structure.
+ * @return None.
+ */
+void sifive_l2pf1_get_config(sifive_l2pf1_config *config);
+
+/*
+ * ! @brief Enables fine grain access to L2 stride prefetcher configuration.
+ * @param config Pointer to user structure with values to be set.
+ * @return None.
+ */
+void sifive_l2pf1_set_config(sifive_l2pf1_config *config);
+
+/*
+ * ! @brief Initialize L2 hardware stride prefetcher unit.
+ * @param None.
+ * @return None.
+ */
+void sifive_l2pf1_init(void);
+
+#endif

--- a/metal/drivers/sifive_remapper2.h
+++ b/metal/drivers/sifive_remapper2.h
@@ -1,0 +1,21 @@
+/* Copyright 2021 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef METAL__DRIVERS__SIFIVE_REMAPPER2_H
+#define METAL__DRIVERS__SIFIVE_REMAPPER2_H
+
+#include <metal/compiler.h>
+#include <metal/remapper.h>
+
+struct __metal_driver_vtable_sifive_remapper2 {
+    const struct metal_remapper_vtable remapper;
+};
+
+__METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_remapper2)
+
+struct __metal_driver_sifive_remapper2 {
+    struct metal_remapper remapper;
+};
+
+#endif /* METAL__DRIVERS__SIFIVE_REMAPPER2_H */
+

--- a/metal/nmi.h
+++ b/metal/nmi.h
@@ -1,0 +1,30 @@
+/* Copyright 2018 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef METAL__NMI_H
+#define METAL__NMI_H
+
+/*! @file nmi.h
+ *
+ * API for manipulating NMI allocation
+ */
+
+#define _STR(x) #x
+
+#define _RNMI_IRQ(ID) _STR(.rnmi_irq_ ## ID)
+#define _RNMI_EXCP(ID) _STR(.rnmi_excp_ ## ID)
+
+#define METAL_NMI_MNRET __asm__ volatile(".word 0x70200073")
+
+/*! @def METAL_PLACE_IN_RNMI_IRQ
+ * @brief Link a function into the RNMI interrupt handler.
+ */
+#define METAL_PLACE_IN_RNMI_IRQ(ID) __attribute__((section(_RNMI_IRQ(ID)), naked))
+
+/*! @def METAL_PLACE_IN_RNMI_EXCP
+ * @brief Link a function into the RNMI exception handler.
+ */
+
+#define METAL_PLACE_IN_RNMI_EXCP(ID) __attribute__((section(_RNMI_EXCP(ID)), interrupt))
+
+#endif

--- a/metal/remapper.h
+++ b/metal/remapper.h
@@ -1,0 +1,249 @@
+/* Copyright 2021 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef METAL__REMAPPER_H
+#define METAL__REMAPPER_H
+
+#include <stdint.h>
+
+struct metal_remapper;
+struct metal_remapper_entry;
+
+/*! @brief vtable for address remapper. */
+struct metal_remapper_vtable {
+    int (*enable_remap)(struct metal_remapper *remapper, int idx);
+    int (*disable_remap)(struct metal_remapper *remapper, int idx);
+    int (*enable_remaps)(struct metal_remapper *remapper, int idxs[],
+                         int num_idxs);
+    int (*disable_remaps)(struct metal_remapper *remapper, int idxs[],
+                          int num_idxs);
+    uint32_t (*get_valid)(struct metal_remapper *remapper, int idx);
+    int (*set_valid)(struct metal_remapper *remapper,
+                     int idx, uint32_t val);
+    int (*flush)(struct metal_remapper *remapper);
+    uint64_t (*get_from_region_base)(struct metal_remapper *remapper);
+    uint64_t (*get_from_region_size)(struct metal_remapper *remapper);
+    uint64_t (*get_to_region_base)(struct metal_remapper *remapper);
+    uint64_t (*get_to_region_size)(struct metal_remapper *remapper);
+    uint64_t (*get_max_from_entry_region_size)(struct metal_remapper *remapper);
+    uint32_t (*get_version)(struct metal_remapper *remapper);
+    uint32_t (*get_entries)(struct metal_remapper *remapper);
+    int (*set_remap)(struct metal_remapper *remapper,
+                     struct metal_remapper_entry *entry);
+    int (*set_remaps)(struct metal_remapper *remapper,
+                      struct metal_remapper_entry *entries[],
+                      int num_entries);
+    uint64_t (*get_from)(struct metal_remapper *remapper, int idx);
+    uint64_t (*get_to)(struct metal_remapper *remapper, int idx);
+};
+
+/*! @brief A handle for a address remapper device. */
+struct metal_remapper {
+    const struct metal_remapper_vtable *vtable;
+};
+
+/*! @brief Remap entry descriptor. */
+struct metal_remapper_entry {
+    int idx; /*!< Index of remap entry. */
+    uint64_t from_addr; /*!< From[] entry address to be remapped. */
+    uint64_t to_addr; /*!< To[] entry address to be remapped. */
+};
+
+/*! @brief Enables an address remapper entry.
+ * @param remapper Address remapper device handle.
+ * @param idx Index of remap entry to enable.
+ * @return 0 If no error.*/
+inline int __metal_remapper_enable_remap(struct metal_remapper *remapper,
+                                         int idx) {
+    return remapper->vtable->enable_remap(remapper, idx);
+}
+
+/*! @brief Disables an address remapper entry.
+ * @param remapper Address remapper device handle.
+ * @param idx Index of remap entry to disable.
+ * @return 0 If no error.
+ */
+inline int __metal_remapper_disable_remap(struct metal_remapper *remapper,
+                                          int idx) {
+    return remapper->vtable->disable_remap(remapper, idx);
+}
+
+/*! @brief Batch enables address remapper entries.
+ * @param remapper Address remapper device handle.
+ * @param idxs[] Array of indexes of remap entries to enable.
+ * @param num_idxs Number of indexes passed to idxs[] array.
+ * @return 0 If no error.*/
+inline int __metal_remapper_enable_remaps(struct metal_remapper *remapper,
+                                          int idxs[], int num_idxs) {
+    return remapper->vtable->enable_remaps(remapper, idxs, num_idxs);
+}
+
+/*! @brief Batch disables an address remapper entries.
+ * @param remapper Address remapper device handle.
+ * @param idxs[] Array of indexes of remap entries to disable.
+ * @param num_idxs Number of indexes passed to idxs[] array.
+ * @return 0 If no error.
+ */
+inline int __metal_remapper_disable_remaps(struct metal_remapper *remapper,
+                                           int idxs[], int num_idxs) {
+    return remapper->vtable->disable_remaps(remapper, idxs, num_idxs);
+}
+
+/*! @brief Get remappervalid[] register content.
+ * @param remapper Address remapper device handle.
+ * @param idx Index of remappervalid[] register.
+ * @return 0 If no error.
+ */
+inline uint32_t __metal_remapper_get_valid(struct metal_remapper *remapper,
+                                           int idx) {
+    return remapper->vtable->get_valid(remapper, idx);
+}
+
+/*! @brief Set remappervalid[] register with given value.
+ * @param remapper Address remapper device handle.
+ * @param idx Index of remappervalid[] register.
+ * @param val Value to be set.
+ * @return 0 If no error.
+ */
+inline int __metal_remapper_set_valid(struct metal_remapper *remapper,
+                                      int idx, uint32_t val) {
+    return remapper->vtable->set_valid(remapper, idx, val);
+}
+
+/*! @brief Disable all address remapper entries.
+ * @param remapper Address remapper device handle.
+ * @return 0 If no error.
+ */
+inline int __metal_remapper_flush(struct metal_remapper *remapper) {
+    return remapper->vtable->flush(remapper);
+}
+
+/*! @brief Get hardware configured from region base address.
+ * @param remapper Address remapper device handle.
+ */
+inline uint64_t __metal_remapper_get_from_region_base(
+        struct metal_remapper *remapper) {
+    return remapper->vtable->get_from_region_base(remapper);
+}
+
+/*! @brief Get hardware configured from region size.
+ * @param remapper Address remapper device handle.
+ */
+inline uint64_t __metal_remapper_get_from_region_size(
+        struct metal_remapper *remapper) {
+    return remapper->vtable->get_from_region_size(remapper);
+}
+
+/*! @brief Get hardware configured to region base address.
+ * @param remapper Address remapper device handle.
+ */
+inline uint64_t __metal_remapper_get_to_region_base(
+         struct metal_remapper *remapper) {
+    return remapper->vtable->get_to_region_base(remapper);
+}
+
+/*! @brief Get hardware configured to region size.
+ * @param remapper Address remapper device handle.
+ */
+inline uint64_t __metal_remapper_get_to_region_size(
+        struct metal_remapper *remapper) {
+    return remapper->vtable->get_to_region_size(remapper);
+}
+
+/*! @brief Get hardware configured maximum from entry region size.
+ * @param remapper Address remapper device handle.
+ */
+inline uint64_t __metal_remapper_get_max_from_entry_region_size(
+        struct metal_remapper *remapper) {
+    return remapper->vtable->get_max_from_entry_region_size(remapper);
+}
+
+/*! @brief Get hardware version of address remapper.
+ * @param remapper Address remapper device handle.
+ * @return current hardware version of address remapper.
+ */
+inline uint32_t __metal_remapper_get_version(struct metal_remapper *remapper) {
+    return remapper->vtable->get_version(remapper);
+}
+
+/*! @brief Get number of entries in address remapper.
+ * @param remapper Address remapper device handle.
+ * @return number of entries in address remapper.
+ */
+inline uint32_t __metal_remapper_get_entries(struct metal_remapper *remapper) {
+    return remapper->vtable->get_entries(remapper);
+}
+
+/*! @brief Set from/to remap entry.
+ * @param remapper Address remapper device handle.
+ * @param entry Pointer to the remap entry descriptor.
+ * @return 0 If no error.
+ */
+inline int __metal_remapper_set_remap(struct metal_remapper *remapper,
+                                      struct metal_remapper_entry *entry) {
+    return remapper->vtable->set_remap(remapper, entry);
+}
+
+/*! @brief Batch set from/to remap entries.
+ * @param remapper Address remapper device handle.
+ * @param entries Array of pointers to the remap entry descriptors.
+ * @return 0 If no error.
+ */
+inline int __metal_remapper_set_remaps(struct metal_remapper *remapper,
+                                       struct metal_remapper_entry *entries[],
+                                       int num_entries) {
+    return remapper->vtable->set_remaps(remapper, entries, num_entries);
+}
+
+/*! @brief Get the from address of a remap entry.
+ * @param remapper Address remapper device handle.
+ * @param idx Index of remap entry.
+ * @return From address of the remap entry.
+ */
+inline uint64_t __metal_remapper_get_from(struct metal_remapper *remapper,
+                                          int idx) {
+    return remapper->vtable->get_from(remapper, idx);
+}
+
+/*! @brief Get the to address of a remap entry.
+ * @param remapper Address remapper device handle.
+ * @param idx Index of remap entry.
+ * @return To address of the remap entry.
+ */
+inline uint64_t __metal_remapper_get_to(struct metal_remapper *remapper,
+                                        int idx) {
+    return remapper->vtable->get_to(remapper, idx);
+}
+
+/*!
+ * @brief The public METAL address remapper interfaces.
+ */
+struct metal_remapper *metal_remapper_get_device(void);
+int metal_remapper_enable_remap(struct metal_remapper *remapper, int idx);
+int metal_remapper_disable_remap(struct metal_remapper *remapper, int idx);
+int metal_remapper_enable_remaps(struct metal_remapper *remapper,
+                                 int idx[], int num_idxs);
+int metal_remapper_disable_remaps(struct metal_remapper *remapper,
+                                  int idx[], int num_idxs);
+uint32_t metal_remapper_get_valid(struct metal_remapper *remapper, int idx);
+int metal_remapper_set_valid(struct metal_remapper *remapper,
+                             int idx, uint32_t val);
+int metal_remapper_flush(struct metal_remapper *remapper);
+uint64_t metal_remapper_get_from_region_base(struct metal_remapper *remapper);
+uint64_t metal_remapper_get_from_region_size(struct metal_remapper *remapper);
+uint64_t metal_remapper_get_to_region_base(struct metal_remapper *remapper);
+uint64_t metal_remapper_get_to_region_size(struct metal_remapper *remapper);
+uint64_t metal_remapper_get_max_from_entry_region_size(
+        struct metal_remapper *remapper);
+uint32_t metal_remapper_get_version(struct metal_remapper *remapper);
+uint32_t metal_remapper_get_entries(struct metal_remapper *remapper);
+int metal_remapper_set_remap(struct metal_remapper *remapper,
+                             struct metal_remapper_entry *entry);
+int metal_remapper_set_remaps(struct metal_remapper *remapper,
+                              struct metal_remapper_entry *entries[],
+                              int num_entries);
+uint64_t metal_remapper_get_from(struct metal_remapper *remapper, int idx);
+uint64_t metal_remapper_get_to(struct metal_remapper *remapper, int idx);
+
+#endif /*METAL__REMAPPER_H */
+

--- a/src/drivers/sifive_clic0.c
+++ b/src/drivers/sifive_clic0.c
@@ -11,7 +11,7 @@
 #include <metal/shutdown.h>
 #include <stdint.h>
 
-#define CLIC0_MAX_INTERRUPTS 4096
+#define CLIC0_MAX_INTERRUPTS 1024
 
 typedef enum metal_clic_vector_ {
     METAL_CLIC_NONVECTOR = 0,

--- a/src/drivers/sifive_l2pf1.c
+++ b/src/drivers/sifive_l2pf1.c
@@ -1,0 +1,185 @@
+/* Copyright 2021 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include <metal/machine/platform.h>
+
+#ifdef METAL_SIFIVE_L2PF1
+
+#include <stdint.h>
+#include <metal/machine.h>
+#include <metal/drivers/sifive_l2pf1.h>
+
+/* Macros to access memory mapped registers. */
+#define REGW(x) *((volatile uint32_t *)(l2pf_base[hartid] + x))
+
+/* Macros for register bit masks. */
+#define REG_MASK_BITWIDTH_1         0x01
+#define REG_MASK_BITWIDTH_2         0x03
+#define REG_MASK_BITWIDTH_4         0x0f
+#define REG_MASK_BITWIDTH_5         0x1f
+#define REG_MASK_BITWIDTH_6         0x3f
+
+/* Macros to specify register bit shift. */
+#define REG_BITSHIFT_2              2
+#define REG_BITSHIFT_4              4
+#define REG_BITSHIFT_8              8
+#define REG_BITSHIFT_9              9
+#define REG_BITSHIFT_13             13
+#define REG_BITSHIFT_14             14
+#define REG_BITSHIFT_19             19
+#define REG_BITSHIFT_20             20
+#define REG_BITSHIFT_21             21
+#define REG_BITSHIFT_28             28
+#define REG_BITSHIFT_29             29
+
+/* Array of base addresses with HART IDs as the index. */
+unsigned long l2pf_base[] = METAL_SIFIVE_L2PF1_BASE_ADDR;
+int l2pf_base_len = sizeof(l2pf_base) / sizeof(unsigned long);
+
+/* Array of distance bits with HART IDs as the index. */
+unsigned long l2pf_distance_bits[] = METAL_SIFIVE_L2PF1_DISTANCE_BITS;
+
+static void _sifive_l2pf1_set_config(int hartid, sifive_l2pf1_config *config) {
+    uint32_t val;
+
+    /* Check for NULL, valid base address. */
+    if ((config) && (hartid < l2pf_base_len) && (l2pf_base[hartid] != 0UL)) {
+        uint32_t distance_bits_mask = (1 << l2pf_distance_bits[hartid]) - 1;
+
+        /* Set basic control register configuration values. */
+        val = (uint32_t)(
+            (config->ScalarLoadSupportEn & REG_MASK_BITWIDTH_1) |
+            ((config->Dist & distance_bits_mask) << REG_BITSHIFT_2) |
+            ((config->MaxAllowedDist & distance_bits_mask) << REG_BITSHIFT_8) |
+            ((config->LinToExpThrd & distance_bits_mask) << REG_BITSHIFT_14) |
+            ((config->CrossPageEn & REG_MASK_BITWIDTH_1) << REG_BITSHIFT_28) |
+            ((config->ForgiveThrd & REG_MASK_BITWIDTH_1) << REG_BITSHIFT_29));
+
+        /* Set L2 user bits control register configuration values. */
+        REGW(METAL_SIFIVE_L2PF1_BASIC_CONTROL) = val;
+
+        val = (uint32_t)(
+            (config->QFullnessThrd & REG_MASK_BITWIDTH_4) |
+            ((config->HitCacheThrd & REG_MASK_BITWIDTH_5)
+              << REG_BITSHIFT_4) |
+            ((config->HitMSHRThrd & REG_MASK_BITWIDTH_4)
+              << REG_BITSHIFT_9) |
+            ((config->Window & REG_MASK_BITWIDTH_6)
+              << REG_BITSHIFT_13) |
+            ((config->ScalarStoreSupportEn & REG_MASK_BITWIDTH_1)
+              << REG_BITSHIFT_19) |
+            ((config->VectorLoadSupportEn & REG_MASK_BITWIDTH_1)
+              << REG_BITSHIFT_20) |
+            ((config->VectorStoreSupportEn & REG_MASK_BITWIDTH_1)
+              << REG_BITSHIFT_21));
+
+        REGW(METAL_SIFIVE_L2PF1_USER_CONTROL) = val;
+    }
+}
+
+static void _sifive_l2pf1_set_all_harts_config(sifive_l2pf1_config *config) {
+    for (int hartid = 0; hartid < l2pf_base_len; hartid++) {
+        _sifive_l2pf1_set_config(hartid, config);
+    }
+}
+
+void sifive_l2pf1_enable(void) {
+    int hartid;
+    __asm__ volatile("csrr %0, mhartid" : "=r"(hartid));
+
+    if ((hartid < l2pf_base_len) && (l2pf_base[hartid] != 0UL)) {
+        uint32_t val = REGW(METAL_SIFIVE_L2PF1_BASIC_CONTROL);
+
+        /* Enable L2 stride prefetch unit for current hart. */
+        val |= REG_MASK_BITWIDTH_1;
+
+        REGW(METAL_SIFIVE_L2PF1_BASIC_CONTROL) = val;
+    }
+}
+
+void sifive_l2pf1_disable(void) {
+    int hartid;
+    __asm__ volatile("csrr %0, mhartid" : "=r"(hartid));
+
+    if ((hartid < l2pf_base_len) && (l2pf_base[hartid] != 0UL)) {
+        uint32_t val = REGW(METAL_SIFIVE_L2PF1_BASIC_CONTROL);
+
+        /* Disable L2 stride prefetch unit for current hart. */
+        val &= ~REG_MASK_BITWIDTH_1;
+
+        REGW(METAL_SIFIVE_L2PF1_BASIC_CONTROL) = val;
+    }
+}
+
+void sifive_l2pf1_get_config(sifive_l2pf1_config *config) {
+    int hartid;
+    __asm__ volatile("csrr %0, mhartid" : "=r"(hartid));
+    uint32_t val;
+
+    /* Check for NULL, valid base address. */
+    if ((config) && (hartid < l2pf_base_len) && (l2pf_base[hartid] != 0UL)) {
+        uint32_t distance_bits_mask = (1 << l2pf_distance_bits[hartid]) - 1;
+
+        /* Get basic control register configuration values. */
+        val = REGW(METAL_SIFIVE_L2PF1_BASIC_CONTROL);
+
+        config->ScalarLoadSupportEn = (val & REG_MASK_BITWIDTH_1);
+        config->Dist =
+            ((val >> REG_BITSHIFT_2) & distance_bits_mask);
+        config->MaxAllowedDist =
+            ((val >> REG_BITSHIFT_8) & distance_bits_mask);
+        config->LinToExpThrd =
+            ((val >> REG_BITSHIFT_14) & distance_bits_mask);
+        config->CrossPageEn =
+            ((val >> REG_BITSHIFT_28) & REG_MASK_BITWIDTH_1);
+        config->ForgiveThrd =
+            ((val >> REG_BITSHIFT_29) & REG_MASK_BITWIDTH_2);
+
+        /* Get L2 user bits control register configuration values. */
+        val = REGW(METAL_SIFIVE_L2PF1_USER_CONTROL);
+
+        config->QFullnessThrd = (val & REG_MASK_BITWIDTH_4);
+        config->HitCacheThrd =
+            ((val >> REG_BITSHIFT_4) & REG_MASK_BITWIDTH_5);
+        config->HitMSHRThrd =
+            ((val >> REG_BITSHIFT_9) & REG_MASK_BITWIDTH_4);
+        config->Window = ((val >> REG_BITSHIFT_13) & REG_MASK_BITWIDTH_6);
+        config->ScalarStoreSupportEn =
+            ((val >> REG_BITSHIFT_19) & REG_MASK_BITWIDTH_1);
+        config->VectorLoadSupportEn =
+            ((val >> REG_BITSHIFT_20) & REG_MASK_BITWIDTH_1);
+        config->VectorStoreSupportEn =
+            ((val >> REG_BITSHIFT_21) & REG_MASK_BITWIDTH_1);
+    }
+}
+
+void sifive_l2pf1_set_config(sifive_l2pf1_config *config) {
+    int hartid;
+    __asm__ volatile("csrr %0, mhartid" : "=r"(hartid));
+    _sifive_l2pf1_set_config(hartid, config);
+}
+
+void sifive_l2pf1_init(void) {
+    sifive_l2pf1_config config;
+
+    /* Basic control register initial configuration (0x15811). */
+    config.ScalarLoadSupportEn = 0x1;
+    config.Dist = 0x4;
+    config.MaxAllowedDist = 0x18;
+    config.LinToExpThrd = 0x5;
+
+    /* L2 user bits control register initial configuration (0x38c84e). */
+    config.QFullnessThrd = 0xe;
+    config.HitCacheThrd = 0x4;
+    config.HitMSHRThrd = 0x4;
+    config.Window = 0x6;
+    config.ScalarStoreSupportEn = 0x1;
+    config.VectorLoadSupportEn = 0x1;
+    config.VectorStoreSupportEn = 0x1;
+
+    _sifive_l2pf1_set_all_harts_config(&config);
+}
+
+#endif
+
+typedef int no_empty_translation_units;

--- a/src/drivers/sifive_remapper2.c
+++ b/src/drivers/sifive_remapper2.c
@@ -1,0 +1,243 @@
+/* Copyright 2021 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include <metal/machine/platform.h>
+
+#ifdef METAL_SIFIVE_REMAPPER2
+
+#include <metal/drivers/sifive_remapper2.h>
+#include <metal/machine.h>
+#include <metal/io.h>
+#include <stdio.h>
+#include <stdint.h>
+
+#define METAL_SIFIVE_REMAPPER2_VALID_REGS_NUM   7
+
+#define METAL_SIFIVE_REMAPPER_ENABLE_KEY   0x51f15e
+
+#define METAL_SIFIVE_REMAPPER2_FROM_REG_OFFSET(idx) \
+    (METAL_SIFIVE_REMAPPER2_FROM_BASE + idx * 16)
+#define METAL_SIFIVE_REMAPPER2_TO_REG_OFFSET(idx)   \
+    (METAL_SIFIVE_REMAPPER2_FROM_BASE + idx * 16 + 8)
+
+/* Macros to access registers */
+#define REMAPPER_REG(offset) (((unsigned long)base + offset))
+#define REMAPPER_REGW(offset)                                          \
+    (__METAL_ACCESS_ONCE((__metal_io_u32 *)REMAPPER_REG(offset)))
+
+static void
+__metal_driver_sifive_remapper_set_key_state(struct metal_remapper *remapper) {
+    unsigned long base = __metal_driver_sifive_remapper2_base(remapper);
+    REMAPPER_REGW(METAL_SIFIVE_REMAPPER2_KEY) = METAL_SIFIVE_REMAPPER_ENABLE_KEY;
+}
+
+int
+__metal_driver_sifive_remapper_enable_remap(struct metal_remapper *remapper,
+                                            int idx) {
+    unsigned long base = __metal_driver_sifive_remapper2_base(remapper);
+    int reg_idx = idx / 32;
+    int bit_offset = idx % 32;
+
+    __metal_driver_sifive_remapper_set_key_state(remapper);
+    REMAPPER_REGW(METAL_SIFIVE_REMAPPER2_VALID_BASE + reg_idx * 4) |=
+        (1 << bit_offset);
+    __METAL_IO_FENCE(o, rw);
+
+    return 0;
+}
+
+int
+__metal_driver_sifive_remapper_disable_remap(struct metal_remapper *remapper,
+                                             int idx) {
+    unsigned long base = __metal_driver_sifive_remapper2_base(remapper);
+    int reg_idx = idx / 32;
+    int bit_offset = idx % 32;
+
+    __metal_driver_sifive_remapper_set_key_state(remapper);
+    REMAPPER_REGW(METAL_SIFIVE_REMAPPER2_VALID_BASE + reg_idx * 4) &=
+        ~(1 << bit_offset);
+    __METAL_IO_FENCE(o, rw);
+
+    return 0;
+}
+
+int
+__metal_driver_sifive_remapper_enable_remaps(struct metal_remapper *remapper,
+                                             int idxs[], int num_idxs) {
+    unsigned long base = __metal_driver_sifive_remapper2_base(remapper);
+    uint32_t enables[METAL_SIFIVE_REMAPPER2_VALID_REGS_NUM] = {0};
+
+    for (int i = 0; i < num_idxs; i++) {
+        int reg_idx = idxs[i] / 32;
+        int bit_offset = idxs[i] % 32;
+        enables[reg_idx] |= (1 << bit_offset);
+    }
+
+    for (int i = 0; i < METAL_SIFIVE_REMAPPER2_VALID_REGS_NUM; i++) {
+        uint32_t remappervalid =
+            REMAPPER_REGW(METAL_SIFIVE_REMAPPER2_VALID_BASE + i * 4);
+        __metal_driver_sifive_remapper_set_key_state(remapper);
+        REMAPPER_REGW(METAL_SIFIVE_REMAPPER2_VALID_BASE + i * 4) =
+            remappervalid | enables[i];
+    }
+
+    return 0;
+}
+
+int
+__metal_driver_sifive_remapper_disable_remaps(struct metal_remapper *remapper,
+                                              int idxs[], int num_idxs) {
+    unsigned long base = __metal_driver_sifive_remapper2_base(remapper);
+    uint32_t disables[METAL_SIFIVE_REMAPPER2_VALID_REGS_NUM] = {0};
+
+    for (int i = 0; i < num_idxs; i++) {
+        int reg_idx = idxs[i] / 32;
+        int bit_offset = idxs[i] % 32;
+        disables[reg_idx] |= (1 << bit_offset);
+    }
+
+    for (int i = 0; i < METAL_SIFIVE_REMAPPER2_VALID_REGS_NUM; i++) {
+        uint32_t remappervalid =
+            REMAPPER_REGW(METAL_SIFIVE_REMAPPER2_VALID_BASE + i * 4);
+        __metal_driver_sifive_remapper_set_key_state(remapper);
+        REMAPPER_REGW(METAL_SIFIVE_REMAPPER2_VALID_BASE + i * 4) =
+            remappervalid & ~disables[i];
+    }
+
+    return 0;
+}
+
+uint32_t
+__metal_driver_sifive_remapper_get_valid(struct metal_remapper *remapper,
+                                         int idx) {
+    if (idx < 0 || idx >= METAL_SIFIVE_REMAPPER2_VALID_REGS_NUM) {
+        return 0;
+    }
+
+    unsigned long base = __metal_driver_sifive_remapper2_base(remapper);
+    return REMAPPER_REGW(METAL_SIFIVE_REMAPPER2_VALID_BASE + idx * 4);
+}
+
+int
+__metal_driver_sifive_remapper_set_valid(struct metal_remapper *remapper,
+                                         int idx, uint32_t val) {
+    if (idx < 0 || idx >= METAL_SIFIVE_REMAPPER2_VALID_REGS_NUM) {
+        return 1;
+    }
+
+    unsigned long base = __metal_driver_sifive_remapper2_base(remapper);
+    __metal_driver_sifive_remapper_set_key_state(remapper);
+    REMAPPER_REGW(METAL_SIFIVE_REMAPPER2_VALID_BASE + idx * 4) = val;
+
+    return 0;
+}
+
+int
+__metal_driver_sifive_remapper_flush(struct metal_remapper *remapper) {
+    unsigned long base = __metal_driver_sifive_remapper2_base(remapper);
+    __metal_driver_sifive_remapper_set_key_state(remapper);
+    REMAPPER_REGW(METAL_SIFIVE_REMAPPER2_FLUSH) = 1;
+    __METAL_IO_FENCE(o, rw);
+
+    return 0;
+}
+
+uint64_t
+__metal_driver_sifive_remapper_get_from_region_base(struct metal_remapper *remapper) {
+    return __metal_driver_sifive_remapper2_from_region_base(remapper);
+}
+
+uint64_t
+__metal_driver_sifive_remapper_get_from_region_size(struct metal_remapper *remapper) {
+    return __metal_driver_sifive_remapper2_from_region_size(remapper);
+}
+
+uint64_t
+__metal_driver_sifive_remapper_get_to_region_base(struct metal_remapper *remapper) {
+    return __metal_driver_sifive_remapper2_to_region_base(remapper);
+}
+
+uint64_t
+__metal_driver_sifive_remapper_get_to_region_size(struct metal_remapper *remapper) {
+    return __metal_driver_sifive_remapper2_to_region_size(remapper);
+}
+
+uint64_t
+__metal_driver_sifive_remapper_get_max_from_entry_region_size(struct metal_remapper *remapper) {
+    return (1ULL << __metal_driver_sifive_remapper2_max_from_entry_addr_width(remapper));
+}
+
+uint32_t
+__metal_driver_sifive_remapper_get_version(struct metal_remapper *remapper) {
+    unsigned long base = __metal_driver_sifive_remapper2_base(remapper);
+    return REMAPPER_REGW(METAL_SIFIVE_REMAPPER2_VERSION);
+}
+
+uint32_t
+__metal_driver_sifive_remapper_get_entries(struct metal_remapper *remapper) {
+    unsigned long base = __metal_driver_sifive_remapper2_base(remapper);
+    return REMAPPER_REGW(METAL_SIFIVE_REMAPPER2_ENTRIES);
+}
+
+int
+__metal_driver_sifive_remapper_set_remap(struct metal_remapper *remapper,
+                                         struct metal_remapper_entry *entry) {
+    unsigned long base = __metal_driver_sifive_remapper2_base(remapper);
+    __metal_driver_sifive_remapper_set_key_state(remapper);
+    REMAPPER_REGW(METAL_SIFIVE_REMAPPER2_FROM_REG_OFFSET(entry->idx)) = entry->from_addr;
+    __metal_driver_sifive_remapper_set_key_state(remapper);
+    REMAPPER_REGW(METAL_SIFIVE_REMAPPER2_TO_REG_OFFSET(entry->idx)) = entry->to_addr;
+    __METAL_IO_FENCE(o, rw);
+
+    return 0;
+}
+
+int
+__metal_driver_sifive_remapper_set_remaps(struct metal_remapper *remapper,
+                                          struct metal_remapper_entry *entries[],
+                                          int num_entries) {
+    for (int i = 0; i < num_entries; i++) {
+        __metal_driver_sifive_remapper_set_remap(remapper, entries[i]);
+    }
+
+    return 0;
+}
+
+uint64_t
+__metal_driver_sifive_remapper_get_from(struct metal_remapper *remapper,
+                                        int idx) {
+    unsigned long base = __metal_driver_sifive_remapper2_base(remapper);
+    return REMAPPER_REGW(METAL_SIFIVE_REMAPPER2_FROM_REG_OFFSET(idx));
+}
+
+uint64_t
+__metal_driver_sifive_remapper_get_to(struct metal_remapper *remapper,
+                                      int idx) {
+    unsigned long base = __metal_driver_sifive_remapper2_base(remapper);
+    return REMAPPER_REGW(METAL_SIFIVE_REMAPPER2_TO_REG_OFFSET(idx));
+}
+
+__METAL_DEFINE_VTABLE(__metal_driver_vtable_sifive_remapper2) = {
+    .remapper.enable_remap = __metal_driver_sifive_remapper_enable_remap,
+    .remapper.disable_remap = __metal_driver_sifive_remapper_disable_remap,
+    .remapper.enable_remaps = __metal_driver_sifive_remapper_enable_remaps,
+    .remapper.disable_remaps = __metal_driver_sifive_remapper_disable_remaps,
+    .remapper.get_valid = __metal_driver_sifive_remapper_get_valid,
+    .remapper.set_valid = __metal_driver_sifive_remapper_set_valid,
+    .remapper.flush = __metal_driver_sifive_remapper_flush,
+    .remapper.get_from_region_base = __metal_driver_sifive_remapper_get_from_region_base,
+    .remapper.get_from_region_size = __metal_driver_sifive_remapper_get_from_region_size,
+    .remapper.get_to_region_base = __metal_driver_sifive_remapper_get_to_region_base,
+    .remapper.get_to_region_size = __metal_driver_sifive_remapper_get_to_region_size,
+    .remapper.get_max_from_entry_region_size = __metal_driver_sifive_remapper_get_max_from_entry_region_size,
+    .remapper.get_version = __metal_driver_sifive_remapper_get_version,
+    .remapper.get_entries = __metal_driver_sifive_remapper_get_entries,
+    .remapper.set_remap = __metal_driver_sifive_remapper_set_remap,
+    .remapper.set_remaps = __metal_driver_sifive_remapper_set_remaps,
+    .remapper.get_from = __metal_driver_sifive_remapper_get_from,
+    .remapper.get_to = __metal_driver_sifive_remapper_get_to,
+};
+
+#endif /* METAL_SIFIVE_REMAPPER2 */
+
+typedef int no_empty_translation_units;

--- a/src/init.c
+++ b/src/init.c
@@ -1,7 +1,10 @@
 /* Copyright 2019 SiFive Inc. */
 /* SPDX-License-Identifier: Apache-2.0 */
 
+#include <metal/machine/platform.h>
 #include <metal/init.h>
+
+#include <metal/drivers/sifive_l2pf1.h>
 
 /*
  * These function pointers are created by the linker script
@@ -21,6 +24,11 @@ void metal_init(void) {
         return;
     }
     init_done = 1;
+
+#ifdef METAL_SIFIVE_L2PF1
+    /* Do L2 Stride Prefetcher initialization. */
+    sifive_l2pf1_init();
+#endif
 
     if (&metal_constructors_end <= &metal_constructors_start) {
         return;

--- a/src/remapper.c
+++ b/src/remapper.c
@@ -1,0 +1,132 @@
+/* Copyright 2021 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include <metal/machine.h>
+#include <metal/remapper.h>
+
+extern int __metal_remapper_enable_remap(struct metal_remapper *remapper,
+                                         int idx);
+extern int __metal_remapper_disable_remap(struct metal_remapper *remapper,
+                                          int idx);
+extern int __metal_remapper_enable_remaps(struct metal_remapper *remapper,
+                                          int idxs[], int num_idxs);
+extern int __metal_remapper_disable_remaps(struct metal_remapper *remapper,
+                                           int idxs[], int num_idxs);
+extern uint32_t __metal_remapper_get_valid(struct metal_remapper *remapper,
+                                           int idx);
+extern int __metal_remapper_set_valid(struct metal_remapper *remapper,
+                                      int idx, uint32_t val);
+extern int __metal_remapper_flush(struct metal_remapper *remapper);
+extern uint64_t __metal_remapper_get_from_region_base(
+        struct metal_remapper *remapper);
+extern uint64_t __metal_remapper_get_from_region_size(
+        struct metal_remapper *remapper);
+extern uint64_t __metal_remapper_get_to_region_base(
+        struct metal_remapper *remapper);
+extern uint64_t __metal_remapper_get_to_region_size(
+        struct metal_remapper *remapper);
+extern uint64_t __metal_remapper_get_max_from_entry_region_size(
+        struct metal_remapper *remapper);
+extern uint32_t __metal_remapper_get_version(struct metal_remapper *remapper);
+extern int __metal_remapper_set_version(struct metal_remapper *remapper,
+                                        uint32_t version);
+extern uint32_t __metal_remapper_get_entries(struct metal_remapper *remapper);
+extern int __metal_remapper_set_remap(struct metal_remapper *remapper,
+                                      struct metal_remapper_entry *entry);
+extern int __metal_remapper_set_remaps(struct metal_remapper *remapper,
+                                       struct metal_remapper_entry *entries[],
+                                       int num_entries);
+extern uint64_t __metal_remapper_get_from(struct metal_remapper *remapper,
+                                          int idx);
+extern uint64_t __metal_remapper_get_to(struct metal_remapper *remapper,
+                                        int idx);
+
+struct metal_remapper *metal_remapper_get_device(void) {
+#ifdef __METAL_DT_REMAPPER_HANDLE
+    return __METAL_DT_REMAPPER_HANDLE;
+#else
+    return NULL;
+#endif
+}
+
+int metal_remapper_enable_remap(struct metal_remapper *remapper, int idx) {
+
+    return __metal_remapper_enable_remap(remapper, idx);
+}
+
+int metal_remapper_disable_remap(struct metal_remapper *remapper, int idx) {
+    return __metal_remapper_disable_remap(remapper, idx);
+}
+
+int metal_remapper_enable_remaps(struct metal_remapper *remapper,
+                                 int idxs[], int num_idxs) {
+    return __metal_remapper_enable_remaps(remapper,
+                                          idxs, num_idxs);
+}
+
+int metal_remapper_disable_remaps(struct metal_remapper *remapper,
+                                  int idxs[], int num_idxs) {
+    return __metal_remapper_disable_remaps(remapper, idxs, num_idxs);
+}
+
+uint32_t metal_remapper_get_valid(struct metal_remapper *remapper, int idx) {
+    return __metal_remapper_get_valid(remapper, idx);
+}
+
+int metal_remapper_set_valid(struct metal_remapper *remapper,
+                             int idx, uint32_t val) {
+    return __metal_remapper_set_valid(remapper, idx, val);
+}
+
+int metal_remapper_flush(struct metal_remapper *remapper) {
+    return __metal_remapper_flush(remapper);
+}
+
+uint64_t metal_remapper_get_from_region_base(struct metal_remapper *remapper) {
+    return __metal_remapper_get_from_region_base(remapper);
+}
+
+uint64_t metal_remapper_get_from_region_size(struct metal_remapper *remapper) {
+    return __metal_remapper_get_from_region_size(remapper);
+}
+
+uint64_t metal_remapper_get_to_region_base(struct metal_remapper *remapper) {
+    return __metal_remapper_get_to_region_base(remapper);
+}
+
+uint64_t metal_remapper_get_to_region_size(struct metal_remapper *remapper) {
+    return __metal_remapper_get_to_region_size(remapper);
+}
+
+uint64_t metal_remapper_get_max_from_entry_region_size(
+        struct metal_remapper *remapper) {
+    return __metal_remapper_get_max_from_entry_region_size(remapper);
+}
+
+uint32_t metal_remapper_get_version(struct metal_remapper *remapper) {
+    return __metal_remapper_get_version(remapper);
+}
+
+uint32_t metal_remapper_get_entries(struct metal_remapper *remapper) {
+    return __metal_remapper_get_entries(remapper);
+}
+
+int metal_remapper_set_remap(struct metal_remapper *remapper,
+                             struct metal_remapper_entry *entry) {
+    return __metal_remapper_set_remap(remapper, entry);
+}
+
+int metal_remapper_set_remaps(struct metal_remapper *remapper,
+                              struct metal_remapper_entry *entries[],
+                              int num_entries) {
+    return __metal_remapper_set_remaps(remapper, entries, num_entries);
+}
+
+uint64_t metal_remapper_get_from(struct metal_remapper *remapper, int idx) {
+    return __metal_remapper_get_from(remapper, idx);
+}
+
+uint64_t metal_remapper_get_to(struct metal_remapper *remapper, int idx) {
+    return __metal_remapper_get_to(remapper, idx);
+}
+


### PR DESCRIPTION
The CLIC design supports up to 1024 interrupt inputs per hart.

Signed-off-by: Frank Chang <frank.chang@sifive.com>