### PR TITLE
Dev/nickh/pmc dev

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -42,6 +42,7 @@ nobase_include_HEADERS += \
 	metal/drivers/sifive_buserror0.h \
 	metal/drivers/sifive_ccache0.h \
 	metal/drivers/sifive_pmc0.h \
+	metal/drivers/ucbbar_cacheable-zero0.h \
 	metal/drivers/sifive_clic0.h \
 	metal/drivers/sifive_fe310-g000_hfrosc.h \
 	metal/drivers/sifive_fe310-g000_hfxosc.h \

--- a/Makefile.am
+++ b/Makefile.am
@@ -41,6 +41,7 @@ nobase_include_HEADERS += \
 	metal/drivers/sifive_remapper2.h \
 	metal/drivers/sifive_buserror0.h \
 	metal/drivers/sifive_ccache0.h \
+	metal/drivers/sifive_pmc0.h \
 	metal/drivers/sifive_clic0.h \
 	metal/drivers/sifive_fe310-g000_hfrosc.h \
 	metal/drivers/sifive_fe310-g000_hfxosc.h \

--- a/Makefile.in
+++ b/Makefile.in
@@ -466,6 +466,7 @@ nobase_include_HEADERS = metal/machine.h metal/machine/inline.h \
 	metal/drivers/sifive_remapper2.h \
 	metal/drivers/riscv_plic0.h metal/drivers/sifive_buserror0.h \
 	metal/drivers/sifive_ccache0.h metal/drivers/sifive_clic0.h \
+	metal/drivers/sifive_pmc0.h \
 	metal/drivers/sifive_fe310-g000_hfrosc.h \
 	metal/drivers/sifive_fe310-g000_hfxosc.h \
 	metal/drivers/sifive_fe310-g000_lfrosc.h \

--- a/Makefile.in
+++ b/Makefile.in
@@ -467,6 +467,7 @@ nobase_include_HEADERS = metal/machine.h metal/machine/inline.h \
 	metal/drivers/riscv_plic0.h metal/drivers/sifive_buserror0.h \
 	metal/drivers/sifive_ccache0.h metal/drivers/sifive_clic0.h \
 	metal/drivers/sifive_pmc0.h \
+	metal/drivers/ucbbar_cacheable-zero0.h \
 	metal/drivers/sifive_fe310-g000_hfrosc.h \
 	metal/drivers/sifive_fe310-g000_hfxosc.h \
 	metal/drivers/sifive_fe310-g000_lfrosc.h \

--- a/metal/drivers/sifive_pmc0.h
+++ b/metal/drivers/sifive_pmc0.h
@@ -1,0 +1,7 @@
+/* Copyright 2020 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef METAL__DRIVERS__SIFIVE_PMC0_H
+#define METAL__DRIVERS__SIFIVE_PMC0_H
+
+#endif

--- a/metal/drivers/ucbbar_cacheable-zero0.h
+++ b/metal/drivers/ucbbar_cacheable-zero0.h
@@ -1,0 +1,7 @@
+/* Copyright 2020 SiFive, Inc */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#ifndef METAL__DRIVERS__SIFIVE_ZERO0_H
+#define METAL__DRIVERS__SIFIVE_ZERO0_H
+
+#endif


### PR DESCRIPTION
After freedom-devicetree-tool support pmc and zero device, add these two empty header file to avoid FESDK compilation failed.