### PR TITLE
sifive_pl2cache0: fix missing hartid init

### DIFF
--- a/src/drivers/sifive_pl2cache0.c
+++ b/src/drivers/sifive_pl2cache0.c
@@ -28,6 +28,8 @@ unsigned long pl2cache_base[] = METAL_SIFIVE_PL2CACHE0_BASE_ADDR;
 
 void sifive_pl2cache0_set_cleanEvictenale_bit(bool val) {
     sifive_pl2cache0_configbits tmp;
+    int hartid;
+    __asm__ volatile("csrr %0, mhartid" : "=r"(hartid));
 
     tmp = (sifive_pl2cache0_configbits)REGW(METAL_SIFIVE_PL2CACHE0_CONFIGBITS);
     tmp.cleanEvictEnable = val;


### PR DESCRIPTION
(cherry picked from commit 966a62d6f1b1a0f654fe8efb004db588cc270001)