### PR TITLE
Dev/nvgubba/lacu gpio

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -52,6 +52,7 @@ nobase_include_HEADERS += \
 	metal/drivers/sifive_gpio-leds.h \
 	metal/drivers/sifive_gpio-switches.h \
 	metal/drivers/sifive_gpio0.h \
+	metal/drivers/sifive_gpio2.h \
 	metal/drivers/sifive_i2c0.h \
 	metal/drivers/sifive_l2pf0.h \
 	metal/drivers/sifive_l2pf1.h \
@@ -129,6 +130,7 @@ libmetal_a_SOURCES = \
 	src/drivers/sifive_gpio-leds.c \
 	src/drivers/sifive_gpio-switches.c \
 	src/drivers/sifive_gpio0.c \
+	src/drivers/sifive_gpio2.c \
 	src/drivers/sifive_i2c0.c \
 	src/drivers/sifive_l2pf0.c \
 	src/drivers/sifive_l2pf1.c \

--- a/Makefile.in
+++ b/Makefile.in
@@ -240,6 +240,7 @@ am_libmetal_a_OBJECTS = src/drivers/fixed-clock.$(OBJEXT) \
 	src/drivers/sifive_gpio-leds.$(OBJEXT) \
 	src/drivers/sifive_gpio-switches.$(OBJEXT) \
 	src/drivers/sifive_gpio0.$(OBJEXT) \
+	src/drivers/sifive_gpio2.$(OBJEXT) \
 	src/drivers/sifive_i2c0.$(OBJEXT) \
 	src/drivers/sifive_l2pf0.$(OBJEXT) \
 	src/drivers/sifive_l2pf1.$(OBJEXT) \
@@ -254,18 +255,18 @@ am_libmetal_a_OBJECTS = src/drivers/fixed-clock.$(OBJEXT) \
 	src/drivers/sifive_uart0.$(OBJEXT) \
 	src/drivers/sifive_simuart0.$(OBJEXT) \
 	src/drivers/sifive_wdog0.$(OBJEXT) \
-	src/drivers/ucb_htif0.$(OBJEXT) src/atomic.$(OBJEXT) \
-	src/button.$(OBJEXT) src/cache.$(OBJEXT) src/clock.$(OBJEXT) \
-	src/cpu.$(OBJEXT) src/entry.$(OBJEXT) src/scrub.$(OBJEXT) \
-	src/trap.$(OBJEXT) src/gpio.$(OBJEXT) src/hpm.$(OBJEXT) \
-	src/i2c.$(OBJEXT) src/init.$(OBJEXT) src/interrupt.$(OBJEXT) \
-	src/led.$(OBJEXT) src/lock.$(OBJEXT) src/memory.$(OBJEXT) \
-	src/pmp.$(OBJEXT) src/privilege.$(OBJEXT) src/prci.$(OBJEXT) \
-	src/pwm.$(OBJEXT) src/rtc.$(OBJEXT) src/shutdown.$(OBJEXT) \
-	src/spi.$(OBJEXT) src/switch.$(OBJEXT) src/synchronize_harts.$(OBJEXT) \
-	src/timer.$(OBJEXT) src/time.$(OBJEXT) src/trap.$(OBJEXT) \
-	src/tty.$(OBJEXT) src/uart.$(OBJEXT) src/vector.$(OBJEXT) \
-	src/watchdog.$(OBJEXT) src/remapper.$(OBJEXT)
+	src/drivers/ucb_htif0.$(OBJEXT) src/remapper.$(OBJEXT) \
+	src/atomic.$(OBJEXT) src/button.$(OBJEXT) src/cache.$(OBJEXT) \
+	src/clock.$(OBJEXT) src/cpu.$(OBJEXT) src/entry.$(OBJEXT) \
+	src/scrub.$(OBJEXT) src/trap.$(OBJEXT) src/gpio.$(OBJEXT) \
+	src/hpm.$(OBJEXT) src/i2c.$(OBJEXT) src/init.$(OBJEXT) \
+	src/interrupt.$(OBJEXT) src/led.$(OBJEXT) src/lock.$(OBJEXT) \
+	src/memory.$(OBJEXT) src/pmp.$(OBJEXT) src/prci.$(OBJEXT) \
+	src/privilege.$(OBJEXT) src/pwm.$(OBJEXT) src/rtc.$(OBJEXT) \
+	src/shutdown.$(OBJEXT) src/spi.$(OBJEXT) src/switch.$(OBJEXT) \
+	src/synchronize_harts.$(OBJEXT) src/timer.$(OBJEXT) \
+	src/time.$(OBJEXT) src/trap.$(OBJEXT) src/tty.$(OBJEXT) \
+	src/uart.$(OBJEXT) src/vector.$(OBJEXT) src/watchdog.$(OBJEXT)
 libmetal_a_OBJECTS = $(am_libmetal_a_OBJECTS)
 AM_V_P = $(am__v_P_@AM_V@)
 am__v_P_ = $(am__v_P_@AM_DEFAULT_V@)
@@ -462,8 +463,8 @@ nobase_include_HEADERS = metal/machine.h metal/machine/inline.h \
 	metal/machine/platform.h metal/drivers/fixed-clock.h \
 	metal/drivers/fixed-factor-clock.h \
 	metal/drivers/riscv_clint0.h metal/drivers/riscv_cpu.h \
-	metal/drivers/sifive_remapper2.h \
-	metal/drivers/riscv_plic0.h metal/drivers/sifive_buserror0.h \
+	metal/drivers/riscv_plic0.h metal/drivers/sifive_remapper2.h \
+	metal/drivers/sifive_buserror0.h \
 	metal/drivers/sifive_ccache0.h metal/drivers/sifive_clic0.h \
 	metal/drivers/sifive_fe310-g000_hfrosc.h \
 	metal/drivers/sifive_fe310-g000_hfxosc.h \
@@ -474,26 +475,24 @@ nobase_include_HEADERS = metal/machine.h metal/machine/inline.h \
 	metal/drivers/sifive_gpio-buttons.h \
 	metal/drivers/sifive_gpio-leds.h \
 	metal/drivers/sifive_gpio-switches.h \
-	metal/drivers/sifive_gpio0.h metal/drivers/sifive_i2c0.h \
-	metal/drivers/sifive_l2pf0.h \
+	metal/drivers/sifive_gpio0.h metal/drivers/sifive_gpio2.h \
+	metal/drivers/sifive_i2c0.h metal/drivers/sifive_l2pf0.h \
 	metal/drivers/sifive_l2pf1.h \
 	metal/drivers/sifive_local-external-interrupts0.h \
-	metal/drivers/sifive_pl2cache0.h \
-        metal/drivers/sifive_prci0.h \
+	metal/drivers/sifive_pl2cache0.h metal/drivers/sifive_prci0.h \
 	metal/drivers/sifive_pwm0.h metal/drivers/sifive_rtc0.h \
 	metal/drivers/sifive_spi0.h metal/drivers/sifive_test0.h \
 	metal/drivers/sifive_trace.h metal/drivers/sifive_uart0.h \
 	metal/drivers/sifive_simuart0.h metal/drivers/sifive_wdog0.h \
-	metal/drivers/ucb_htif0.h metal/drivers/sifive_hca1_regs.h \
-	metal/atomic.h metal/button.h metal/cache.h metal/clock.h \
-	metal/compiler.h metal/cpu.h metal/csr.h metal/gpio.h \
-	metal/hpm.h metal/i2c.h metal/init.h \
-	metal/interrupt.h metal/io.h metal/itim.h metal/led.h \
-	metal/lim.h metal/lock.h metal/memory.h metal/nmi.h metal/pmp.h \
-	metal/prci.h metal/privilege.h metal/pwm.h metal/rtc.h \
-	metal/shutdown.h metal/scrub.h metal/spi.h metal/switch.h \
-	metal/timer.h metal/time.h metal/tty.h metal/uart.h metal/watchdog.h \
-	metal/remapper.h
+	metal/drivers/ucb_htif0.h metal/remapper.h metal/atomic.h \
+	metal/button.h metal/cache.h metal/clock.h metal/compiler.h \
+	metal/cpu.h metal/csr.h metal/gpio.h metal/hpm.h metal/i2c.h \
+	metal/init.h metal/interrupt.h metal/io.h metal/itim.h \
+	metal/led.h metal/lim.h metal/lock.h metal/memory.h \
+	metal/nmi.h metal/pmp.h metal/prci.h metal/privilege.h \
+	metal/pwm.h metal/rtc.h metal/shutdown.h metal/scrub.h \
+	metal/spi.h metal/switch.h metal/timer.h metal/time.h \
+	metal/tty.h metal/uart.h metal/watchdog.h
 
 # This will generate these sources before the compilation step
 BUILT_SOURCES = \
@@ -527,6 +526,7 @@ libmetal_a_SOURCES = \
 	src/drivers/sifive_gpio-leds.c \
 	src/drivers/sifive_gpio-switches.c \
 	src/drivers/sifive_gpio0.c \
+	src/drivers/sifive_gpio2.c \
 	src/drivers/sifive_i2c0.c \
 	src/drivers/sifive_l2pf0.c \
 	src/drivers/sifive_l2pf1.c \
@@ -831,6 +831,8 @@ src/drivers/sifive_gpio-switches.$(OBJEXT):  \
 	src/drivers/$(DEPDIR)/$(am__dirstamp)
 src/drivers/sifive_gpio0.$(OBJEXT): src/drivers/$(am__dirstamp) \
 	src/drivers/$(DEPDIR)/$(am__dirstamp)
+src/drivers/sifive_gpio2.$(OBJEXT): src/drivers/$(am__dirstamp) \
+	src/drivers/$(DEPDIR)/$(am__dirstamp)
 src/drivers/sifive_i2c0.$(OBJEXT): src/drivers/$(am__dirstamp) \
 	src/drivers/$(DEPDIR)/$(am__dirstamp)
 src/drivers/sifive_l2pf0.$(OBJEXT): src/drivers/$(am__dirstamp) \
@@ -891,6 +893,7 @@ src/lock.$(OBJEXT): src/$(am__dirstamp) src/$(DEPDIR)/$(am__dirstamp)
 src/memory.$(OBJEXT): src/$(am__dirstamp) \
 	src/$(DEPDIR)/$(am__dirstamp)
 src/pmp.$(OBJEXT): src/$(am__dirstamp) src/$(DEPDIR)/$(am__dirstamp)
+src/prci.$(OBJEXT): src/$(am__dirstamp) src/$(DEPDIR)/$(am__dirstamp)
 src/privilege.$(OBJEXT): src/$(am__dirstamp) \
 	src/$(DEPDIR)/$(am__dirstamp)
 src/pwm.$(OBJEXT): src/$(am__dirstamp) src/$(DEPDIR)/$(am__dirstamp)
@@ -961,7 +964,6 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@gloss/$(DEPDIR)/sys_wait.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@gloss/$(DEPDIR)/sys_write.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@segger/$(DEPDIR)/SEGGER_target_metal.Po@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/remapper.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/atomic.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/button.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/cache.Po@am__quote@
@@ -977,8 +979,10 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/lock.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/memory.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/pmp.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/prci.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/privilege.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/pwm.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/remapper.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/rtc.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/scrub.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/$(DEPDIR)/shutdown.Po@am__quote@
@@ -998,7 +1002,6 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@src/drivers/$(DEPDIR)/riscv_clint0.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/drivers/$(DEPDIR)/riscv_cpu.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/drivers/$(DEPDIR)/riscv_plic0.Po@am__quote@
-@AMDEP_TRUE@@am__include@ @am__quote@src/drivers/$(DEPDIR)/sifive_remapper2.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/drivers/$(DEPDIR)/sifive_buserror0.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/drivers/$(DEPDIR)/sifive_ccache0.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/drivers/$(DEPDIR)/sifive_clic0.Po@am__quote@
@@ -1012,6 +1015,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@src/drivers/$(DEPDIR)/sifive_gpio-leds.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/drivers/$(DEPDIR)/sifive_gpio-switches.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/drivers/$(DEPDIR)/sifive_gpio0.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/drivers/$(DEPDIR)/sifive_gpio2.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/drivers/$(DEPDIR)/sifive_i2c0.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/drivers/$(DEPDIR)/sifive_l2pf0.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/drivers/$(DEPDIR)/sifive_l2pf1.Po@am__quote@
@@ -1019,6 +1023,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@src/drivers/$(DEPDIR)/sifive_pl2cache0.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/drivers/$(DEPDIR)/sifive_prci0.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/drivers/$(DEPDIR)/sifive_pwm0.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@src/drivers/$(DEPDIR)/sifive_remapper2.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/drivers/$(DEPDIR)/sifive_rtc0.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/drivers/$(DEPDIR)/sifive_simuart0.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@src/drivers/$(DEPDIR)/sifive_spi0.Po@am__quote@

--- a/metal/drivers/sifive_gpio2.h
+++ b/metal/drivers/sifive_gpio2.h
@@ -1,0 +1,22 @@
+/* Copyright 2018 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef METAL__DRIVERS__SIFIVE_GPI02_H
+#define METAL__DRIVERS__SIFIVE_GPI02_H
+
+#include <metal/compiler.h>
+#include <metal/gpio.h>
+
+struct __metal_driver_vtable_sifive_gpio2 {
+    const struct __metal_gpio_vtable gpio;
+};
+
+// struct __metal_driver_sifive_gpio2;
+
+__METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_gpio2)
+
+struct __metal_driver_sifive_gpio2 {
+    struct metal_gpio gpio;
+};
+
+#endif

--- a/metal/drivers/sifive_gpio2.h
+++ b/metal/drivers/sifive_gpio2.h
@@ -1,4 +1,4 @@
-/* Copyright 2018 SiFive, Inc */
+/* Copyright 2021 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 
 #ifndef METAL__DRIVERS__SIFIVE_GPI02_H
@@ -10,8 +10,6 @@
 struct __metal_driver_vtable_sifive_gpio2 {
     const struct __metal_gpio_vtable gpio;
 };
-
-// struct __metal_driver_sifive_gpio2;
 
 __METAL_DECLARE_VTABLE(__metal_driver_vtable_sifive_gpio2)
 

--- a/src/drivers/sifive_gpio2.c
+++ b/src/drivers/sifive_gpio2.c
@@ -1,4 +1,4 @@
-/* Copyright 2018 SiFive, Inc */
+/* Copyright 2021 SiFive, Inc */
 /* SPDX-License-Identifier: Apache-2.0 */
 
 #include <metal/machine/platform.h>
@@ -42,7 +42,7 @@ long __metal_driver_sifive_gpio2_output(struct metal_gpio *ggpio) {
 #if 0
     return __METAL_ACCESS_ONCE(
         (__metal_io_u32 *)(base + METAL_SIFIVE_GPIO2_PORT));
-#endif 
+#endif
     return 0;
 }
 
@@ -70,20 +70,18 @@ int __metal_driver_sifive_gpio2_output_set(struct metal_gpio *ggpio,
                                            long value) {
     long base = __metal_driver_sifive_gpio2_base(ggpio);
 
-#if 0
-    __METAL_ACCESS_ONCE((__metal_io_u32 *)(base + METAL_SIFIVE_GPIO2_PORT)) |=
-        value;
-#endif
+    __METAL_ACCESS_ONCE(
+        (__metal_io_u32 *)(base + METAL_SIFIVE_GPIO2_OUTPUT_VALUE)) |= value;
+
     return 0;
 }
 
 int __metal_driver_sifive_gpio2_output_clear(struct metal_gpio *ggpio,
                                              long value) {
     long base = __metal_driver_sifive_gpio2_base(ggpio);
-#if 0
-    __METAL_ACCESS_ONCE((__metal_io_u32 *)(base + METAL_SIFIVE_GPIO2_PORT)) &=
-        ~value;
-#endif
+
+    __METAL_ACCESS_ONCE(
+        (__metal_io_u32 *)(base + METAL_SIFIVE_GPIO2_OUTPUT_VALUE)) &= ~value;
 
     return 0;
 }
@@ -92,12 +90,11 @@ int __metal_driver_sifive_gpio2_output_toggle(struct metal_gpio *ggpio,
                                               long value) {
     long base = __metal_driver_sifive_gpio2_base(ggpio);
 
-#if 0
-    __METAL_ACCESS_ONCE((__metal_io_u32 *)(base + METAL_SIFIVE_GPIO2_PORT)) =
+    __METAL_ACCESS_ONCE(
+        (__metal_io_u32 *)(base + METAL_SIFIVE_GPIO2_OUTPUT_VALUE)) =
         __METAL_ACCESS_ONCE(
-            (__metal_io_u32 *)(base + METAL_SIFIVE_GPIO2_PORT)) ^
+            (__metal_io_u32 *)(base + METAL_SIFIVE_GPIO2_OUTPUT_VALUE)) ^
         value;
-#endif
 
     return 0;
 }

--- a/src/drivers/sifive_gpio2.c
+++ b/src/drivers/sifive_gpio2.c
@@ -1,0 +1,260 @@
+/* Copyright 2018 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include <metal/machine/platform.h>
+
+#ifdef METAL_SIFIVE_GPIO2
+
+#include <metal/drivers/sifive_gpio2.h>
+#include <metal/io.h>
+#include <metal/machine.h>
+
+int __metal_driver_sifive_gpio2_enable_input(struct metal_gpio *ggpio,
+                                             long source) {
+    long base = __metal_driver_sifive_gpio2_base(ggpio);
+
+    __METAL_ACCESS_ONCE(
+        (__metal_io_u32 *)(base + METAL_SIFIVE_GPIO2_INPUT_EN)) |= source;
+
+    return 0;
+}
+
+int __metal_driver_sifive_gpio2_disable_input(struct metal_gpio *ggpio,
+                                              long source) {
+    long base = __metal_driver_sifive_gpio2_base(ggpio);
+
+    __METAL_ACCESS_ONCE(
+        (__metal_io_u32 *)(base + METAL_SIFIVE_GPIO2_INPUT_EN)) &= ~source;
+
+    return 0;
+}
+
+long __metal_driver_sifive_gpio2_input(struct metal_gpio *ggpio) {
+    long base = __metal_driver_sifive_gpio2_base(ggpio);
+
+    return __METAL_ACCESS_ONCE(
+        (__metal_io_u32 *)(base + METAL_SIFIVE_GPIO2_VALUE));
+}
+
+long __metal_driver_sifive_gpio2_output(struct metal_gpio *ggpio) {
+    long base = __metal_driver_sifive_gpio2_base(ggpio);
+
+#if 0
+    return __METAL_ACCESS_ONCE(
+        (__metal_io_u32 *)(base + METAL_SIFIVE_GPIO2_PORT));
+#endif 
+    return 0;
+}
+
+int __metal_driver_sifive_gpio2_disable_output(struct metal_gpio *ggpio,
+                                               long source) {
+    long base = __metal_driver_sifive_gpio2_base(ggpio);
+
+    __METAL_ACCESS_ONCE(
+        (__metal_io_u32 *)(base + METAL_SIFIVE_GPIO2_OUTPUT_EN)) &= ~source;
+
+    return 0;
+}
+
+int __metal_driver_sifive_gpio2_enable_output(struct metal_gpio *ggpio,
+                                              long source) {
+    long base = __metal_driver_sifive_gpio2_base(ggpio);
+
+    __METAL_ACCESS_ONCE(
+        (__metal_io_u32 *)(base + METAL_SIFIVE_GPIO2_OUTPUT_EN)) |= source;
+
+    return 0;
+}
+
+int __metal_driver_sifive_gpio2_output_set(struct metal_gpio *ggpio,
+                                           long value) {
+    long base = __metal_driver_sifive_gpio2_base(ggpio);
+
+#if 0
+    __METAL_ACCESS_ONCE((__metal_io_u32 *)(base + METAL_SIFIVE_GPIO2_PORT)) |=
+        value;
+#endif
+    return 0;
+}
+
+int __metal_driver_sifive_gpio2_output_clear(struct metal_gpio *ggpio,
+                                             long value) {
+    long base = __metal_driver_sifive_gpio2_base(ggpio);
+#if 0
+    __METAL_ACCESS_ONCE((__metal_io_u32 *)(base + METAL_SIFIVE_GPIO2_PORT)) &=
+        ~value;
+#endif
+
+    return 0;
+}
+
+int __metal_driver_sifive_gpio2_output_toggle(struct metal_gpio *ggpio,
+                                              long value) {
+    long base = __metal_driver_sifive_gpio2_base(ggpio);
+
+#if 0
+    __METAL_ACCESS_ONCE((__metal_io_u32 *)(base + METAL_SIFIVE_GPIO2_PORT)) =
+        __METAL_ACCESS_ONCE(
+            (__metal_io_u32 *)(base + METAL_SIFIVE_GPIO2_PORT)) ^
+        value;
+#endif
+
+    return 0;
+}
+
+int __metal_driver_sifive_gpio2_enable_io(struct metal_gpio *ggpio, long source,
+                                          long dest) {
+    long base = __metal_driver_sifive_gpio2_base(ggpio);
+
+    __METAL_ACCESS_ONCE((__metal_io_u32 *)(base + METAL_SIFIVE_GPIO2_IOF_EN)) |=
+        dest;
+
+    return 0;
+}
+
+int __metal_driver_sifive_gpio2_disable_io(struct metal_gpio *ggpio,
+                                           long source) {
+    long base = __metal_driver_sifive_gpio2_base(ggpio);
+
+    __METAL_ACCESS_ONCE((__metal_io_u32 *)(base + METAL_SIFIVE_GPIO2_IOF_EN)) &=
+        ~source;
+
+    return 0;
+}
+
+int __metal_driver_sifive_gpio2_config_int(struct metal_gpio *ggpio,
+                                           long source, int intr_type) {
+    long base = __metal_driver_sifive_gpio2_base(ggpio);
+
+    switch (intr_type) {
+    case METAL_GPIO_INT_DISABLE:
+        __METAL_ACCESS_ONCE(
+            (__metal_io_u32 *)(base + METAL_SIFIVE_GPIO2_RISE_IE)) &= ~source;
+        __METAL_ACCESS_ONCE(
+            (__metal_io_u32 *)(base + METAL_SIFIVE_GPIO2_FALL_IE)) &= ~source;
+        __METAL_ACCESS_ONCE(
+            (__metal_io_u32 *)(base + METAL_SIFIVE_GPIO2_HIGH_IE)) &= ~source;
+        __METAL_ACCESS_ONCE(
+            (__metal_io_u32 *)(base + METAL_SIFIVE_GPIO2_LOW_IE)) &= ~source;
+        break;
+    case METAL_GPIO_INT_RISING:
+        __METAL_ACCESS_ONCE(
+            (__metal_io_u32 *)(base + METAL_SIFIVE_GPIO2_RISE_IE)) |= source;
+        break;
+    case METAL_GPIO_INT_FALLING:
+        __METAL_ACCESS_ONCE(
+            (__metal_io_u32 *)(base + METAL_SIFIVE_GPIO2_FALL_IE)) |= source;
+        break;
+    case METAL_GPIO_INT_BOTH_EDGE:
+        __METAL_ACCESS_ONCE(
+            (__metal_io_u32 *)(base + METAL_SIFIVE_GPIO2_RISE_IE)) |= source;
+        __METAL_ACCESS_ONCE(
+            (__metal_io_u32 *)(base + METAL_SIFIVE_GPIO2_FALL_IE)) |= source;
+        break;
+    case METAL_GPIO_INT_HIGH:
+        __METAL_ACCESS_ONCE(
+            (__metal_io_u32 *)(base + METAL_SIFIVE_GPIO2_HIGH_IE)) |= source;
+        break;
+    case METAL_GPIO_INT_LOW:
+        __METAL_ACCESS_ONCE(
+            (__metal_io_u32 *)(base + METAL_SIFIVE_GPIO2_LOW_IE)) |= source;
+        break;
+    case METAL_GPIO_INT_BOTH_LEVEL:
+        __METAL_ACCESS_ONCE(
+            (__metal_io_u32 *)(base + METAL_SIFIVE_GPIO2_HIGH_IE)) |= source;
+        __METAL_ACCESS_ONCE(
+            (__metal_io_u32 *)(base + METAL_SIFIVE_GPIO2_LOW_IE)) |= source;
+        break;
+    case METAL_GPIO_INT_MAX:
+        __METAL_ACCESS_ONCE(
+            (__metal_io_u32 *)(base + METAL_SIFIVE_GPIO2_RISE_IE)) |= source;
+        __METAL_ACCESS_ONCE(
+            (__metal_io_u32 *)(base + METAL_SIFIVE_GPIO2_FALL_IE)) |= source;
+        __METAL_ACCESS_ONCE(
+            (__metal_io_u32 *)(base + METAL_SIFIVE_GPIO2_HIGH_IE)) |= source;
+        __METAL_ACCESS_ONCE(
+            (__metal_io_u32 *)(base + METAL_SIFIVE_GPIO2_LOW_IE)) |= source;
+        break;
+    }
+    return 0;
+}
+
+int __metal_driver_sifive_gpio2_clear_int(struct metal_gpio *ggpio, long source,
+                                          int intr_type) {
+    long base = __metal_driver_sifive_gpio2_base(ggpio);
+
+    switch (intr_type) {
+    case METAL_GPIO_INT_RISING:
+        __METAL_ACCESS_ONCE(
+            (__metal_io_u32 *)(base + METAL_SIFIVE_GPIO2_RISE_IP)) |= source;
+        break;
+    case METAL_GPIO_INT_FALLING:
+        __METAL_ACCESS_ONCE(
+            (__metal_io_u32 *)(base + METAL_SIFIVE_GPIO2_FALL_IP)) |= source;
+        break;
+    case METAL_GPIO_INT_BOTH_EDGE:
+        __METAL_ACCESS_ONCE(
+            (__metal_io_u32 *)(base + METAL_SIFIVE_GPIO2_RISE_IP)) |= source;
+        __METAL_ACCESS_ONCE(
+            (__metal_io_u32 *)(base + METAL_SIFIVE_GPIO2_FALL_IP)) |= source;
+        break;
+    case METAL_GPIO_INT_HIGH:
+        __METAL_ACCESS_ONCE(
+            (__metal_io_u32 *)(base + METAL_SIFIVE_GPIO2_HIGH_IP)) |= source;
+        break;
+    case METAL_GPIO_INT_LOW:
+        __METAL_ACCESS_ONCE(
+            (__metal_io_u32 *)(base + METAL_SIFIVE_GPIO2_LOW_IP)) |= source;
+        break;
+    case METAL_GPIO_INT_BOTH_LEVEL:
+        __METAL_ACCESS_ONCE(
+            (__metal_io_u32 *)(base + METAL_SIFIVE_GPIO2_HIGH_IP)) |= source;
+        __METAL_ACCESS_ONCE(
+            (__metal_io_u32 *)(base + METAL_SIFIVE_GPIO2_LOW_IP)) |= source;
+        break;
+    case METAL_GPIO_INT_MAX:
+        __METAL_ACCESS_ONCE(
+            (__metal_io_u32 *)(base + METAL_SIFIVE_GPIO2_RISE_IP)) |= source;
+        __METAL_ACCESS_ONCE(
+            (__metal_io_u32 *)(base + METAL_SIFIVE_GPIO2_FALL_IP)) |= source;
+        __METAL_ACCESS_ONCE(
+            (__metal_io_u32 *)(base + METAL_SIFIVE_GPIO2_HIGH_IP)) |= source;
+        __METAL_ACCESS_ONCE(
+            (__metal_io_u32 *)(base + METAL_SIFIVE_GPIO2_LOW_IP)) |= source;
+        break;
+    }
+    return 0;
+}
+
+struct metal_interrupt *
+__metal_driver_gpio_interrupt_controller(struct metal_gpio *gpio) {
+    return __metal_driver_sifive_gpio2_interrupt_parent(gpio);
+}
+
+int __metal_driver_gpio_get_interrupt_id(struct metal_gpio *gpio, int pin) {
+    int irq;
+    irq = __metal_driver_sifive_gpio2_interrupt_lines(gpio, pin);
+    return irq;
+}
+
+__METAL_DEFINE_VTABLE(__metal_driver_vtable_sifive_gpio2) = {
+    .gpio.disable_input = __metal_driver_sifive_gpio2_disable_input,
+    .gpio.enable_input = __metal_driver_sifive_gpio2_enable_input,
+    .gpio.input = __metal_driver_sifive_gpio2_input,
+    .gpio.output = __metal_driver_sifive_gpio2_output,
+    .gpio.disable_output = __metal_driver_sifive_gpio2_disable_output,
+    .gpio.enable_output = __metal_driver_sifive_gpio2_enable_output,
+    .gpio.output_set = __metal_driver_sifive_gpio2_output_set,
+    .gpio.output_clear = __metal_driver_sifive_gpio2_output_clear,
+    .gpio.output_toggle = __metal_driver_sifive_gpio2_output_toggle,
+    .gpio.enable_io = __metal_driver_sifive_gpio2_enable_io,
+    .gpio.disable_io = __metal_driver_sifive_gpio2_disable_io,
+    .gpio.config_int = __metal_driver_sifive_gpio2_config_int,
+    .gpio.clear_int = __metal_driver_sifive_gpio2_clear_int,
+    .gpio.interrupt_controller = __metal_driver_gpio_interrupt_controller,
+    .gpio.get_interrupt_id = __metal_driver_gpio_get_interrupt_id,
+};
+
+#endif /* METAL_SIFIVE_GPIO2 */
+
+typedef int no_empty_translation_units;


### PR DESCRIPTION
Hi,

Can you please review the changes for Lacucaracha GPIO Driver changes for FESDK.
Following is the link for the recent GPIO RTL Changes for Lacucaracha **(Refer to gpio design document.pdf)**

I have tested LED testcases for the first iteration on Arty board and it works fine for E20 Standard Configuration. This first commit is to get your inputs any changes are required for the driver based on your review comments, So that i can take care in my future commits

PS: I didnt touched the old Sifive gpio drivers to maintain the backward compatibility