### PR TITLE
Fix the compact patterns for crt0.s and entry.s.

### DIFF
--- a/gloss/crt0.S
+++ b/gloss/crt0.S
@@ -43,10 +43,10 @@ _start:
 .option norelax
 #ifdef __riscv_cmodel_compact
 1:
-  auipc a0, %pcrel_hi(__global_pointer__)
-  addi a0, a0, %pcrel_lo(1b)
-  ld   gp, 0(a0)
-  add  gp, gp, a0
+  auipc t0, %pcrel_hi(__global_pointer__)
+  addi t0, t0, %pcrel_lo(1b)
+  ld   gp, 0(t0)
+  add  gp, gp, t0
 #else
   la gp, __global_pointer$
 #endif
@@ -66,7 +66,24 @@ _start:
    * is not necessary then it must simply set metal_segment_data_source_start to
    * be equal to metal_segment_data_target_start. */
 #ifdef __riscv_cmodel_compact
-  la.got.gprel t0, metal_segment_data_source_start
+  /* When rodata is placed nearly to text, then we can use la to access
+   * metal_segment_data_source_start directly; When the Rodata is placed
+   * nearly to rwdata, then use the lla.gprel is more suitable.  But once
+   * the rodata is far away from both text and rwdata, then generally we
+   * should use la.got.gprel to access it. Unfortunately, la.got.gprel
+   * cannot work for metal_segment_data_source_start, if LMA and VMA are
+   * different in the linker script.  Since we need to move the data,
+   * including GOT sections, from the LMA to VMA, then we can get the right
+   * values of got entries.  Therefore, use la.got.gprel to access the
+   * metal_segment_data_source_start will get the uninitilaize value.
+   * One of the solution is that - use compact stub to access the
+   * metal_segment_data_source_start, just like what we did above, to
+   * initialize gp.  */
+  1:
+  auipc t1, %pcrel_hi(__metal_segment_data_source_start__)
+  addi t1, t1, %pcrel_lo(1b)
+  ld   t0, 0(t1)
+  add  t0, t0, t1
   lla.gprel t1, metal_segment_data_target_start
   lla.gprel t2, metal_segment_data_target_end
 #else
@@ -341,11 +358,18 @@ name:
 .asciz "libgloss"
 
 #ifdef __riscv_cmodel_compact
-/* Compact stub.  */
+/* Compact stubs.  */
   .section .text.__global_pointer__, "aMG",@progbits, 8, __global_pointer__, comdat
   .align 3
   .global __global_pointer__
   .type   __global_pointer__, object
 __global_pointer__:
-  .quad   __global_pointer$ -.
+  .quad   __global_pointer$ - .
+
+  .section .text.__metal_segment_data_source_start__, "aMG",@progbits, 8, __metal_segment_data_source_start__, comdat
+  .align 3
+  .global __metal_segment_data_source_start__
+  .type   __metal_segment_data_source_start__, object
+__metal_segment_data_source_start__:
+  .quad   metal_segment_data_source_start - .
 #endif

--- a/src/entry.S
+++ b/src/entry.S
@@ -23,10 +23,10 @@ _enter:
 .option norelax
 #ifdef __riscv_cmodel_compact
 1:
-    auipc a0, %pcrel_hi(__global_pointer__)
-    addi a0, a0, %pcrel_lo(1b)
-    ld   gp, 0(a0)
-    add  gp, gp, a0
+    auipc t0, %pcrel_hi(__global_pointer__)
+    addi t0, t0, %pcrel_lo(1b)
+    ld   gp, 0(t0)
+    add  gp, gp, t0
 #else
     la gp, __global_pointer$
 #endif


### PR DESCRIPTION
Hi Guys,

There are two problems here that cause testcases to runtime fail for freedom-e-sdk,

- We shouldn't use a0 for compact patterns, since it usually used for function parameters.

1:
  auipc a0, %pcrel_hi(__global_pointer__)
  addi a0, a0, %pcrel_lo(1b)
  ld   gp, 0(a0)
  add  gp, gp, a0
  la gp, __global_pointer$
.option pop

  /* Stack pointer is expected to be initialized before _start */

  /* If we're not hart 0, skip the initialization work */
  la t0, __metal_boot_hart
  bne a0, t0, _skip_init

Obviously my code is wrong here, a0 usually used for function parameters, so if I use it to do anything special, then the value of a0 will be changed.  Maybe t0/t1 is more suitable.

- We shouldn't use la.got.gprel before the data movement if LMA != VMA.
When rodata is placed nearly to text, then we can use la to access metal_segment_data_source_start 
directly; When the rodata is placed nearly to rwdata, then use the lla.gprel is more suitable.  But once the rodata is placed far away from both text and rwdata, generally we should use la.got.gprel to access it. Unfortunately, la.got.gprel cannot work for metal_segment_data_source_start, if LMA and VMA are different in the linker script.  Since we need to move the data, including GOT sections, from the LMA to VMA, then we can get the right values of got entries.  Therefore, use la.got.gprel to access the metal_segment_data_source_start will get the uninitilaize value.

One of the solution is that - use compact stub to access the metal_segment_data_source_start, just like what we did above, to initialize gp.  But we need four instructions and one 8 bytes stub, so the code size will be slightly larger (4 * 4 + 8 = 24 bytes, originally, the la.got.gprel may be relaxed to a 4 bytes ld, so it will be 20 bytes more).