### PR TITLE
Fix wrong inline assembly code in nop_putc.

### DIFF
--- a/src/tty.c
+++ b/src/tty.c
@@ -43,7 +43,8 @@ int nop_putc(int c) {
     // truly in a0, for easier post-processing, and so there is a single
     // 32-bit opcode to match against.
     // So explicitly ensure that the argument is placed into a0 first.
-    __asm__ volatile("mv a0, %0; slli x0,a0,0x11" ::"r"(c));
+    register long xc asm("a0") = c;
+    __asm__ volatile("slli x0,a0,0x11" ::"r"(xc));
     return -1;
 }
 int metal_tty_putc(int c) __attribute__((weak, alias("nop_putc")));


### PR DESCRIPTION
We need to add `a0` into clobber list.

In clang, the result is incorrect.
```
c.mv         a1, a0
c.li         a0, -1
c.mv         a0, a1
slli         zero, a0, 0x11
c.jr         ra
```
we could rewrite it and avoid additional `mv` instruction.