### PR TITLE
Fix issue with gloss _write function

### DIFF
--- a/gloss/sys_write.c
+++ b/gloss/sys_write.c
@@ -13,7 +13,7 @@ ssize_t _write(int file, const void *ptr, size_t len) {
     const char *bptr = ptr;
     for (size_t i = 0; i < len; ++i)
         metal_tty_putc(bptr[i]);
-    return 0;
+    return len;
 }
 
 extern __typeof(_write) write


### PR DESCRIPTION
`_write` is returning `0` instead of the expected number of characters written.

One of the consequences is that
```
printf("string1\nstring2\n")
```
will only output:
```
string1\n
```
because `printf` will abort after the first `_write` call.

This was fixed by @loiclefort on a downstream (private) fork, but that fix was apparently never upstreamed. It was reported recently in the SiFive forums: https://forums.sifive.com/t/some-freedom-studio-qemu-annoyances/5561