### PR TITLE
Enable vector unit without misa.V

### DIFF
--- a/gloss/crt0.S
+++ b/gloss/crt0.S
@@ -252,16 +252,20 @@ _skip_init:
   csrwi fcsr, 0
 1:
 
-  /* Check for vector extension support and enable it if found.
-   * Omit if toolchain doesn't support the vector extension. */
-#ifdef __riscv_v
-  csrr a5, misa
-  li a4, 0x200000
-  and a5, a5, a4
-  beqz a5, 1f
+  /* Check for vector extension support and enable the vector unit if found.
+   * Omit if the toolchain doesn't support any vector extension.
+   * (NB: __riscv_vector is defined for V as well as Zve*.) */
+#ifdef __riscv_vector
+  /* Unfortunately, Zve* (embedded vector extensions) do not set misa.V,
+   * so, until the RISC-V standard discovery mechanism is finalized, we use
+   * a trick: we set mstatus.VS to Dirty, and then read it back. It's set to
+   * Off iff there's no vector unit. This should detect the presence of any
+   * standard vector extension (V or Zve*) or the absence of all. */
+  li a5, 0x600
+  csrs mstatus, a5
   csrr a5, mstatus
-  ori a5, a5, 0x200
-  csrw mstatus, a5
+  andi a5, a5, 0x600
+  beqz a5, 1f
   vsetivli x0, 0, e8, m1, ta, ma
   csrwi vcsr, 0
 1:


### PR DESCRIPTION
This PR attempts to resolve #429 by the techniques described therein:
- switching to the `__riscv_vector` macro;
- using the mstatus.VS trick.

My implementation does introduce a subtle change in the semantics. Previously, if I'm understanding it correctly, this code implemented the following state transition of mstatus.VS (when misa.V was set):

```
 Before |  After
-----------------
    Off | Initial
Initial | Initial
  Clean |   Dirty
  Dirty |   Dirty
```

Now, this code unconditionally sets mstatus.VS to Dirty. 

I'm not sure I understand the previous Freedom-Metal behavior (nor the similar behavior of mstatus.FS). I feel like it would be most sensible to set these bits to Initial. Perhaps the assumption is that these bits are guaranteed to be Off at this point in execution, so they will always transition to Initial? I welcome the Freedom Metal developers to clarify their intention, and take over this PR.